### PR TITLE
docs: mention MySQL external version

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,6 +123,9 @@ By default, a running Open edX platform deployed with Tutor includes all necessa
     MYSQL_ROOT_USERNAME: <root user name>
     MYSQL_ROOT_PASSWORD: <root user password>
 
+.. note::
+    When configuring an external MySQL database, please make sure it is using version 5.7.
+
 Elasticsearch
 *************
 


### PR DESCRIPTION
See: https://discuss.overhang.io/t/managed-rds-mysql-8-0-not-compatible-with-current-docker-compose/1429/3

When running the command `tutor local init` with MySQL >5.7, the script will error as the `IDENTIFIED BY` syntax is not supported for the `GRANT` command anymore in later versions of MySQL.