### PR TITLE
fix: always run Caddy on Kubernetes

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Bugfix] Fix running Caddy container in k8s, which should always be the case even if `ENABLE_WEB_PROXY` is false.
 - 💥[Improvement] Run all services as unprivileged containers, for better security. This has multiple consequences:
   - The "openedx-dev" image is now built with `tutor dev dc build lms`.
   - The "smtp" service now runs the "devture/exim-relay" Docker image, which is unprivileged. Also, the default SMTP port is now 8025.

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -1,4 +1,3 @@
-{% if ENABLE_WEB_PROXY %}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -21,19 +20,24 @@ spec:
           volumeMounts:
             - mountPath: /etc/caddy/
               name: config
+            {%- if ENABLE_WEB_PROXY %}
             - mountPath: /data/
               name: data
+            {%- endif %}
           ports:
             - containerPort: 80
+            {%- if ENABLE_WEB_PROXY %}
             - containerPort: 443
+            {%- endif %}
       volumes:
         - name: config
           configMap:
             name: caddy-config
+        {%- if ENABLE_WEB_PROXY %}
         - name: data
           persistentVolumeClaim:
             claimName: caddy
-{% endif %}
+        {%- endif %}
 {% if RUN_CMS %}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Caddy should always be running, even when ENABLE_WEB_PROXY is false.
It's the service that should not always be running.