### PR TITLE
fix: YamlParamType supports line terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+## Unreleased
+- [Bugfix] Fix YamlParamType regex to support line terminators.
+
 ## v11.2.7 (2021-04-23)
 
 - [Security] Apply security patch [27394](https://github.com/edx/edx-platform/pull/27394).

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -39,3 +39,9 @@ class SerializeTests(unittest.TestCase):
         with self.assertRaises(click.exceptions.BadParameter):
             param.convert("name", "param", {})
         self.assertEqual(("x", "a=bcd"), param.convert("x=a=bcd", "param", {}))
+        self.assertEqual(
+            ("x", {"key1": {"subkey": "value"}, "key2": {"subkey": "value"}}),
+            param.convert(
+                "x=key1:\n  subkey: value\nkey2:\n  subkey: value", "param", {}
+            ),
+        )

--- a/tutor/serialize.py
+++ b/tutor/serialize.py
@@ -39,7 +39,7 @@ def parse(v: Union[str, IO[str]]) -> Any:
 
 class YamlParamType(click.ParamType):
     name = "yaml"
-    PARAM_REGEXP = r"(?P<key>[a-zA-Z0-9_-]+)=(?P<value>.*)"
+    PARAM_REGEXP = r"(?P<key>[a-zA-Z0-9_-]+)=(?P<value>(.|\n|\r)*)"
 
     def convert(self, value: str, param: Any, ctx: Any) -> Tuple[str, Any]:
         match = re.match(self.PARAM_REGEXP, value)


### PR DESCRIPTION
This fix allows using a multiple line formatted Yaml string as input for setting a Tutor config value.