### PR TITLE
Revert "fix: empty entrypoints in docker-compose=2.0.0.beta4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix "`sh` is not a recognized command" in some plugins, including minio.
+
 ## v12.0.2 (2021-07-06)
 
 - [Bugfix] Fix "Invalid command argument" during upgrade from Koa to Lilac.

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -114,13 +114,18 @@ class K8sJobRunner(jobs.BaseJobRunner):
         job["metadata"]["name"] = job_name
         job["metadata"].setdefault("labels", {})
         job["metadata"]["labels"]["app.kubernetes.io/name"] = job_name
-        # Define k8s args (aka: CMD)
-        job["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "sh",
-            "-e",
-            "-c",
-            command,
-        ]
+        # Define k8s entrypoint/args
+        shell_command = ["sh", "-e", "-c"]
+        if job["spec"]["template"]["spec"]["containers"][0].get("command") == []:
+            # In some cases, we need to bypass the container entrypoint.
+            # Unfortunately, AFAIK, there is no way to do so in K8s manifests. So we mark
+            # some jobs with "command: []". For these jobs, the entrypoint becomes "sh -e -c".
+            # We do not do this for every job, because some (most) entrypoints are actually useful.
+            job["spec"]["template"]["spec"]["containers"][0]["command"] = shell_command
+            container_args = [command]
+        else:
+            container_args = shell_command + [command]
+        job["spec"]["template"]["spec"]["containers"][0]["args"] = container_args
         job["spec"]["backoffLimit"] = 1
         job["spec"]["ttlSecondsAfterFinished"] = 3600
         # Save patched job to "jobs.yml" file


### PR DESCRIPTION
This reverts commit 6f04223d0135e1debb005f2a9802f081ed21d203.

It turns out that we cannot ignore "command: []" statements in k8s manifests.
That's because there is no way to clear entrypoint in k8s manifests, but
sometimes we do need to bypass the entrypoints. For instance, the minio client
container sets "mc" as the default entrypoint, which does not work with our job
logic.

As a consequence, Tutor becomes incompatible with docker-compose 2.0.0.beta4.
The "entrypoint must be a string" error is actually an upstream bug:
https://github.com/docker/compose-cli/issues/1848

See:
- The corresponding minio issue: https://github.com/overhangio/tutor-minio/issues/9
- The previous conversation about empty entrypoints: https://discuss.overhang.io/t/undefined-entrypoint-throws-error-in-docker-compose-2-0-0-beta-4/1716