### PR TITLE
Add uwsgi buffer size to prevent its exceeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+## unreleased
+
+- [Bugfix] Fix 502 error on request to lms with header larger than the maximum uwsgi buffer size
+
 ## v11.2.8 (2021-04-27)
 
 - [Bugfix] Fix parsing of YAML-formatted values in ``config save --set KEY=VALUE`` commands, in use for instance with Ecommerce.

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -214,4 +214,5 @@ CMD uwsgi \
     --single-interpreter \
     --enable-threads \
     --processes=${UWSGI_WORKERS:-2} \
+    --buffer-size=8192 \
     --wsgi-file ${SERVICE_VARIANT}/wsgi.py


### PR DESCRIPTION
502 was observed when default size 4096 being hit

Close #426
This is equivalent to https://github.com/overhangio/tutor-ecommerce/commit/6df2c99362ee12239eb27b79455539411e4d479e