### PR TITLE
fix: "upstream sent too big header" nginx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix "upstream sent too big header" error during login of existing users after a Koa to Lilac upgrade.
+
 ## v12.0.0 (2021-06-09)
 
 - 💥[Improvement] Upgrade all services to open-release/lilac.master.

--- a/tutor/templates/apps/nginx/lms.conf
+++ b/tutor/templates/apps/nginx/lms.conf
@@ -13,6 +13,9 @@ server {
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 
+  # Allow large cookies
+  proxy_buffer_size 8k;
+
   location @proxy_to_lms_app {
     proxy_redirect off;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
It was reported that existing users could not sign-in after a Koa -> Lilac
upgrade. This is due to the fact that cookies exceed the 4kb limit, which is
rejected by nginx. The fix consists in increasing this limit to 8kb:
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size

This issue was reported here: https://discuss.overhang.io/t/lilac-upgrade-login-issues/1617
Note that I was not able to reproduce the issue. The fix was tested by the
issue reporter.

This is ready for review @overhangio/tutor-developers.