### PR TITLE
feat: better logging during plugin loading failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Better error logging when loading a plugin from an incompatible version.
+
 ## v11.2.11 (2021-05-18)
 
 - [Feature] Add redis database configuration for both cache and celery.

--- a/tutor/plugins.py
+++ b/tutor/plugins.py
@@ -229,7 +229,15 @@ class EntrypointPlugin(BasePlugin):
     @classmethod
     def iter_load(cls) -> Iterator["EntrypointPlugin"]:
         for entrypoint in pkg_resources.iter_entry_points(cls.ENTRYPOINT):
-            yield cls(entrypoint)
+            try:
+                yield cls(entrypoint)
+            except:
+                fmt.echo_error(
+                    "Failed to load entrypoint '{} = {}' from distribution {}".format(
+                        entrypoint.name, entrypoint.module_name, entrypoint.dist
+                    )
+                )
+                raise
 
 
 class OfficialPlugin(BasePlugin):


### PR DESCRIPTION
When upgrading Tutor plugins to the next release, I often end up with a
virtualenv that contains plugins that depend on different versions of
tutor-openedx. This causes a crash that did not log the name of the responsible
package. For instance:

    Traceback (most recent call last):
      File "/home/regis/venvs/tutor/bin/tutor", line 11, in <module>
        load_entry_point('tutor-openedx', 'console_scripts', 'tutor')()
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/commands/cli.py", line 37, in main
        add_plugin_commands(cli)
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/commands/plugins.py", line 137, in add_plugin_commands
        for plugin in plugins.iter_installed():
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/plugins.py", line 401, in iter_installed
        yield from Plugins.iter_installed()
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/plugins.py", line 362, in iter_installed
        for plugin in PluginClass.iter_installed():
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/plugins.py", line 199, in iter_installed
        for plugin in cls.iter_load():
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/plugins.py", line 233, in iter_load
        yield cls(entrypoint)
      File "/home/regis/projets/overhang/repos/overhang/tutor/tutor/plugins.py", line 220, in __init__
        super().__init__(entrypoint.name, entrypoint.load())
      File "/home/regis/venvs/tutor/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2442, in load
        self.require(*args, **kwargs)
      File "/home/regis/venvs/tutor/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2465, in require
        items = working_set.resolve(reqs, env, installer, extras=self.extras)
      File "/home/regis/venvs/tutor/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.VersionConflict: (tutor-openedx 11.2.11 (/home/regis/projets/overhang/repos/overhang/tutor), Requirement.parse('tutor-openedx<13.0.0,>=12.0.0'))

In this commit, we introduce an error log that displays the name and location
of the package. E.g:

    Failed to load entrypoint 'minio = tutorminio.plugin' from distribution tutor-minio 12.0.0

This is ready for review @overhangio/tutor-developers.