### PR TITLE
improvement: correctly set email logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Make sure that the logo included in email notifications (including discussion responses) is the same as the site logo.
+- [Bugfix] Install IPython directly from pypi instead of installing it from source (the reason it was installed from source is no longer relevant). The effect of this shall speed up the process of building the openedx-dev Docker image.
 - [Feature] Add "openedx-dockerfile-post-git-checkout" patch.
 - [Improvement] In the "openedx" Docker images, convert git patches to cherry-picks for a cleaner source tree.
 - 💥[Feature] Make it possible to override local job configuration. This deprecates the older model for running jobs which dates back from a long time ago.
-
-- [Bugfix] Install Ipython directly from pypy instead of installing it from source (the reason it was installed from source is no longer relevant). The effect of this shall speed up the process of openedx-dev Docker image. 
 
 ## v12.0.4 (2021-08-12)
 

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -18,6 +18,21 @@ COURSE_ABOUT_VISIBILITY_PERMISSION = "see_about_page"
 # Allow insecure oauth2 for local interaction with local containers
 OAUTH_ENFORCE_SECURE = False
 
+# Email settings
+class LazyStaticAbsoluteUrl:
+    """
+    Evaluates a static asset path lazily at runtime
+    """
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        from django.conf import settings
+        from django.contrib.staticfiles.storage import staticfiles_storage
+        return settings.LMS_ROOT_URL + staticfiles_storage.url(self.path)
+# We need a lazily-computed logo url to capture the url of the theme-specific logo.
+DEFAULT_EMAIL_LOGO_URL = LazyStaticAbsoluteUrl("images/logo.png")
+
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:
     if not os.path.exists(folder):


### PR DESCRIPTION
Previously, the logo included in emails was loaded from edX' CDN. Here, we make
sure that the logo is actually the same as the site logo. Because the logo may
be theme-specific, we need to compute the logo url at runtime, and use a
lazily-evaluated string.

This is for #447.

This is ready for review @overhangio/tutor-developers, and in particular @BbrSofiane.