### PR TITLE
reload-gunicorn: look for python3 binary

### DIFF
--- a/tutor/templates/build/openedx/bin/reload-gunicorn
+++ b/tutor/templates/build/openedx/bin/reload-gunicorn
@@ -1,3 +1,3 @@
 #! /bin/bash
 echo "Reloading gunicorn process..."
-kill -HUP $(pidof /openedx/venv/bin/python2 /openedx/venv/bin/gunicorn)
+kill -HUP $(pidof /openedx/venv/bin/python3 /openedx/venv/bin/gunicorn)


### PR DESCRIPTION
Quite a simple change. I found the `reload-gunicorn` bin quite handy, which is broken since the migration to juniper.