### PR TITLE
fix: LANGUAGE_COOKIE_NAME is not set by default

### DIFF
--- a/tutor/templates/apps/openedx/config/cms.env.json
+++ b/tutor/templates/apps/openedx/config/cms.env.json
@@ -37,6 +37,7 @@
   "EMAIL_USE_TLS": {{ "true" if SMTP_USE_TLS else "false" }},
   "HTTPS": "{{ "on" if ENABLE_HTTPS else "off" }}",
   "LANGUAGE_CODE": "{{ LANGUAGE_CODE }}",
+  "LANGUAGE_COOKIE_NAME": "{{ LANGUAGE_COOKIE_NAME }}",
   "SESSION_COOKIE_DOMAIN": ".{{ LMS_HOST|common_domain(CMS_HOST) }}",
   {{ patch("cms-env", separator=",\n", suffix=",")|indent(2) }}
   "CACHES": {

--- a/tutor/templates/apps/openedx/config/lms.env.json
+++ b/tutor/templates/apps/openedx/config/lms.env.json
@@ -47,6 +47,7 @@
   "ACE_ROUTING_KEY": "edx.lms.core.default",
   "HTTPS": "{{ "on" if ENABLE_HTTPS else "off" }}",
   "LANGUAGE_CODE": "{{ LANGUAGE_CODE }}",
+  "LANGUAGE_COOKIE_NAME": "{{ LANGUAGE_COOKIE_NAME }}",
   "SESSION_COOKIE_DOMAIN": ".{{ LMS_HOST|common_domain(CMS_HOST) }}",
   {{ patch("lms-env", separator=",\n", suffix=",")|indent(2) }}
   "CACHES": {

--- a/tutor/templates/config.yml
+++ b/tutor/templates/config.yml
@@ -49,6 +49,7 @@ JWT_COMMON_SECRET_KEY: "{{ OPENEDX_SECRET_KEY }}"
 JWT_RSA_PRIVATE_KEY: "{{ 2048|rsa_private_key }}"
 K8S_NAMESPACE: "openedx"
 LANGUAGE_CODE: "en"
+LANGUAGE_COOKIE_NAME: "openedx-language-preference"
 MONGODB_HOST: "mongodb"
 MONGODB_DATABASE: "openedx"
 MONGODB_PORT: 27017


### PR DESCRIPTION
Regression caused by https://github.com/edx/edx-platform/pull/28796

Details:

```
response.delete_cookie(
    settings.LANGUAGE_COOKIE_NAME,
    domain=settings.SHARED_COOKIE_DOMAIN
)
caused an Exception due to absence of LANGUAGE_COOKIE_NAME settings variable

> production.py

LANGUAGE_COOKIE_NAME = ENV_TOKENS.get('LANGUAGE_COOKIE', None) or ENV_TOKENS.get('LANGUAGE_COOKIE_NAME')
```


Exception:

```python
2021-10-07 20:26:57,299 INFO 8 [audit] [user 3] [ip 172.19.0.1] models.py:2723 - Login success - user.id: 3
2021-10-07 20:26:57,318 INFO 8 [openedx_events.tooling] [user 3] [ip 172.19.0.1] tooling.py:160 - Responses of the Open edX Event <org.openedx.learning.auth.session.login.completed.v1>:
[]
2021-10-07 20:26:57,429 ERROR 8 [root] [user 3] [ip 172.19.0.1] signals.py:22 - Uncaught exception from None
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/openedx/venv/lib/python3.8/site-packages/django/utils/deprecation.py", line 96, in __call__
    response = self.process_response(request, response)
  File "./openedx/core/djangoapps/lang_pref/middleware.py", line 93, in process_response
    response.delete_cookie(
  File "/openedx/venv/lib/python3.8/site-packages/django/http/response.py", line 216, in delete_cookie
    secure = key.startswith(('__Secure-', '__Host-'))
AttributeError: 'NoneType' object has no attribute 'startswith'
```