### PR TITLE
fix: 500 error during user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix 500 error during user registration.
 - [Bugfix] Fix Mongodb compatibility version upgrade when upgrading from Koa to Lilac.
 
 ## v12.1.2 (2021-09-18)
 
-- [Bugfix] Fix (agin) forum starting issue: "NoMethodError: undefined method 'encode' for nil:NilClass".
+- [Bugfix] Fix (again) forum starting issue: "NoMethodError: undefined method 'encode' for nil:NilClass".
 
 ## v12.1.1 (2021-09-17)
 

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -30,6 +30,12 @@ class LazyStaticAbsoluteUrl:
         from django.conf import settings
         from django.contrib.staticfiles.storage import staticfiles_storage
         return settings.LMS_ROOT_URL + staticfiles_storage.url(self.path)
+
+    def to_json(self):
+        # This method is required for json serialization by edx-ace, notably for
+        # serialization of the registration email. See
+        # edx_ace.serialization.MessageEncoder.
+        return str(self)
 # We need a lazily-computed logo url to capture the url of the theme-specific logo.
 DEFAULT_EMAIL_LOGO_URL = LazyStaticAbsoluteUrl("images/logo.png")
 


### PR DESCRIPTION
See: https://discuss.overhang.io/t/no-activation-email-errors-logged-on-user-sign-up/1969

A 500 error was being triggered during user registration.

    Traceback (most recent call last):
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
        response = get_response(request)
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
        response = self.process_exception_by_middleware(e, request)
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
        return view_func(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
        return self.dispatch(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/debug.py", line 76, in sensitive_post_parameters_wrapper
        return view(request, *args, **kwargs)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 485, in dispatch
        return super().dispatch(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
        response = self.handle_exception(exc)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
        self.raise_uncaught_exception(exc)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
        raise exc
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
        response = handler(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
        return view_func(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/ratelimit/decorators.py", line 24, in _wrapped
        return fn(request, *args, **kw)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 529, in post
        response, user = self._create_account(request, data)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 572, in _create_account
        user = create_account_with_params(request, data)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 236, in create_account_with_params
        compose_and_send_activation_email(user, profile, registration)
      File "/openedx/edx-platform/common/djangoapps/student/views/management.py", line 214, in compose_and_send_activation_email
        send_activation_email.delay(str(msg))
      File "/openedx/venv/lib/python3.8/site-packages/edx_ace/serialization.py", line 29, in __str__
        return json.dumps(self, cls=MessageEncoder)
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/__init__.py", line 234, in dumps
        return cls(
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 199, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 257, in iterencode
        return _iterencode(o, 0)
      File "/openedx/venv/lib/python3.8/site-packages/edx_ace/serialization.py", line 119, in default
        return super().default(o)   # pragma: no cover
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 179, in default
        raise TypeError(f'Object of type {o.__class__.__name__} '
    TypeError: Object of type LazyStaticAbsoluteUrl is not JSON serializable
    2021-09-28 05:21:52,174 ERROR 122 [django.request] [user 11] [ip XY.XY.XY.XY] log.py:222 - Internal Server Error: /api/user/v2/account/registration/
    Traceback (most recent call last):
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
        response = get_response(request)
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
        response = self.process_exception_by_middleware(e, request)
      File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
        return view_func(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
        return self.dispatch(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/debug.py", line 76, in sensitive_post_parameters_wrapper
        return view(request, *args, **kwargs)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 485, in dispatch
        return super().dispatch(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
        response = self.handle_exception(exc)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
        self.raise_uncaught_exception(exc)
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
        raise exc
      File "/openedx/venv/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
        response = handler(request, *args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
        return view_func(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
        return bound_method(*args, **kwargs)
      File "/openedx/venv/lib/python3.8/site-packages/ratelimit/decorators.py", line 24, in _wrapped
        return fn(request, *args, **kw)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 529, in post
        response, user = self._create_account(request, data)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 572, in _create_account
        user = create_account_with_params(request, data)
      File "./openedx/core/djangoapps/user_authn/views/register.py", line 236, in create_account_with_params
        compose_and_send_activation_email(user, profile, registration)
      File "/openedx/edx-platform/common/djangoapps/student/views/management.py", line 214, in compose_and_send_activation_email
        send_activation_email.delay(str(msg))
      File "/openedx/venv/lib/python3.8/site-packages/edx_ace/serialization.py", line 29, in __str__
        return json.dumps(self, cls=MessageEncoder)
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/__init__.py", line 234, in dumps
        return cls(
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 199, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 257, in iterencode
        return _iterencode(o, 0)
      File "/openedx/venv/lib/python3.8/site-packages/edx_ace/serialization.py", line 119, in default
        return super().default(o)   # pragma: no cover
      File "/opt/pyenv/versions/3.8.6/lib/python3.8/json/encoder.py", line 179, in default
        raise TypeError(f'Object of type {o.__class__.__name__} '
    TypeError: Object of type LazyStaticAbsoluteUrl is not JSON serializable

The reason for that was that edx-ace could not json-serialize the context to be
passed to the registration email renderer. That was caused by the
LazyStaticAbsoluteUrl object created to address missing logo in registration
email. To make sure that this object is serializable by
edx_ace.serialization.MessageEncoder, we add a trivial .to_json() method to the
LazyStaticAbsoluteUrl class.

This error could (at first) not be reproduced in development, because
AUTOMATIC_AUTH_FOR_TESTING is set to true in devstack settings.