### PR TITLE
Skip updating config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: Breaking changes between versions are indicated by "💥".
 ## Unreleased
 
 - [Bugfix] Fix "upstream sent too big header" error during login of existing users after a Koa to Lilac upgrade.
+- [Feature] Added the ability to skip `config.yml` file modification while running `tutor config save` command with `-e` or `--env-only` flag.
 
 ## v12.0.0 (2021-06-09)
 

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -39,9 +39,16 @@ def config_command() -> None:
     multiple=True,
     help="Remove a configuration value (can be used multiple times)",
 )
+@click.option(
+    "-e", "--env-only", "env_only", is_flag=True, help="Skip updating config.yaml"
+)
 @click.pass_obj
 def save(
-    context: Context, interactive: bool, set_vars: Config, unset_vars: List[str]
+    context: Context,
+    interactive: bool,
+    set_vars: Config,
+    unset_vars: List[str],
+    env_only: bool,
 ) -> None:
     config, defaults = interactive_config.load_all(
         context.root, interactive=interactive
@@ -50,7 +57,8 @@ def save(
         tutor_config.merge(config, dict(set_vars), force=True)
     for key in unset_vars:
         config.pop(key, None)
-    tutor_config.save_config_file(context.root, config)
+    if not env_only:
+        tutor_config.save_config_file(context.root, config)
     tutor_config.merge(config, defaults)
     env.save(context.root, config)
 


### PR DESCRIPTION
## Description

There are some cases where we want to skip updating `config.yml` and simply want to generate the environment. This PR introduces a new flag `-e` / `--env-only` for `tutor config save` command. Which allows updating/creating the environment without updating `config.yml`.

Related conversation - https://discuss.overhang.io/t/avoid-writing-env-variables-to-config-yml/1665

## Testing instructions

1. Pull this PR
2. Generate a new config by running `tutor config save`.
3. Set k8s namespace in the environment - `export TUTOR_K8S_NAMESPACE=testnamespace`
4. Run `tutor config save -e` 
5. `K8S_NAMESPACE` will not appear in `config.yml`. Without this PR, `K8S_NAMESPACE` would have been set in the `config.yml` file.
