### PR TITLE
fix: docs instructions to enable shell completion

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -97,13 +97,13 @@ With Tutor, it is very easy to upgrade to a more recent Open edX or Tutor releas
 Autocomplete
 ------------
 
-Tutor is built on top of `Click <https://click.palletsprojects.com>`_, which is a great library for building command line interface (CLI) tools. As such, Tutor benefits from all Click features, including `auto-completion <https://click.palletsprojects.com/en/7.x/bashcomplete/>`_. After installing Tutor, auto-completion can be enabled by running::
+Tutor is built on top of `Click <https://click.palletsprojects.com>`_, which is a great library for building command line interface (CLI) tools. As such, Tutor benefits from all Click features, including `auto-completion <https://click.palletsprojects.com/en/8.x/bashcomplete/>`_. After installing Tutor, auto-completion can be enabled in bash by running::
 
-    _TUTOR_COMPLETE=source tutor >> ~/.bashrc
+    _TUTOR_COMPLETE=bash_source tutor >> ~/.bashrc
 
 If you are running zsh, run instead::
 
-    _TUTOR_COMPLETE=source_zsh tutor >> ~/.zshrc
+    _TUTOR_COMPLETE=zsh_source tutor >> ~/.zshrc
 
 After opening a new shell, you can test auto-completion by typing::
 

--- a/docs/plugins/api.rst
+++ b/docs/plugins/api.rst
@@ -176,7 +176,7 @@ When saving the environment, template files that are stored in a template root w
 command
 ~~~~~~~
 
-A plugin can provide custom command line commands. Commands are assumed to be `click.Command <https://click.palletsprojects.com/en/7.x/api/#commands>`__ objects.
+A plugin can provide custom command line commands. Commands are assumed to be `click.Command <https://click.palletsprojects.com/en/8.x/api/#commands>`__ objects.
 
 Example::
 
@@ -191,7 +191,7 @@ Any user who installs the ``myplugin`` plugin can then run::
     $ tutor myplugin
     Hello from myplugin!
 
-You can even define subcommands by creating `command groups <https://click.palletsprojects.com/en/7.x/api/#click.Group>`__::
+You can even define subcommands by creating `command groups <https://click.palletsprojects.com/en/8.x/api/#click.Group>`__::
 
     import click
 
@@ -208,4 +208,4 @@ This would allow any user to run::
     $ tutor myplugin dosomething
     This subcommand is awesome
 
-See the official `click documentation <https://click.palletsprojects.com/en/7.x/>`__ for more information.
+See the official `click documentation <https://click.palletsprojects.com/en/8.x/>`__ for more information.


### PR DESCRIPTION
Instructions actually changed after the upgrade to Click 0.8.

See:
https://click.palletsprojects.com/en/8.0.x/changes/?highlight=completion#version-8-0-0
https://click.palletsprojects.com/en/8.0.x/shell-completion/

Close #457.