### PR TITLE
fix: empty entrypoints in docker-compose=2.0.0.beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix mysql initialisation in docker-compose==2.0.0beta4.
 - [Improvement] Tutor is now published on pypi as "tutor".
 
 ## v12.0.1 (2021-06-22)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -114,16 +114,13 @@ class K8sJobRunner(jobs.BaseJobRunner):
         job["metadata"]["name"] = job_name
         job["metadata"].setdefault("labels", {})
         job["metadata"]["labels"]["app.kubernetes.io/name"] = job_name
-        # Define k8s entrypoint/args
-        shell_command = ["sh", "-e", "-c"]
-        if job["spec"]["template"]["spec"]["containers"][0].get("command") == []:
-            # Empty "command" (aka: entrypoint) might not be taken into account by jobs, so we need to manually
-            # override the entrypoint. We do not do this for every job, because some entrypoints are actually useful.
-            job["spec"]["template"]["spec"]["containers"][0]["command"] = shell_command
-            container_args = [command]
-        else:
-            container_args = shell_command + [command]
-        job["spec"]["template"]["spec"]["containers"][0]["args"] = container_args
+        # Define k8s args (aka: CMD)
+        job["spec"]["template"]["spec"]["containers"][0]["args"] = [
+            "sh",
+            "-e",
+            "-c",
+            command,
+        ]
         job["spec"]["backoffLimit"] = 1
         job["spec"]["ttlSecondsAfterFinished"] = 3600
         # Save patched job to "jobs.yml" file

--- a/tutor/templates/k8s/jobs.yml
+++ b/tutor/templates/k8s/jobs.yml
@@ -77,7 +77,6 @@ spec:
       containers:
       - name: mysql
         image: {{ DOCKER_IMAGE_MYSQL }}
-        command: []
 ---
 apiVersion: batch/v1
 kind: Job
@@ -105,4 +104,3 @@ spec:
             value: "{{ FORUM_MONGODB_DATABASE }}"
 
 {{ patch("k8s-jobs") }}
-

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -3,8 +3,6 @@ services:
 
     mysql-job:
       image: {{ DOCKER_IMAGE_MYSQL }}
-      entrypoint: []
-      command: ["echo", "done"]
       depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
 
     lms-job:


### PR DESCRIPTION
An issue with the latest release of docker-compose was reported here:
https://discuss.overhang.io/t/undefined-entrypoint-throws-error-in-docker-compose-2-0-0-beta-4/1716

The mysql-job definition had an empty entrypoint (`[]`). This was causing the following error:

    the initiation of mysql fails with “services.mysql-job.entrypoint must be a string …
    Error: Command failed with status 15”

I can't remember at all why we had to define an empty entrypoint. It probably
has to do with the fact that we could not run `sh -e -c "..."` commands in
mysql jobs. Similarly, the k8s job definition sets `command: []`. I tested both
local and k8s deployments without these definitions and they work just fine. So
I guess we can get rid of them.