### PR TITLE
Add env variables to silence docker/docker-compose commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+## Unreleased
+
+- [Improvement] Add environment variables to silence ``docker`` and ``docker-compose`` commands. (#268)
+
 ## 3.8.0 (2019-11-22)
 
 - [Improvement] Add `k8s-deployments-nginx-volume-mounts` patch

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -88,6 +88,16 @@ Finally, tracking logs that store `user events <https://edx.readthedocs.io/proje
     $(tutor config printroot)/data/lms/logs/tracking.log
     $(tutor config printroot)/data/cms/logs/tracking.log
 
+Docker command verbosity
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The verbosity of ``docker`` and ``docker-compose`` commands can be adjusted by setting the values of the ``DOCKER_LOG_LEVEL`` and ``COMPOSE_LOG_LEVEL`` environment variables. For instance, to silence all output::
+
+    export DOCKER_LOG_LEVEL=fatal     # one of "debug", "info", "warn", "error", "fatal"
+    export COMPOSE_LOG_LEVEL=critical # one of "debug", "info", "warn", "error", "critical"
+    
+Note that the "fatal" error level is called "critical in docker-compose.
+
 
 Extra commands
 --------------

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -11,6 +11,9 @@ from . import exceptions
 from . import fmt
 
 
+DOCKER_LOG_LEVEL = os.environ.get("TUTOR_DOCKER_LOG_LEVEL")
+COMPOSE_LOG_LEVEL = os.environ.get("TUTOR_COMPOSE_LOG_LEVEL")
+
 def ensure_file_directory_exists(path):
     """
     Create file's base directory if it does not exist.
@@ -74,7 +77,10 @@ def docker(*command):
         raise exceptions.TutorError(
             "docker is not installed. Please follow instructions from https://docs.docker.com/install/"
         )
-    return execute("docker", *command)
+    docker_command = ["docker"]
+    if DOCKER_LOG_LEVEL:
+        docker_command.append("--log-level=" + DOCKER_LOG_LEVEL.lower())
+    return execute(*docker_command, *command)
 
 
 def docker_compose(*command):
@@ -82,7 +88,10 @@ def docker_compose(*command):
         raise exceptions.TutorError(
             "docker-compose is not installed. Please follow instructions from https://docs.docker.com/compose/install/"
         )
-    return execute("docker-compose", *command)
+    docker_compose_command = ["docker-compose"]
+    if COMPOSE_LOG_LEVEL:
+        docker_compose_command.append("--log-level=" + COMPOSE_LOG_LEVEL.upper())
+    return execute(*docker_compose_command, *command)
 
 
 def kubectl(*command):


### PR DESCRIPTION
This is a work in progress. Currently, the following upstream issue
prevents the `log-level` option from actually silencing the
docke-compose output: docker/compose#6026

As we can see with:

    COMPOSE_LOG_LEVEL=critical tutor start -d

Close #268