### PR TITLE
Add option to patch lms and cms nginx server block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: Breaking changes between versions are indicated by "💥".
 ## Unreleased
 
 - [Bugfix] Fix Dockerfile parsing on Windows
+- [Improvement] Add option to patch lms and cms nginx server blocks
 
 ## v10.5.0 (2020-11-19)
 

--- a/tutor/templates/apps/nginx/cms.conf
+++ b/tutor/templates/apps/nginx/cms.conf
@@ -47,5 +47,6 @@ server {
     try_files /$file =404;
     expires 31536000s;
   }
+  {{ patch("nginx-cms") }}
 }
 {% endif %}

--- a/tutor/templates/apps/nginx/lms.conf
+++ b/tutor/templates/apps/nginx/lms.conf
@@ -64,5 +64,6 @@ server {
     try_files /$file =404;
     expires 31536000s;
   }
+  {{ patch("nginx-lms") }}
 }
 {% endif %}


### PR DESCRIPTION
As proposed in https://discuss.overhang.io/t/editing-nginx-lms-and-cms-conf/1096

This allows yaml plugins to define a `nginx-lms` and `nginx-cms` block. The block gets inserted in the lms and cms server configuration for nginx. For example, this plugin proxies requests to `/js-components` to an external website (needs `ca-certificates` bundle installed on the host machine):

```
cat tutor-plugins/totem-proxy.yml 
---
name: totem-proxy
version: 0.1.0
patches:
  nginx-lms: |
    location /js-components/ {
        proxy_ssl_verify on;
        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
        proxy_pass https://totem-project.org/js-components/;
        proxy_ssl_server_name on;
    }

  nginx-cms: |
    location /js-components/ {
        proxy_ssl_verify on;
        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
        proxy_pass https://totem-project.org/js-components/;
        proxy_ssl_server_name on;
    }

  local-docker-compose-nginx-volumes: |
    - /etc/ssl/certs:/etc/ssl/certs:ro
```