### PR TITLE
feat: make it easier to run edx-platform unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Make it easier to run edx-platform unit tests.
 - [Bugfix] Fix segmentation fault during `tutor config save` on Mac OS M1 (#473). Thanks @ghassanmas!
 - [Bugfix] Fix a bug that prevented connecting to external MongoDB instances.
 - [Improvement] Make sure that the logo included in email notifications (including discussion responses) is the same as the site logo.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -240,20 +240,15 @@ From then on, all ``dev`` commands will use the ``mysettings`` module. For insta
 Running edx-platform unit tests
 -------------------------------
 
-It's possible to run the full set of unit tests that ship with `edx-platform <https://github.com/edx/edx-platform/>`__. To do so, you should first build the "test" target of the "openedx-dev" Docker image::
+It's possible to run the full set of unit tests that ship with `edx-platform <https://github.com/edx/edx-platform/>`__. To do so, run a shell in the LMS development container::
 
-    tutor images build --target=test openedx-dev
-
-.. warning::
-    Don't forget to re-build the development image afterwards if you'd like to run ``dev`` commands again! To do so, run ``tutor images build openedx-dev`` after you are done testing.
+    tutor dev run lms bash
 
 Then, run unit tests with ``pytest`` commands::
 
-    # Run a test container
-    tutor dev run lms bash
-
     # Run tests on common apps
     unset DJANGO_SETTINGS_MODULE
+    unset SERVICE_VARIANT
     export EDXAPP_TEST_MONGO_HOST=mongodb
     pytest common
     pytest openedx

--- a/tutor/templates/apps/openedx/settings/cms/test.py
+++ b/tutor/templates/apps/openedx/settings/cms/test.py
@@ -1,1 +1,3 @@
+from cms.envs.test import *
+
 {% include "apps/openedx/settings/partials/common_test.py" %}

--- a/tutor/templates/apps/openedx/settings/lms/test.py
+++ b/tutor/templates/apps/openedx/settings/lms/test.py
@@ -1,1 +1,3 @@
+from lms.envs.test import *
+
 {% include "apps/openedx/settings/partials/common_test.py" %}

--- a/tutor/templates/apps/openedx/settings/partials/common_test.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_test.py
@@ -1,9 +1,3 @@
-# TODO clean this up
-import os
-os.environ["EDXAPP_TEST_MONGO_HOST"] = "mongodb"
-
-from ..test import *
-
 # Fix MongoDb connection credentials
 DOC_STORE_CONFIG["user"] = None
 DOC_STORE_CONFIG["password"] = None

--- a/tutor/templates/build/openedx-dev/Dockerfile
+++ b/tutor/templates/build/openedx-dev/Dockerfile
@@ -27,13 +27,6 @@ RUN chmod a+x /openedx/bin/*
 ARG USERID=1000
 RUN create-user.sh $USERID
 
-######## Test image
-FROM base as test
-
-# Run all tests by default
-ENTRYPOINT ["docker-entrypoint-test.sh"]
-CMD pytest
-
 ######## Development image
 FROM base as dev
 

--- a/tutor/templates/build/openedx-dev/bin/docker-entrypoint-test.sh
+++ b/tutor/templates/build/openedx-dev/bin/docker-entrypoint-test.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -e
-
-# Unset service variantm, which otherwise causes some unit tests to fail
-unset SERVICE_VARIANT
-# This variable should be set adequately depending on the set of unit tests to run
-unset DJANGO_SETTINGS_MODULE
-
-exec "$@"


### PR DESCRIPTION
It should be unnecessary to build a custom openedx-dev Docker image. All tests
can run from within the dev Docker image, with a couple additional environment
variables.

This is ready for review @overhangio/tutor-developers.