### PR TITLE
Advice people to run npm install before running openedx-assets build

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -100,6 +100,7 @@ In order to run a fork of edx-platform, dependencies need to be properly install
     tutor dev run -v /path/to/edx-platform:/openedx/edx-platform lms bash
     pip install --requirement requirements/edx/development.txt
     python setup.py install
+    npm install
     openedx-assets build --env=dev
 
 Debug edx-platform


### PR DESCRIPTION
When I tried running `openedx-assets build` on my `tutor dev lms` machine, I got an error: 

```
openedx@1dfe0ece7805:~/edx-platform$ openedx-assets build --env=dev

mkdir_p path('common/static/common/js/vendor')
mkdir_p path('common/static/common/css')
mkdir_p path('common/static/common/css/vendor')
Copying vendor files into static directory
Traceback (most recent call last):
  File "/openedx/bin/openedx-assets", line 218, in <module>
    main()
  File "/openedx/bin/openedx-assets", line 89, in main
    args.func(args)
  File "/openedx/bin/openedx-assets", line 94, in run_build
    run_npm(args)
  File "/openedx/bin/openedx-assets", line 117, in run_npm
    assets.process_npm_assets()
  File "/openedx/edx-platform/pavelib/assets.py", line 643, in process_npm_assets
    copy_vendor_library(library)
  File "/openedx/edx-platform/pavelib/assets.py", line 614, in copy_vendor_library
    raise Exception(u'Missing vendor file {library_path}'.format(library_path=library_path))
Exception: Missing vendor file node_modules/backbone.paginator/lib/backbone.paginator.js
```
As suggested in [this topic](https://discuss.overhang.io/t/issue-with-paver-update-assets/641) I had to run `npm install` to get the packages it tries to copy from. That makes sense, so I think it should be part of the instructions here.