### PR TITLE
docs: using docker-compose.override.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- 💥[Feature] Make it possible to override local job configuration. This deprecates the older model for running jobs which dates back from a long time ago.
+
 ## v12.0.4 (2021-08-12)
 
 - [Security] Apply security patch [28442](https://github.com/edx/edx-platform/pull/28442).

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -271,3 +271,12 @@ To dump all data from the MySQL and Mongodb databases used on the platform, run 
     tutor local exec mongodb mongodump --out=/data/db/dump.mongodb
 
 The ``dump.sql`` and ``dump.mongodb`` files will be located in ``$(tutor config printroot)/data/mysql`` and ``$(tutor config printroot)/data/mongodb``.
+
+Customizing the deployed services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You might want to customize the docker-compose services listed in ``$(tutor config printroot)/env/local/docker-compose.yml``. To do so, you should create a ``docker-compose.override.yml`` file in that same folder::
+
+    vim $(tutor config printroot)/env/local/docker-compose.override.yml
+
+The values in this file will override the values from ``docker-compose.yml`` and ``docker-compose.prod.yml``, as explained in the `docker-compose documentation <https://docs.docker.com/compose/extends/#adding-and-overriding-configuration>`__.

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -280,3 +280,5 @@ You might want to customize the docker-compose services listed in ``$(tutor conf
     vim $(tutor config printroot)/env/local/docker-compose.override.yml
 
 The values in this file will override the values from ``docker-compose.yml`` and ``docker-compose.prod.yml``, as explained in the `docker-compose documentation <https://docs.docker.com/compose/extends/#adding-and-overriding-configuration>`__.
+
+Similarly, the job service configuration can be overridden by creating a ``docker-compose.jobs.override.yml`` file in that same folder.


### PR DESCRIPTION
This feature was previously undocumented.

See: https://discuss.overhang.io/t/override-and-docker-compose/1857

This is ready for review @overhangio/tutor-developers.

EDIT: in addition, we make it possible to override job-specific configs. To simplify the code, we get rid of the deprecated way of running jobs, which dates back from v3.12.0. See: https://discuss.overhang.io/t/problem-fetching-saml-idp-metadata/1330/23