### PR TITLE
[BB-4702] Ability to pass docker build options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: Breaking changes between versions are indicated by "💥".
 ## Unreleased
 
 - [Bugfix] Fix Mongodb compatibility version upgrade when upgrading from Koa to Lilac.
+- [Feature] Ability to pass [docker build options](https://docs.docker.com/engine/reference/commandline/build/#options) via ``--docker-arg`` option in ``tutor images build`` command.
 
 ## v12.1.2 (2021-09-18)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -372,3 +372,17 @@ By default, Tutor runs the `overhangio/openedx <https://hub.docker.com/r/overhan
 (See the relevant :ref:`configuration parameters <docker_images>`.)
 
 The customised Docker image tag value will then be used by Tutor to run the platform, for instance when running ``tutor local quickstart``.
+
+
+Passing custom docker build options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can set a limited set of Docker build options via ``tutor images build`` command. In some situations it might be necessary to tweak the docker build command, ex- setting up build caching using buildkit.
+In these situations, you can set ``--docker-arg`` flag in the ``tutor images build`` command. You can set any `supported options <https://docs.docker.com/engine/reference/commandline/build/#options>`_ in the docker build command, For example::
+
+    tutor images build openedx \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        --docker-arg="--cache-from" \
+        --docker-arg="docker.io/myusername/openedx:mytag"
+
+This will result in passing the ``--cache-from`` option with the value ``docker.io/myusername/openedx:mytag`` to the docker build command.

--- a/tutor/commands/images.py
+++ b/tutor/commands/images.py
@@ -54,6 +54,13 @@ def images_command() -> None:
     "--target",
     help="Set the target build stage to build.",
 )
+@click.option(
+    "-d",
+    "--docker-arg",
+    "docker_args",
+    multiple=True,
+    help="Set extra options for docker build command.",
+)
 @click.pass_obj
 def build(
     context: Context,
@@ -62,6 +69,7 @@ def build(
     build_args: List[str],
     add_hosts: List[str],
     target: str,
+    docker_args: List[str],
 ) -> None:
     config = tutor_config.load(context.root)
     command_args = []
@@ -73,6 +81,8 @@ def build(
         command_args += ["--add-host", add_host]
     if target:
         command_args += ["--target", target]
+    if docker_args:
+        command_args += docker_args
     for image in image_names:
         build_image(context.root, config, image, *command_args)
 


### PR DESCRIPTION
## Description

This PR adds the ability to pass any docker build [options](https://docs.docker.com/engine/reference/commandline/build/) via the newly added `--docker-arg` flag.

## Supporting information

https://discuss.overhang.io/t/ability-to-specify-cache-sources-during-image-build/1890

## Testing instructions

- Pull this PR
- Try to build the `openedx` image with - `tutor images build openedx --docker-arg="--build-arg" --docker-arg="EDX_PLATFORM_VERSION=open-release/koa.3"` command
- You should see arg `EDX_PLATFORM_VERSION` is set to `open-release/koa.3` in the output of docker image build command.