### PR TITLE
fix: crash during `local quickstart -p`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
-## unreleased
+## Unreleased
 
-- [Bugfix] Fix 502 error on request to lms with header larger than the maximum uwsgi buffer size
+- [Bugfix] Fix crash in `local quickstart -p` command.
+- [Bugfix] Fix 502 error on request to lms with header larger than the maximum uwsgi buffer size.
 
 ## v11.2.8 (2021-04-27)
 

--- a/tests/test_bindmounts.py
+++ b/tests/test_bindmounts.py
@@ -29,3 +29,8 @@ class BindMountsTests(unittest.TestCase):
         )
         self.assertEqual(("/openedx/venv", "/tmp/openedx:/openedx"), volume_args)
         self.assertEqual(("run", "lms", "echo", "boom"), non_volume_args)
+
+    def test_parse_volumes_empty_list(self) -> None:
+        volume_args, non_volume_args = bindmounts.parse_volumes([])
+        self.assertEqual((), volume_args)
+        self.assertEqual((), non_volume_args)

--- a/tutor/bindmounts.py
+++ b/tutor/bindmounts.py
@@ -75,7 +75,7 @@ def parse_volumes(docker_compose_args: List[str]) -> Tuple[List[str], List[str]]
 
     @click.command(context_settings={"ignore_unknown_options": True})
     @click.option("-v", "--volume", "volumes", multiple=True)
-    @click.argument("args", nargs=-1, required=True)
+    @click.argument("args", nargs=-1)
     def custom_docker_compose(
         volumes: List[str], args: List[str]
     ) -> None:  # pylint: disable=unused-argument

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -276,7 +276,7 @@ def logs(context: click.Context, follow: bool, tail: bool, service: str) -> None
     name="dc",
 )
 @click.argument("command")
-@click.argument("args", nargs=-1, required=True)
+@click.argument("args", nargs=-1)
 @click.pass_obj
 def dc_command(context: Context, command: str, args: List[str]) -> None:
     config = tutor_config.load(context.root)


### PR DESCRIPTION
When running `tutor local quickstart -p` we were getting the following error:

    Usage: custom [OPTIONS] ARGS...
    Try 'custom --help' for help.

    Error: Missing argument 'ARGS...'.

The docker-compose command sometimes accept a single command ("pull") with zero
argument.

See: https://discuss.overhang.io/t/local-quickstart-not-working-when-pullimages-enabled/1526

This is ready for review cc @overhangio/tutor-developers.