### PR TITLE
fix: bypass build to accelerate "local start"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Faster `tutor local start` by building only necessary images.
+
 ## v12.1.5 (2021-10-25)
 
 - 💥[Improvement] Change the `settheme` command such that, by default, a custom theme is assigned to the LMS and the CMS, both in production and development mode.

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -65,13 +65,11 @@ class ComposeJobRunner(jobs.BaseJobRunner):
 @click.argument("services", metavar="service", nargs=-1)
 @click.pass_obj
 def start(context: Context, detach: bool, services: List[str]) -> None:
-    command = ["up", "--remove-orphans"]
+    command = ["up", "--remove-orphans", "--build"]
     if detach:
         command.append("-d")
 
     config = tutor_config.load(context.root)
-    # Rebuild Docker images with a `build: ...` context.
-    context.docker_compose(context.root, config, "build")
     # Start services
     context.docker_compose(context.root, config, *command, *services)
 


### PR DESCRIPTION
Previously, we were building all images every time we ran a "local start"
command. This was causing unnecessary rebuild. Here, instead, we make use of
the `docker-compose up --build`. This means that only the required images will
be rebuilt.