### PR TITLE
fix: better logging during `plugins disable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Better logging during `plugins disable`.
 - [Bugfix] Fix "upstream sent too big header" error during login of existing users after a Koa to Lilac upgrade.
 
 ## v12.0.0 (2021-06-09)

--- a/tutor/plugins.py
+++ b/tutor/plugins.py
@@ -411,19 +411,22 @@ def enable(config: Config, name: str) -> None:
     enabled.sort()
 
 
-def disable(config: Config, name: str) -> None:
-    fmt.echo_info("Disabling plugin {}...".format(name))
-    for plugin in Plugins(config).iter_enabled():
-        if name == plugin.name:
-            # Remove "set" config entries
-            for key, value in plugin.config_set.items():
-                config.pop(key, None)
-                fmt.echo_info("    Removed config entry {}={}".format(key, value))
-    # Remove plugin from list
+def disable(config: Config, plugin: BasePlugin) -> None:
+    # Remove plugin-specific set config
+    for key in plugin.config_set.keys():
+        config.pop(key, None)
+
+    # Remove plugin from list of enabled plugins
     enabled = enabled_plugins(config)
-    while name in enabled:
-        enabled.remove(name)
-    fmt.echo_info("    Plugin disabled")
+    while plugin.name in enabled:
+        enabled.remove(plugin.name)
+
+
+def get_enabled(config: Config, name: str) -> BasePlugin:
+    for plugin in iter_enabled(config):
+        if plugin.name == name:
+            return plugin
+    raise ValueError("Enabled plugin {} could not be found.".format(plugin.name))
 
 
 def iter_enabled(config: Config) -> Iterator[BasePlugin]:


### PR DESCRIPTION
When disable a plugin that set config entried, such as the minio plugin, tutor was logging the following:

    Disabling plugin minio...
        Removed config entry OPENEDX_AWS_ACCESS_KEY=openedx
        Removed config entry OPENEDX_AWS_SECRET_ACCESS_KEY={{ MINIO_AWS_SECRET_ACCESS_KEY }}
        Plugin disabled

The config values were not rendered during printing, which is a shame, because
the whole point of this log line is to warn users of passwords/secrets that are
being removed. Here, we make sure that the config values are properly rendered.
The new logs are now:

    Disabling plugin minio...
        Removing config entry OPENEDX_AWS_ACCESS_KEY=openedx
        Removing config entry OPENEDX_AWS_SECRET_ACCESS_KEY=64vpCVLxhDxBuNjakSrX4CQg
        Plugin disabled