### PR TITLE
docs: system prune to complete removal

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -105,6 +105,7 @@ Then, delete all data associated to your Open edX platform::
     
     # WARNING: this step is irreversible
     sudo rm -rf "$(tutor config printroot)"
+    sudo docker system prune --all
 
 Finally, uninstall Tutor itself::
     


### PR DESCRIPTION
The images, containers and volumes linger even after the removing the
.local directory. They can be removed with 

    docker system prune --all