### PR TITLE
fix: missing py2neo dependency breaks `images build openedx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix missing py2neo dependency in `images build openedx` (#411).
+
 ## v11.2.4 (2021-03-17)
 
 - [Bugfix] Fix "Invalid Request" error during SAML authentication (thanks @Ant1x!).

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -76,6 +76,9 @@ WORKDIR /openedx/edx-platform
 # Install the right version of pip/setuptools
 RUN pip install setuptools==44.1.0 pip==20.0.2 wheel==0.34.2
 
+# Install requirements which were stripped from pypi: this can be removed once the fix has been merged in Koa
+RUN pip install -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
+
 # Install base requirements
 RUN pip install -r ./requirements/edx/base.txt
 


### PR DESCRIPTION
All releases of py2neo prior to 4.0.0 were stripped from Pypi, so we
need to install this dependency from source.

See:
https://github.com/openedx/build-test-release-wg/issues/37
https://github.com/edx/edx-platform/pull/27168

Close #411.

This is ready for review @overhangio/tutor-developers.