### PR TITLE
K8s namespace permission improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Avoid permission issues in Kubernetes/Openshift for users who do not have the rights to edit their namespace.
 - [Improvement] Better Kubernetes object creation.
 
 ## v11.3.0 (2021-05-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Better Kubernetes object creation.
+
 ## v11.3.0 (2021-05-18)
 
 - 💥[Security] Disable python-evaluated input by default as we don't run codejail.

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -239,8 +239,7 @@ def start(context: Context) -> None:
         "--kustomize",
         tutor_env.pathjoin(context.root),
         "--selector",
-        # Here use `notin (job, xxx)` when there are other components to ignore
-        "app.kubernetes.io/component!=job",
+        "app.kubernetes.io/component notin (job,volume,namespace)",
     )
 
 


### PR DESCRIPTION
In most cases, it makes very little sense to edit the namespace that an
application is running in. Quite often, users are granted access to just one
namespace and don't have the necessary rights to edit the namespace -- and for
good security reasons. In such cases, the k8s namespace object already exists
and there is no need for the user to edit or create it. Here, what we do is
that we create the namespace only if it does not exist. This should solve quite
a few permission issues, notably for Openshift users.

This is ready for review @overhangio/tutor-developers. cc @menardorama