### PR TITLE
fix: TypeError when PLUGINS is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix edge case where `PLUGINS` entry is null in config.yml.
 - [Bugfix] Fix missing py2neo dependency in `images build openedx` (#411).
 
 ## v11.2.4 (2021-03-17)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -81,6 +81,10 @@ class PluginsTests(unittest.TestCase):
             self.assertEqual([], config["PLUGINS"])
             self.assertNotIn("KEY", config)
 
+    def test_none_plugins(self) -> None:
+        config = {plugins.CONFIG_KEY: None}
+        self.assertFalse(plugins.is_enabled(config, "myplugin"))
+
     def test_patches(self) -> None:
         class plugin1:
             patches = {"patch1": "Hello {{ ID }}"}

--- a/tutor/plugins.py
+++ b/tutor/plugins.py
@@ -410,7 +410,8 @@ def iter_enabled(config: Dict[str, Any]) -> Iterator[BasePlugin]:
 
 
 def is_enabled(config: Dict[str, Any], name: str) -> bool:
-    return name in config.get(CONFIG_KEY, [])
+    plugin_list = config.get(CONFIG_KEY) or []
+    return name in plugin_list
 
 
 def iter_patches(config: Dict[str, str], name: str) -> Iterator[Tuple[str, str]]:


### PR DESCRIPTION
When the PLUGINS config entry is None (`PLUGINS:`), the following error
was being triggered:

  File "/.../tutor/tutor/plugins.py",
  line 304, in is_enabled
      return name in config.get(CONFIG_KEY, [])
      TypeError: argument of type 'NoneType' is not iterable

This is ready for review @BbrSofiane.