### PR TITLE
Increase the timeout of the gunicorn worker command in openedx Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+## Unreleased
+
+- [Improvement] Increase the timeout of the gunicorn worker command in openedx Dockerfile
+
 ## v10.5.1 (2020-11-30)
 
 - [Bugfix] Fix Dockerfile parsing on Windows

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -203,4 +203,4 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 # Run server
 COPY gunicorn_conf.py /openedx/gunicorn_conf.py
 EXPOSE 8000
-CMD gunicorn -c /openedx/gunicorn_conf.py --name ${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 --max-requests-jitter=100 --access-logfile - ${SERVICE_VARIANT}.wsgi:application
+CMD gunicorn -c /openedx/gunicorn_conf.py --name ${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 --max-requests-jitter=100 --timeout=120 --access-logfile - ${SERVICE_VARIANT}.wsgi:application


### PR DESCRIPTION
As discussed in https://discuss.overhang.io/t/lms-worker-timeout-issue/1057/8, the timeout of the gunicorn worker is a bit low, causing the worker to crashloop on slower systems. By increasing the timeout to 120 seconds, the worker should have time to come up before it gets restarted.