### PR TITLE
Fix default settings on development environment

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -217,7 +217,7 @@ Custom edx-platform settings
 
 By default, tutor settings files are mounted inside the docker images at ``/openedx/edx-platform/lms/envs/tutor/`` and ``/openedx/edx-platform/cms/envs/tutor/``. In the various ``dev`` commands, the default ``edx-platform`` settings module is set to ``tutor.development`` and you don't have to do anything to set up these settings.
 
-If, for some reason, you want to use different settings, you will need to pass the ``-e SETTINGS=mycustomsettings`` option to each command. Alternatively, you can define the ``TUTOR_EDX_PLATFORM_SETTINGS`` environment variable.
+If, for some reason, you want to use different settings, you will need to define the ``EDX_PLATFORM_SETTINGS`` environment variable.
 
 For instance, let's assume you have created the ``/path/to/edx-platform/lms/envs/mysettings.py`` and ``/path/to/edx-platform/cms/envs/mysettings.py`` modules. These settings should be pretty similar to the following files::
 
@@ -231,7 +231,7 @@ Alternatively, the ``mysettings.py`` files can import the tutor development sett
 
 You should then specify the settings to use on the host::
 
-    export TUTOR_EDX_PLATFORM_SETTINGS=mysettings
+    export EDX_PLATFORM_SETTINGS=mysettings
 
 From then on, all ``dev`` commands will use the ``mysettings`` module. For instance::
 

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.7"
 x-openedx-service:
   &openedx-service
   image: {{ DOCKER_IMAGE_OPENEDX_DEV }}
+  environment:
+    SETTINGS: ${EDX_PLATFORM_SETTINGS:-tutor.development}
   volumes:
     # Settings & config
     - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro


### PR DESCRIPTION
First, allow using custom Django settings on a development environment (as documented but not implemented), setting it to the
correct value of `tutor.development`.  Prior to this, `tutor dev runserver lms` would default to `tutor.production` when on a custom edX branch.

Second, fix the documentation so the correct environment variable is described, at the same time removing an option that doesn't seem to work.