### PR TITLE
docs: updated local installation guide

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -64,6 +64,8 @@ Prepare the edx-platform repo
 In order to run a fork of edx-platform, dependencies need to be properly installed and assets compiled in that repo. To do so, run::
 
     export TUTOR_EDX_PLATFORM_PATH=/path/to/edx-platform
+    cd /path/to/edx-platform
+    npm install
     tutor dev run lms pip install --requirement requirements/edx/development.txt
     tutor dev run lms python setup.py install
     tutor dev run lms paver update_assets --settings=tutor.development


### PR DESCRIPTION
While trying to run `tutor` with a local `edx-platform` repository I was getting these errors:
```
chown: changing ownership of '/openedx/edx-platform/common/static/edx-ui-toolkit/js': No such file or directory
chown: changing ownership of '/openedx/edx-platform/common/static/edx-pattern-library/js': No such file or directory
chown: changing ownership of '/openedx/edx-platform/common/static/edx-pattern-library/fonts': No such file or directory
```

After searching for solutions, I've found this issue which suggested installing `npm` dependencies in the `edx-platform` project: https://github.com/overhangio/tutor/issues/135

After installing the dependencies I was able to run the other commands necessary to install python dependencies, call the setup file and compile the assets.