### PR TITLE
Add patches that enable adding settings during build process (collectstatic and i18ncompile).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: Breaking changes between versions are indicated by "💥".
 ## Unreleased
 
 - [Bugfix] Fix minor edge case in `long_to_base64` utility function.
+- [Improvement] Add openedx patches to add settings during build process.
 
 ## v11.2.3 (2021-02-20)
 

--- a/tutor/templates/build/openedx/settings/partials/assets.py
+++ b/tutor/templates/build/openedx/settings/partials/assets.py
@@ -17,3 +17,5 @@ XQUEUE_INTERFACE = {
 DATABASES = {
     "default": {},
 }
+
+{{ patch("openedx-common-assets-settings") }}

--- a/tutor/templates/build/openedx/settings/partials/i18n.py
+++ b/tutor/templates/build/openedx/settings/partials/i18n.py
@@ -16,3 +16,5 @@ derive_settings(__name__)
 
 LOCALE_PATHS.append("/openedx/locale/contrib/locale")
 LOCALE_PATHS.append("/openedx/locale/user/locale")
+
+{{ patch("openedx-common-i18n-settings") }}


### PR DESCRIPTION
As discussed here https://discuss.overhang.io/t/proposal-for-addition-of-some-patches/1309, this PR adds two new patches to
set some extra settings used during the collectstatic and i18ncompile processes.