### PR TITLE
fix: segmentation fault on Mac OS M1 (Big Sur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix segmentation fault during `tutor config save` on Mac OS M1 (#473). Thanks @ghassanmas!
+- [Bugfix] Fix a bug that prevented connecting to external MongoDB instances.
 - [Improvement] Make sure that the logo included in email notifications (including discussion responses) is the same as the site logo.
 - [Bugfix] Install IPython directly from pypi instead of installing it from source (the reason it was installed from source is no longer relevant). The effect of this shall speed up the process of building the openedx-dev Docker image.
 - [Feature] Add "openedx-dockerfile-post-git-checkout" patch.
 - [Improvement] In the "openedx" Docker images, convert git patches to cherry-picks for a cleaner source tree.
 - 💥[Feature] Make it possible to override local job configuration. This deprecates the older model for running jobs which dates back from a long time ago.
-- [Bugfix] Fix a bug that prevented connecting to external MongoDB instances.
 
 ## v12.0.4 (2021-08-12)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,3 +36,12 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(
             b"\x00", base64.urlsafe_b64decode(utils.long_to_base64(0) + "==")
         )
+
+    def test_rsa_key(self) -> None:
+        key = utils.rsa_private_key(1024)
+        imported = utils.rsa_import_key(key)
+        self.assertIsNotNone(imported.e)
+        self.assertIsNotNone(imported.d)
+        self.assertIsNotNone(imported.n)
+        self.assertIsNotNone(imported.p)
+        self.assertIsNotNone(imported.q)


### PR DESCRIPTION
On Mac OS M1 (ARM processor), when the GMP library is available, pycryptodome
crashes with a segmentation fault during the generation of the RSA keys.

Upstream issue: https://github.com/Legrandin/pycryptodome/issues/506
Upstream fix: https://github.com/Legrandin/pycryptodome/pull/541

Close #473.