### PR TITLE
Feature to disable certificate views

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -186,6 +186,16 @@ To renew the certificate, run this command once per month::
 
 .. _customise:
 
+Disable default course certificates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``DISABLE_CERTIFICATES_HTML_VIEW`` (default: ``false``)
+
+By activating this feature, the system will no longer show certain views related to the default certificates platform.
+
+This feature was developed so that it is retrocompatible, so that it wont break previous versions.
+
+
 Custom Open edX docker image
 ----------------------------
 

--- a/tutor/templates/apps/openedx/config/cms.env.json
+++ b/tutor/templates/apps/openedx/config/cms.env.json
@@ -8,7 +8,7 @@
   "FEATURES": {
     {{ patch("common-env-features", separator=",\n", suffix=",")|indent(4) }}
     {{ patch("cms-env-features", separator=",\n", suffix=",")|indent(4) }}
-    "CERTIFICATES_HTML_VIEW": true,
+    "CERTIFICATES_HTML_VIEW": {{ "false" if DISABLE_CERTIFICATES_HTML_VIEW else "true" }},
     "PREVIEW_LMS_BASE": "preview.{{ LMS_HOST }}",
     "ENABLE_COURSEWARE_INDEX": true,
     "ENABLE_CSMH_EXTENDED": false,

--- a/tutor/templates/apps/openedx/config/lms.env.json
+++ b/tutor/templates/apps/openedx/config/lms.env.json
@@ -8,7 +8,7 @@
   "FEATURES": {
     {{ patch("common-env-features", separator=",\n", suffix=",")|indent(4) }}
     {{ patch("lms-env-features", separator=",\n", suffix=",")|indent(4) }}
-    "CERTIFICATES_HTML_VIEW": true,
+    "CERTIFICATES_HTML_VIEW": {{ "false" if DISABLE_CERTIFICATES_HTML_VIEW else "true" }},
     "PREVIEW_LMS_BASE": "preview.{{ LMS_HOST }}",
     "ENABLE_COURSE_DISCOVERY": true,
     "ENABLE_COURSEWARE_SEARCH": true,

--- a/tutor/templates/config.yml
+++ b/tutor/templates/config.yml
@@ -28,6 +28,7 @@ ANDROID_RELEASE_STORE_PASSWORD: "android store password"
 ANDROID_RELEASE_KEY_PASSWORD: "android release key password"
 ANDROID_RELEASE_KEY_ALIAS: "android release key alias"
 DEV_PROJECT_NAME: "tutor_dev"
+DISABLE_CERTIFICATES_HTML_VIEW: false
 DOCKER_IMAGE_OPENEDX: "overhangio/openedx:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_OPENEDX_DEV: "overhangio/openedx-dev:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_ANDROID: "overhangio/openedx-android:{{ TUTOR_VERSION }}"


### PR DESCRIPTION
While using tutor for a project, we felt the need to hide the platform certificate data so that we can use our own. And to avoid removing code left and right, it's easier if it is configurable. Oh, and i made sure it was backwards compatible.