### PR TITLE
Enable prerequisites course feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: Breaking changes between versions are indicated by "💥".
 ## Unreleased
 
 - [Feature] Add configuration setting `PREVIEW_LMS_BASE` for custom preview domain.
+- [Improvement] Enable milestones application flag `MILESTONES_APP` and prerequisite courses feature flags `ENABLE_PREREQUISITE_COURSES` by default.
 
 ## v12.1.3 (2021-09-28)
 

--- a/tutor/templates/apps/openedx/config/cms.env.json
+++ b/tutor/templates/apps/openedx/config/cms.env.json
@@ -13,7 +13,9 @@
     "ENABLE_COURSEWARE_INDEX": true,
     "ENABLE_CSMH_EXTENDED": false,
     "ENABLE_LEARNER_RECORDS": false,
-    "ENABLE_LIBRARY_INDEX": true
+    "ENABLE_LIBRARY_INDEX": true,
+    "MILESTONES_APP": true,
+    "ENABLE_PREREQUISITE_COURSES": true
   },
   "LMS_ROOT_URL": "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}",
   "CMS_ROOT_URL": "{{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}",

--- a/tutor/templates/apps/openedx/config/lms.env.json
+++ b/tutor/templates/apps/openedx/config/lms.env.json
@@ -20,7 +20,9 @@
     "ENABLE_LEARNER_RECORDS": false,
     "ENABLE_MOBILE_REST_API": true,
     "ENABLE_OAUTH2_PROVIDER": true,
-    "ENABLE_THIRD_PARTY_AUTH": true
+    "ENABLE_THIRD_PARTY_AUTH": true,
+    "MILESTONES_APP": true,
+    "ENABLE_PREREQUISITE_COURSES": true
   },
   "LMS_ROOT_URL": "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}",
   "CMS_ROOT_URL": "{{ "https" if ENABLE_HTTPS else "http" }}://{{ CMS_HOST }}",


### PR DESCRIPTION
### Description

This PR enables prerequisites course feature (https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_prerequisites.html) by default, adding MILESTONES_APP and ENABLE_PREREQUISITE_COURSES to the initial features with a `true` value.

### Supporting information

https://discuss.overhang.io/t/course-prerequisites/162

### Testing instructions

* Pull this PR
* Run `tutor local quickstart` 
* Go to `studio.local.overhang.io`
* Select a course
* Go to Settings > Schedule and Details
* `Prerequisite Course` should be shown as an option.