### PR TITLE
fix: mongodb upgrade during koa -> lilac migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix Mongodb compatibility version upgrade when upgrading from Koa to Lilac.
+
 ## v12.1.2 (2021-09-18)
 
 - [Bugfix] Fix (agin) forum starting issue: "NoMethodError: undefined method 'encode' for nil:NilClass".

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -1,4 +1,5 @@
 import os
+from time import sleep
 
 import click
 
@@ -198,6 +199,8 @@ def upgrade_mongodb(
     config["DOCKER_IMAGE_MONGODB"] = "mongo:{}".format(to_docker_version)
     tutor_env.save(context.obj.root, config)
     context.invoke(compose.start, detach=True, services=["mongodb"])
+    fmt.echo_info("Waiting for mongodb to boot...")
+    sleep(10)
     context.invoke(
         compose.execute,
         args=[


### PR DESCRIPTION
When upgrading mongodb, the mongodb container takes a little while to become
ready. Running the "exec" command thus triggers an error:

    docker-compose -f /path/to/env/local/docker-compose.yml -f /path/to/env/local/docker-compose.prod.yml --project-name tutor_local exec mongodb mongo --eval db.adminCommand({ setF
    eatureCompatibilityVersion: "4.0" })
    MongoDB shell version v4.0.24
    connecting to: mongodb://127.0.0.1:27017/?gssapiServiceName=mongodb
    2021-06-14T10:53:21.510+0000 E QUERY    [js] Error: couldn't connect to server 127.0.0.1:27017, connection attempt failed: SocketException: Error connecting to 127.0.0.1:27017 :: caused by :: Connection refused:
    connect@src/mongo/shell/mongo.js:356:17
    @(connect):2:6
    exception: connect failed
    Error: Command failed with status 1: docker-compose -f /path/to/env/local/docker-compose.yml -f /path/to/env/local/docker-compose.prod.yml --project-name tutor_local exec mongodb mongo --eval db.adminCommand({ setFeatureCompatibilityVersion: "4.0" })

We add a "sleep" statement to the upgrade process to ensure that the mongodb
container is available.

This is ready for review @overhangio/tutor-developers.