### PR TITLE
Fix tutor binary permission error on MacOSX

### DIFF
--- a/docs/_release_description.md
+++ b/docs/_release_description.md
@@ -1,7 +1,7 @@
 Tutor can be installed simply by downloading the compiled binaries:
 
     sudo curl -L "https://github.com/overhangio/tutor/releases/download/TUTOR_VERSION/tutor-$(uname -s)_$(uname -m)" -o /usr/local/bin/tutor
-    sudo chmod +x /usr/local/bin/tutor
+    sudo chmod 0755 /usr/local/bin/tutor
 
 See the [install docs](https://docs.tutor.overhang.io/install.html) for more install options and instructions.
 

--- a/docs/cli_download.rst
+++ b/docs/cli_download.rst
@@ -3,4 +3,4 @@
 .. parsed-literal::
 
     sudo curl -L "\ https\ ://github.com/overhangio/tutor/releases/download/v\ |tutor_version|/tutor-$(uname -s)_$(uname -m)" -o /usr/local/bin/tutor
-    sudo chmod +x /usr/local/bin/tutor
+    sudo chmod 0755 /usr/local/bin/tutor


### PR DESCRIPTION
Otherwise it will not be readable by normal users.