### PR TITLE
Support .woff and .woff2 file format for fonts

### DIFF
--- a/tutor/env.py
+++ b/tutor/env.py
@@ -14,7 +14,7 @@ from .__about__ import __version__
 
 TEMPLATES_ROOT = pkg_resources.resource_filename("tutor", "templates")
 VERSION_FILENAME = "version"
-BIN_FILE_EXTENSIONS = [".ico", ".jpg", ".png", ".ttf"]
+BIN_FILE_EXTENSIONS = [".ico", ".jpg", ".png", ".ttf", ".woff", ".woff2"]
 
 
 class Renderer:


### PR DESCRIPTION
Right now if I add .woff or .woff2 fonts files to an Indigo-based theme's `lms/static/fonts` directory, I get the following error:

```
$ /indigo-folder# make
tutor config render --extra-config ./config-totem.yml ./theme "$(tutor config printroot)/env/build/openedx/themes/indigo-totem"
Error loading template lms/static/fonts/NotoSans-Bold.woff
Traceback (most recent call last):
  File "/home/maarten/.local/bin/tutor", line 8, in <module>
    sys.exit(main())
  File "/home/maarten/.local/lib/python3.8/site-packages/tutor/commands/cli.py", line 38, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/usr/lib/python3/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/maarten/.local/lib/python3.8/site-packages/tutor/commands/config.py", line 86, in render
    renderer.render_all_to(dst)
  File "/home/maarten/.local/lib/python3.8/site-packages/tutor/env.py", line 153, in render_all_to
    rendered = self.render_file(template)
  File "/home/maarten/.local/lib/python3.8/site-packages/tutor/env.py", line 137, in render_file
    template = self.environment.get_template(path)
  File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/usr/lib/python3/dist-packages/jinja2/loaders.py", line 113, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/usr/lib/python3/dist-packages/jinja2/loaders.py", line 175, in get_source
    contents = f.read().decode(self.encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb4 in position 10: invalid start byte
make: *** [Makefile:2: render] Error 1
```

I did not first create an issue to discuss the solution because it's such a small change, but let me know if you would like me to still do that!