### PR TITLE
Fix typo of minio MANIFEST.in

### DIFF
--- a/plugins/minio/MANIFEST.in
+++ b/plugins/minio/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include tutorxminio/patches *
+recursive-include tutorminio/patches *


### PR DESCRIPTION
After I `pip install minio`  and run
```
tutor enable minio
tutor config save
```
minio didn't work.

I thinks is this typo cause setuptool miss the files of patches directory.
