### PR TITLE
Swap incorrect documentation filenames

### DIFF
--- a/docs/reference/cli/k8s.rst
+++ b/docs/reference/cli/k8s.rst
@@ -1,3 +1,3 @@
-.. click:: tutor.commands.local:local
-   :prog: tutor local
+.. click:: tutor.commands.k8s:k8s
+   :prog: tutor k8s
    :nested: full

--- a/docs/reference/cli/local.rst
+++ b/docs/reference/cli/local.rst
@@ -1,3 +1,3 @@
-.. click:: tutor.commands.k8s:k8s
-   :prog: tutor k8s
+.. click:: tutor.commands.local:local
+   :prog: tutor local
    :nested: full


### PR DESCRIPTION
Love the recent updates to the documentation 😍 but noticed that the URLs were mixed-up here.