### PR TITLE
fix: Only ignore warnings if they exist.

### DIFF
--- a/tutor/templates/apps/openedx/settings/partials/pre_common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/pre_common_all.py
@@ -1,10 +1,19 @@
 # Silence overly verbose warnings
 import logging
 import warnings
-from django.utils.deprecation import RemovedInDjango30Warning, RemovedInDjango31Warning
-from rest_framework import RemovedInDRF310Warning, RemovedInDRF311Warning
-warnings.simplefilter('ignore', RemovedInDjango30Warning)
-warnings.simplefilter('ignore', RemovedInDjango31Warning)
-warnings.simplefilter('ignore', RemovedInDRF310Warning)
-warnings.simplefilter('ignore', RemovedInDRF311Warning)
+# Ignore if these warning types exist.
+try:
+    from django.utils.deprecation import RemovedInDjango30Warning, RemovedInDjango31Warning
+    warnings.simplefilter('ignore', RemovedInDjango30Warning)
+    warnings.simplefilter('ignore', RemovedInDjango31Warning)
+except ImportError:
+    pass
+
+try:
+    from rest_framework import RemovedInDRF310Warning, RemovedInDRF311Warning
+    warnings.simplefilter('ignore', RemovedInDRF310Warning)
+    warnings.simplefilter('ignore', RemovedInDRF311Warning)
+except ImportError:
+    pass
+
 warnings.simplefilter('ignore', DeprecationWarning)


### PR DESCRIPTION
If we are running a newer version of DRF or are in the process of
upgrading DRF, we want to be able to drop the version where these
warnings exist without breaking tutor.  This pattern will suppress the
warnings if it can but will not fail to startup if that kind of warning
no longer exists.