### PR TITLE
Fix SAML 'Invalid Request' Error

### DIFF
--- a/tutor/templates/apps/caddy/Caddyfile
+++ b/tutor/templates/apps/caddy/Caddyfile
@@ -1,5 +1,7 @@
 {{ LMS_HOST }}{% if not ENABLE_HTTPS %}:80{% endif %} {
-    reverse_proxy nginx:80
+    reverse_proxy nginx:80 {
+        header_up X-Forwarded-Port {{ 443 if ENABLE_HTTPS else 80 }}
+    }
 }
 preview.{{ LMS_HOST }}{% if not ENABLE_HTTPS %}:80{% endif %} {
     reverse_proxy nginx:80


### PR DESCRIPTION
After upgrading from Juniper to Koa, we have noticed our SAML authentications requests started to fail.

Upon investigation this was caused by the implementation of Caddy. 
Previously, nginx was setting the `X-Forwarded-Port` header upstream to openedx. It was explicitly defined in the configuration file in earlier versions of Tutor.
Caddy will set some headers like `X-Forwarded-For` by default, however it will not set `X-Forwarded-Port` by default.
This PR modifies the Caddyfile to set this header. The current nginx configuration will pass this header through transparently.

Further information about the SAML issue is below.

The OneLogin SAML library will use the incoming host and port information to validate that a client is calling back to the exact ACS URL that was specified in the original SAML authentication request.
The client's incoming request appears as: `https://tutor.com:8000/auth/....` which does not match the original server's ACS URL (of `https://tutor.com/auth/...`) in the authentication request.
However, in Juniper this was working and port 8000 was not appended - as nginx was telling openedx the client is on port 443.

The port mismatch causes the OneLogin library to deny the authentication request, and this library receives the port information ultimately from the `X-Forwarded-Port` header (if present) otherwise it will use the listening port of the lms (`8000`)

Unfortunately it was necessary to hard-code ports 443 and 80 into this PR, since the variables Caddy has available rely only on the incoming `Host` header - and most browsers/clients will not set a port in this header if it's using the well-known port for the protocol