### PR TITLE
WIP: Add backup and restore commands to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ post_configure: $(post_configure_targets)
 
 ##################### Database
 
+DOCKERIZEWAIT = dockerize -wait tcp://mysql:3306 -timeout 20s
+
 databases: provision-databases migrate provision-oauth2 ## Bootstrap databases
 
 provision-databases: ## Create necessary databases and users

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ reindex-courses: ## Refresh course index so they can be found in the LMS search 
 
 ##################### Backup Utilities
 
-ISO_NOW=$(shell date -u "+%Y-%m-%d--%H:%M:%S%z--%Z")
+ISO_NOW=$(shell date -u "+%Y-%m-%dT%H:%M:%S%z")
 backup-lms: ## Backup the mysql database used for the lms.
 	@echo "Exporting mysql database..."
 	@$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,14 @@ migrate-xqueue: ## Perform database migrations for the XQueue service
 reindex-courses: ## Refresh course index so they can be found in the LMS search engine
 	$(DOCKER_COMPOSE_RUN) cms ./manage.py cms reindex_course --all --setup
 
+##################### Backup Utilities
+
+backup-lms: ## Backup the mysql database used for the lms.
+	@echo "Exporting mysql database..."
+	$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \
+	$(DOCKERIZEWAIT) && mysqldump -u root -p\$$MYSQL_ROOT_PASSWORD --host mysql openedx > \
+	/openedx/backups/lms$(shell date -u "+%Y-%m-%d--%H:%M:%S%z--%Z").sql 2>/dev/null || true"
+
 ##################### Static assets
 
 # To collect assets we don't rely on the "paver update_assets" command because

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,14 @@ reindex-courses: ## Refresh course index so they can be found in the LMS search 
 
 ##################### Backup Utilities
 
+ISO_NOW=$(shell date -u "+%Y-%m-%d--%H:%M:%S%z--%Z")
 backup-lms: ## Backup the mysql database used for the lms.
 	@echo "Exporting mysql database..."
 	@$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \
 	$(DOCKERIZEWAIT) && mysqldump -u root -p\$$MYSQL_ROOT_PASSWORD --host mysql openedx > \
-	/openedx/backups/lms$(shell date -u "+%Y-%m-%d--%H:%M:%S%z--%Z").sql 2>/dev/null || true"
+	/openedx/backups/lms$(ISO_NOW).sql 2>/dev/null || true"
+	@echo "Backup Complete!"
+	@echo "Created file: lms$(ISO_NOW).sql"
 
 ##################### Static assets
 

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ provision-oauth2: ## Create users for SSO between services
 
 migrate: migrate-openedx migrate-forum $(extra_migrate_targets) ## Perform all database migrations
 migrate-openedx: ## Perform database migrations on LMS/CMS
-	$(DOCKER_COMPOSE_RUN) lms bash -c "dockerize -wait tcp://mysql:3306 -timeout 20s && ./manage.py lms migrate"
-	$(DOCKER_COMPOSE_RUN) cms bash -c "dockerize -wait tcp://mysql:3306 -timeout 20s && ./manage.py cms migrate"
+	$(DOCKER_COMPOSE_RUN) lms bash -c "$(DOCKERIZEWAIT) && ./manage.py lms migrate"
+	$(DOCKER_COMPOSE_RUN) cms bash -c "$(DOCKERIZEWAIT) && ./manage.py cms migrate"
 	$(MAKE) reindex-courses
 migrate-forum: ## Perform database migrations on discussion forums
 	$(DOCKER_COMPOSE_RUN) forum bash -c "bundle exec rake search:initialize && \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ reindex-courses: ## Refresh course index so they can be found in the LMS search 
 
 backup-lms: ## Backup the mysql database used for the lms.
 	@echo "Exporting mysql database..."
-	$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \
+	@$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \
 	$(DOCKERIZEWAIT) && mysqldump -u root -p\$$MYSQL_ROOT_PASSWORD --host mysql openedx > \
 	/openedx/backups/lms$(shell date -u "+%Y-%m-%d--%H:%M:%S%z--%Z").sql 2>/dev/null || true"
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,8 @@ backup-cms: ## Backup the MongoDB database used for Studio.
 	@echo "Backup Complete!"
 	@echo "Created backup: cms$(ISO_NOW)"
 
-restore-lms: backup-lms ## Restor the lms mysql db from a dump on the disk. Specify DUMP. A backup will be made first.
+restore-lms: backup-lms restore-lms-dangerous## Restor the lms mysql db from a dump on the disk. Specify DUMP. A backup will be made first.
+restore-lms-dangerous:
 	@echo "Restoring from file ${DUMP}"
 	@$(DOCKER_COMPOSE_RUN) lms bash -c "export $(shell cat ${PWD}/config/mysql/auth.env); \
 	if [ -f /openedx/backups/${DUMP} ]; \
@@ -130,7 +131,8 @@ restore-lms: backup-lms ## Restor the lms mysql db from a dump on the disk. Spec
 	else echo 'File \`${DUMP}\` does not exist! Nothing imported.'; fi"
 
 # The conditional is the same used in the backup mongodb command. See backup-cms
-restore-cms: backup-cms ## Restor the cms mongo db from a dump on the disk. Specify DUMP. A backup will be made first.
+restore-cms: backup-cms restore-cms-dangerous ## Restor the cms mongo db from a dump on the disk. Specify DUMP. A backup will be made first.
+restore-cms-dangerous:
 	@echo "Restoring from file ${DUMP}"
 	@if [ -z `docker ps -q --no-trunc | grep $$(docker-compose ps -q mongodb)` ]; \
 	then echo "mongodb container not running, starting container..."; \

--- a/README.md
+++ b/README.md
@@ -197,6 +197,32 @@ Open a python shell in the lms or the cms:
     make lms-python
     make cms-python
 
+### Database backup utilities
+
+Backup the mysql database for the lms:
+
+    make backup-lms
+
+Mysql backups are created with `mysqldump` and backups are stored in the `./backups/lms` directory uncompressed. The dump files are automatically timestamped.
+
+Restore a previous backup to the lms:
+
+    make restore-lms DUMP=<name of dumpfile>
+
+By default a backup is made just before restoration is done. If you do not want to backup first run the `restore-lms-dangerous` command. Any backup made with `mysqldump` should be able to be placed in the `./backups/lms` directory and restored with this command.
+
+Backup the MongoDB database for the cms:
+
+    make backup-cms
+
+MongoDB backups are created with `mongodump` and backups are stored in the `./backups/cms` directory uncompressed. The dump files are automatically timestamped.
+
+Restore a previous backup to the lms:
+
+    make restore-cms DUMP=<name of dumpfile>
+
+By default a backup is made just before restoration is done. If you do not want to backup first run the `restore-cms-dangerous` command. Any backup made with `mongodump` should be able to be placed in the `./backups/cms` directory and restored with this command.
+
 ## For developers
 
 In addition to running Open edX in production, you can use the docker containers for local development. This means you can hack on Open edX without setting up a Virtual Machine. Essentially, this replaces the devstack provided by edX.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - ./config/openedx:/openedx/config
       - ./data/lms:/openedx/data
       - ./data/themes:/openedx/themes
+      - ./data/backups/lms:/openedx/backups
     depends_on:
       - elasticsearch
       - forum
@@ -108,6 +109,7 @@ services:
       - ./config/openedx:/openedx/config
       - ./data/cms:/openedx/data
       - ./data/themes:/openedx/themes
+      - ./data/backups/cms:/openedx/backups
     depends_on:
       - memcached
       - mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/mongodb:/data/db
+      - ./data/backups/cms:/openedx/backups
 
   mysql:
     image: mysql:5.6.36
@@ -109,7 +110,6 @@ services:
       - ./config/openedx:/openedx/config
       - ./data/cms:/openedx/data
       - ./data/themes:/openedx/themes
-      - ./data/backups/cms:/openedx/backups
     depends_on:
       - memcached
       - mongodb


### PR DESCRIPTION
After reading #87 I realized that there seemed to be no non-filesystem based backup provisions. This MR adds them.

## Adds the Makefile commands:

 - `backup-lms`
 - `backup-cms`
 - `restore-lms`
 - `restore-cms`

The restore commands allow users to specify the `DUMP` used for the restoration.