### PR TITLE
security: disable python-evaluated input by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
-- [Bugfix] Fix discussion notification not work.
+- 💥[Security] Disable python-evaluated input by default as we don't run codejail.
+- [Bugfix] Fix missing discussion notifications.
 - [Improvement] Better error logging when loading a plugin from an incompatible version.
 
 ## v11.2.11 (2021-05-18)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -136,5 +136,15 @@ JWT_AUTH["JWT_ISSUERS"] = [
     }
 ]
 
+# Disable codejail support
+# explicitely configuring python is necessary to prevent unsafe calls
+import codejail.jail_code
+codejail.jail_code.configure("python", "nonexistingpythonbinary", user=None)
+# another configuration entry is required to override prod/dev settings
+CODE_JAIL = {
+    "python_bin": "nonexistingpythonbinary",
+    "user": None,
+}
+
 {{ patch("openedx-common-settings") }}
 ######## End of settings common to LMS and CMS


### PR DESCRIPTION
As described in issue #284, tutor does not come with codejail enabled out of
the box. Actually, we don't even have a working plugin, yet. To prevent users
from running unsafe code, we explicitely disable python-evaluated input by
disabling the "python" interpreter. This might break some courses; thus, this
is a non-backward compatible change.

This is ready for review @overhangio/tutor-developers.