### PR TITLE
feat: cleaner git patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Feature] Add "openedx-dockerfile-post-git-checkout" patch.
 - [Improvement] In the "openedx" Docker images, convert git patches to cherry-picks for a cleaner source tree.
 - 💥[Feature] Make it possible to override local job configuration. This deprecates the older model for running jobs which dates back from a long time ago.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] In the "openedx" Docker images, convert git patches to cherry-picks for a cleaner source tree.
 - 💥[Feature] Make it possible to override local job configuration. This deprecates the older model for running jobs which dates back from a long time ago.
 
 ## v12.0.4 (2021-08-12)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -35,13 +35,17 @@ RUN mkdir -p /openedx/edx-platform && \
     git clone $EDX_PLATFORM_REPOSITORY --branch $EDX_PLATFORM_VERSION --depth 1 /openedx/edx-platform
 WORKDIR /openedx/edx-platform
 
+# Identify tutor user to cherry-pick commits
+RUN git config --global user.email "tutor@overhang.io" \
+  && git config --global user.name "Tutor"
+
 {% if patch("openedx-dockerfile-git-patches-default") %}
 # Custom edx-platform patches
 {{ patch("openedx-dockerfile-git-patches-default") }}
 {% else %}
 # Patch edx-platform
-# RUN curl --silent https://github.com/overhangio/edx-platform/commit/<sha1>.patch | git apply -
-RUN curl --silent https://github.com/overhangio/edx-platform/commit/8ecc1903ca9170a719c0e63e99fb231822eb26d8.patch | git apply -
+# Security patch: https://github.com/edx/edx-platform/pull/28442
+RUN git fetch https://github.com/edx/edx-platform 8ecc1903ca9170a719c0e63e99fb231822eb26d8 && git cherry-pick 8ecc1903ca9170a719c0e63e99fb231822eb26d8
 {% endif %}
 
 ###### Download extra locales to /openedx/locale/contrib/locale

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -48,6 +48,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 RUN git fetch https://github.com/edx/edx-platform 8ecc1903ca9170a719c0e63e99fb231822eb26d8 && git cherry-pick 8ecc1903ca9170a719c0e63e99fb231822eb26d8
 {% endif %}
 
+{# Example: RUN git fetch https://github.com/edx/edx-platform <GITSHA1> && git cherry-pick <GITSHA1> #}
+{{ patch("openedx-dockerfile-post-git-checkout") }}
+
 ###### Download extra locales to /openedx/locale/contrib/locale
 FROM minimal as locales
 ARG OPENEDX_I18N_VERSION={{ OPENEDX_COMMON_VERSION }}


### PR DESCRIPTION
- Replace `git patch` by `git cherry-pick` for a cleaner git tree.
- Add a "openedx-dockerfile-post-git-checkout" patch to enable plugin developers to patch edx-platform.

See the commit descriptions for more information.

This is ready for review @overhangio/tutor-developers.