### PR TITLE
fix discussion notification not work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix discussion notification not work.
 - [Improvement] Better error logging when loading a plugin from an incompatible version.
 
 ## v11.2.11 (2021-05-18)

--- a/tutor/templates/apps/openedx/config/lms.env.json
+++ b/tutor/templates/apps/openedx/config/lms.env.json
@@ -47,6 +47,7 @@
   "EMAIL_HOST": "{{ SMTP_HOST }}",
   "EMAIL_PORT": {{ SMTP_PORT }},
   "EMAIL_USE_TLS": {{ "true" if SMTP_USE_TLS else "false" }},
+  "ACE_ROUTING_KEY": "edx.lms.core.default",
   "HTTPS": "{{ "on" if ENABLE_HTTPS else "off" }}",
   "LANGUAGE_CODE": "{{ LANGUAGE_CODE }}",
   "SESSION_COOKIE_DOMAIN": ".{{ LMS_HOST|common_domain(CMS_HOST) }}",


### PR DESCRIPTION
Discussion email notification relies on edx_ace and celery routing
key for ace is not set properly by default, which causes the send
mail task is never consumed.