### PR TITLE
refactor: better config type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-format: ## Run code formatting tests
 	black --check --diff $(BLACK_OPTS)
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --ignore=templates ${SRC_DIRS}
+	pylint --errors-only --enable=unused-import --ignore=templates ${SRC_DIRS}
 
 test-unit: ## Run unit tests
 	python -m unittest discover tests

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict
 import unittest
 from unittest.mock import Mock, patch
 import tempfile
 
 from tutor import config as tutor_config
 from tutor import interactive
+from tutor.types import get_typed, Config
 
 
 class ConfigTests(unittest.TestCase):
@@ -13,13 +13,13 @@ class ConfigTests(unittest.TestCase):
         self.assertNotIn("TUTOR_VERSION", defaults)
 
     def test_merge(self) -> None:
-        config1 = {"x": "y"}
-        config2 = {"x": "z"}
+        config1: Config = {"x": "y"}
+        config2: Config = {"x": "z"}
         tutor_config.merge(config1, config2)
         self.assertEqual({"x": "y"}, config1)
 
     def test_merge_render(self) -> None:
-        config: Dict[str, Any] = {}
+        config: Config = {}
         defaults = tutor_config.load_defaults()
         with patch.object(tutor_config.utils, "random_string", return_value="abcd"):
             tutor_config.merge(config, defaults)
@@ -62,13 +62,13 @@ class ConfigTests(unittest.TestCase):
             config, defaults = interactive.load_all(rootdir, interactive=False)
 
         self.assertIn("MYSQL_ROOT_PASSWORD", config)
-        self.assertEqual(8, len(config["MYSQL_ROOT_PASSWORD"]))
+        self.assertEqual(8, len(get_typed(config, "MYSQL_ROOT_PASSWORD", str)))
         self.assertNotIn("LMS_HOST", config)
         self.assertEqual("www.myopenedx.com", defaults["LMS_HOST"])
         self.assertEqual("studio.{{ LMS_HOST }}", defaults["CMS_HOST"])
 
     def test_is_service_activated(self) -> None:
-        config = {"RUN_SERVICE1": True, "RUN_SERVICE2": False}
+        config: Config = {"RUN_SERVICE1": True, "RUN_SERVICE2": False}
 
         self.assertTrue(tutor_config.is_service_activated(config, "service1"))
         self.assertFalse(tutor_config.is_service_activated(config, "service2"))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from typing import Any, Dict
 import unittest
 from unittest.mock import patch, Mock
 
@@ -8,6 +7,7 @@ from tutor import config as tutor_config
 from tutor import env
 from tutor import fmt
 from tutor import exceptions
+from tutor.types import Config
 
 
 class EnvTests(unittest.TestCase):
@@ -55,7 +55,7 @@ class EnvTests(unittest.TestCase):
         self.assertRaises(exceptions.TutorError, env.render_str, {}, "hello {{ name }}")
 
     def test_render_file(self) -> None:
-        config: Dict[str, Any] = {}
+        config: Config = {}
         tutor_config.merge(config, tutor_config.load_defaults())
         config["MYSQL_ROOT_PASSWORD"] = "testpassword"
         rendered = env.render_file(config, "hooks", "mysql", "init")
@@ -125,7 +125,7 @@ class EnvTests(unittest.TestCase):
                 f.write("Hello my ID is {{ ID }}")
 
             # Create configuration
-            config = {"ID": "abcd"}
+            config: Config = {"ID": "abcd"}
 
             # Render templates
             with patch.object(
@@ -162,7 +162,7 @@ class EnvTests(unittest.TestCase):
                 f.write("some content")
 
             # Load env once
-            config: Dict[str, Any] = {"PLUGINS": []}
+            config: Config = {"PLUGINS": []}
             env1 = env.Renderer.instance(config).environment
 
             with patch.object(
@@ -171,7 +171,7 @@ class EnvTests(unittest.TestCase):
                 return_value=[plugin1],
             ):
                 # Load env a second time
-                config["PLUGINS"].append("myplugin")
+                config["PLUGINS"] = ["myplugin"]
                 env2 = env.Renderer.instance(config).environment
 
             self.assertNotIn("plugin1/myplugin.txt", env1.loader.list_templates())  # type: ignore

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,10 +1,11 @@
 import unittest
 from tutor import images
+from tutor.types import Config
 
 
 class ImagesTests(unittest.TestCase):
     def test_get_tag(self) -> None:
-        config = {
+        config: Config = {
             "DOCKER_IMAGE_OPENEDX": "registry/openedx",
             "DOCKER_IMAGE_OPENEDX_DEV": "registry/openedxdev",
         }

--- a/tutor/bindmounts.py
+++ b/tutor/bindmounts.py
@@ -1,17 +1,18 @@
 import os
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Callable, List, Tuple
 
 import click
 from mypy_extensions import VarArg
 
 from .exceptions import TutorError
+from .types import Config
 from .utils import get_user_id
 
 
 def create(
     root: str,
-    config: Dict[str, Any],
-    docker_compose_func: Callable[[str, Dict[str, Any], VarArg(str)], int],
+    config: Config,
+    docker_compose_func: Callable[[str, Config, VarArg(str)], int],
     service: str,
     path: str,
 ) -> str:

--- a/tutor/commands/android.py
+++ b/tutor/commands/android.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import click
 
 from .compose import ComposeJobRunner
@@ -7,6 +5,7 @@ from .local import docker_compose as local_docker_compose
 from .. import config as tutor_config
 from .. import env as tutor_env
 from .. import fmt
+from ..types import Config
 from .context import Context
 
 
@@ -28,7 +27,7 @@ def build(context: Context, mode: str) -> None:
     )
 
 
-def build_command(config: Dict[str, str], target: str) -> str:
+def build_command(config: Config, target: str) -> str:
     gradle_target = {
         "debug": "assembleProdDebuggable",
         "release": "assembleProdRelease",

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, Dict, List
+from typing import Callable, List
 
 import click
 from mypy_extensions import VarArg
@@ -11,6 +11,7 @@ from ..exceptions import TutorError
 from .. import fmt
 from .. import jobs
 from .. import serialize
+from ..types import Config
 from .. import utils
 from .context import Context
 
@@ -19,8 +20,8 @@ class ComposeJobRunner(jobs.BaseJobRunner):
     def __init__(
         self,
         root: str,
-        config: Dict[str, Any],
-        docker_compose_func: Callable[[str, Dict[str, Any], VarArg(str)], int],
+        config: Config,
+        docker_compose_func: Callable[[str, Config, VarArg(str)], int],
     ):
         super().__init__(root, config)
         self.docker_compose_func = docker_compose_func

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import List
 
 import click
 
@@ -8,6 +8,7 @@ from .. import exceptions
 from .. import fmt
 from .. import interactive as interactive_config
 from .. import serialize
+from ..types import Config
 from .context import Context
 
 
@@ -40,7 +41,7 @@ def config_command() -> None:
 )
 @click.pass_obj
 def save(
-    context: Context, interactive: bool, set_vars: Dict[str, Any], unset_vars: List[str]
+    context: Context, interactive: bool, set_vars: Config, unset_vars: List[str]
 ) -> None:
     config, defaults = interactive_config.load_all(
         context.root, interactive=interactive
@@ -91,7 +92,7 @@ def printvalue(context: Context, key: str) -> None:
     config = tutor_config.load(context.root)
     try:
         # Note that this will incorrectly print None values
-        fmt.echo(config[key])
+        fmt.echo(str(config[key]))
     except KeyError as e:
         raise exceptions.TutorError(
             "Missing configuration value: {}".format(key)

--- a/tutor/commands/context.py
+++ b/tutor/commands/context.py
@@ -1,9 +1,7 @@
-from typing import Any, Dict
+from ..types import Config
 
 
-def unimplemented_docker_compose(
-    root: str, config: Dict[str, Any], *command: str
-) -> int:
+def unimplemented_docker_compose(root: str, config: Config, *command: str) -> int:
     raise NotImplementedError
 
 
@@ -13,5 +11,5 @@ class Context:
         self.root = root
         self.docker_compose_func = unimplemented_docker_compose
 
-    def docker_compose(self, root: str, config: Dict[str, Any], *command: str) -> int:
+    def docker_compose(self, root: str, config: Config, *command: str) -> int:
         return self.docker_compose_func(root, config, *command)

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -1,17 +1,18 @@
 import os
-from typing import Any, Dict, List
+from typing import List
 
 import click
 
 from .. import config as tutor_config
 from .. import env as tutor_env
 from .. import fmt
+from ..types import Config
 from .. import utils
 from . import compose
 from .context import Context
 
 
-def docker_compose(root: str, config: Dict[str, Any], *command: str) -> int:
+def docker_compose(root: str, config: Config, *command: str) -> int:
     """
     Run docker-compose with dev arguments.
     """

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -1,18 +1,18 @@
 import os
-from typing import Dict, Any
 
 import click
 
 from .. import config as tutor_config
 from .. import env as tutor_env
 from .. import fmt
+from ..types import get_typed, Config
 from .. import utils
 from . import compose
 from .config import save as config_save_command
 from .context import Context
 
 
-def docker_compose(root: str, config: Dict[str, Any], *command: str) -> int:
+def docker_compose(root: str, config: Config, *command: str) -> int:
     """
     Run docker-compose with local and production yml files.
     """
@@ -27,7 +27,7 @@ def docker_compose(root: str, config: Dict[str, Any], *command: str) -> int:
         tutor_env.pathjoin(root, "local", "docker-compose.prod.yml"),
         *args,
         "--project-name",
-        config["LOCAL_PROJECT_NAME"],
+        get_typed(config, "LOCAL_PROJECT_NAME", str),
         *command
     )
 
@@ -118,7 +118,7 @@ Are you sure you want to continue?"""
         running_version = "koa"
 
 
-def upgrade_from_ironwood(context: click.Context, config: Dict[str, Any]) -> None:
+def upgrade_from_ironwood(context: click.Context, config: Config) -> None:
     click.echo(fmt.title("Upgrading from Ironwood"))
     tutor_env.save(context.obj.root, config)
 
@@ -166,7 +166,7 @@ def upgrade_from_ironwood(context: click.Context, config: Dict[str, Any]) -> Non
     context.invoke(compose.stop)
 
 
-def upgrade_from_juniper(context: click.Context, config: Dict[str, Any]) -> None:
+def upgrade_from_juniper(context: click.Context, config: Config) -> None:
     click.echo(fmt.title("Upgrading from Juniper"))
     tutor_env.save(context.obj.root, config)
 

--- a/tutor/commands/webui.py
+++ b/tutor/commands/webui.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 import tarfile
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 from urllib.request import urlopen
 
 import click
@@ -15,6 +15,7 @@ from .. import fmt
 from .. import env as tutor_env
 from .. import exceptions
 from .. import serialize
+from ..types import Config
 from .context import Context
 
 
@@ -135,7 +136,7 @@ def load_config(root: str) -> Dict[str, Optional[str]]:
     return config
 
 
-def save_webui_config_file(root: str, config: Dict[str, Any]) -> None:
+def save_webui_config_file(root: str, config: Config) -> None:
     path = config_path(root)
     directory = os.path.dirname(path)
     if not os.path.exists(directory):

--- a/tutor/images.py
+++ b/tutor/images.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict
-
-from . import fmt
-from . import utils
+from . import fmt, utils
+from .types import Config, get_typed
 
 
-def get_tag(config: Dict[str, Any], name: str) -> Any:
-    return config["DOCKER_IMAGE_" + name.upper().replace("-", "_")]
+def get_tag(config: Config, name: str) -> str:
+    key = "DOCKER_IMAGE_" + name.upper().replace("-", "_")
+    return get_typed(config, key, str)
 
 
 def build(path: str, tag: str, *args: str) -> None:

--- a/tutor/jobs.py
+++ b/tutor/jobs.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-from . import env
-from . import fmt
-from . import plugins
+from . import env, fmt, plugins
+from .types import Config
 
 BASE_OPENEDX_COMMAND = """
 export DJANGO_SETTINGS_MODULE=$SERVICE_VARIANT.envs.$SETTINGS
@@ -11,7 +10,7 @@ echo "Loading settings $DJANGO_SETTINGS_MODULE"
 
 
 class BaseJobRunner:
-    def __init__(self, root: str, config: Dict[str, Any]):
+    def __init__(self, root: str, config: Config):
         self.root = root
         self.config = config
 

--- a/tutor/serialize.py
+++ b/tutor/serialize.py
@@ -1,12 +1,11 @@
 import re
-from typing import Any, IO, Iterator, Tuple, Union
+from typing import IO, Any, Iterator, Tuple, Union
 
+import click
 import yaml
 from _io import TextIOWrapper
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
-
-import click
 
 
 def load(stream: Union[str, IO[str]]) -> Any:
@@ -19,6 +18,12 @@ def load_all(stream: str) -> Iterator[Any]:
 
 def dump(content: Any, fileobj: TextIOWrapper) -> None:
     yaml.dump(content, stream=fileobj, default_flow_style=False)
+
+
+def dumps(content: Any) -> str:
+    result = yaml.dump(content, default_flow_style=False)
+    assert isinstance(result, str)
+    return result
 
 
 def parse(v: Union[str, IO[str]]) -> Any:

--- a/tutor/types.py
+++ b/tutor/types.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+
+from . import exceptions
+
+ConfigValue = Union[
+    str, float, None, bool, List[str], List[Any], Dict[str, Any], Dict[Any, Any]
+]
+Config = Dict[str, ConfigValue]
+
+
+def cast_config(config: Any) -> Config:
+    if not isinstance(config, dict):
+        raise exceptions.TutorError(
+            "Invalid configuration: expected dict, got {}".format(config.__class__)
+        )
+    for key in config.keys():
+        if not isinstance(key, str):
+            raise exceptions.TutorError(
+                "Invalid configuration: expected str, got {} for key '{}'".format(
+                    key.__class__, key
+                )
+            )
+    return config
+
+
+T = TypeVar("T")
+
+
+def get_typed(
+    config: Config, key: str, expected_type: Type[T], default: Optional[T] = None
+) -> T:
+    value = config.get(key, default)
+    if not isinstance(value, expected_type):
+        raise exceptions.TutorError(
+            "Invalid config entry: expected {}, got {} for key '{}'".format(
+                expected_type.__name__, value.__class__, key
+            )
+        )
+    return value


### PR DESCRIPTION
I stumbled upon a bug that should have been detected by the type checking. Turns out, considering that config is of type Dict[str, Any] means that we can use just any method on all config values -- which is terrible. I discovered this after I set `config["PLUGINS"] = None`: this triggered a crash when I enabled a plugin.

We resolve this by making the Config type more explicit. We also take the opportunity to remove a few cast statements.

Pylint now also checks for unused imports.

I understand this is a complex PR -- well, we are still in the process of figuring out how to best use mypy.

This is ready for review @overhangio/tutor-developers.
