### PR TITLE
Adds to_json jinja filter

### DIFF
--- a/tutor/env.py
+++ b/tutor/env.py
@@ -35,6 +35,7 @@ class Renderer:
             environment.filters["common_domain"] = utils.common_domain
             environment.filters["reverse_host"] = utils.reverse_host
             environment.filters["walk_templates"] = walk_templates
+            environment.filters["to_json"] = utils.to_json
             environment.globals["TUTOR_VERSION"] = __version__
 
             cls.ENVIRONMENT_CONFIG = deepcopy(config)

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 import random
 import shutil
 import string
@@ -58,6 +59,10 @@ def walk_files(path):
     for dirpath, _, filenames in os.walk(path):
         for filename in filenames:
             yield os.path.join(dirpath, filename)
+
+
+def to_json(value):
+    return json.dumps(value, indent=2)
 
 
 def docker_run(*command):


### PR DESCRIPTION
Rationale: plugins may require the user to set yaml configuration variables that are something other than strings.  Such as, for instance, a custom [XBLOCK_SETTINGS](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/services.py#L36) dict entry in `lms-env`.  This makes it so they can define it in yaml, and render it with `PLUGIN_XBLOCK_SETTINGS|to_json` where needed.