### PR TITLE
A couple minor improvements to plugin management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Ignore Python plugins which cannot be loaded.
+
 ## v12.1.6 (2021-11-02)
 
 - [Improvement] Upgrade all services to open-release/lilac.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Make `tutor plugins list` print plugins sorted by name.
 - [Improvement] Ignore Python plugins which cannot be loaded.
 
 ## v12.1.6 (2021-11-02)

--- a/tutor/plugins.py
+++ b/tutor/plugins.py
@@ -231,14 +231,18 @@ class EntrypointPlugin(BasePlugin):
     def iter_load(cls) -> Iterator["EntrypointPlugin"]:
         for entrypoint in pkg_resources.iter_entry_points(cls.ENTRYPOINT):
             try:
+                error: Optional[str] = None
                 yield cls(entrypoint)
-            except:
+            except pkg_resources.VersionConflict as e:
+                error = e.report()
+            except Exception as e:
+                error = str(e)
+            if error:
                 fmt.echo_error(
-                    "Failed to load entrypoint '{} = {}' from distribution {}".format(
-                        entrypoint.name, entrypoint.module_name, entrypoint.dist
+                    "Failed to load entrypoint '{} = {}' from distribution {}: {}".format(
+                        entrypoint.name, entrypoint.module_name, entrypoint.dist, error
                     )
                 )
-                raise
 
 
 class OfficialPlugin(BasePlugin):

--- a/tutor/plugins.py
+++ b/tutor/plugins.py
@@ -363,11 +363,14 @@ class Plugins:
         prevent too many re-computations, which happens a lot.
         """
         installed_plugin_names = set()
+        plugins = []
         for PluginClass in cls.PLUGIN_CLASSES:
             for plugin in PluginClass.iter_installed():
                 if plugin.name not in installed_plugin_names:
                     installed_plugin_names.add(plugin.name)
-                    yield plugin
+                    plugins.append(plugin)
+        plugins = sorted(plugins, key=lambda plugin: plugin.name)
+        yield from plugins
 
     def iter_enabled(self) -> Iterator[BasePlugin]:
         for plugin in self.iter_installed():


### PR DESCRIPTION
- Do not crash on non-importable plugins.
- Always print plugins sorted by name.

This is ready for review @overhangio/tutor-developers.