### PR TITLE
fix: remove trailing slashes in volume paths for docker-compose v2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
+- [Bugfix] Remove trailing slashes in docker-compose files for [compatibility with docker-compose v2 in WSL](https://github.com/docker/compose/issues/8558).
 
 ## v12.1.7 (2021-11-18)
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -101,16 +101,16 @@ You are then free to bind-mount any directory to any container. For instance, to
     services:
       lms:
         volumes:
-          - /path/to/edx-platform/:/openedx/edx-platform
+          - /path/to/edx-platform:/openedx/edx-platform
       cms:
         volumes:
-          - /path/to/edx-platform/:/openedx/edx-platform
+          - /path/to/edx-platform:/openedx/edx-platform
       lms-worker:
         volumes:
-          - /path/to/edx-platform/:/openedx/edx-platform
+          - /path/to/edx-platform:/openedx/edx-platform
       cms-worker:
         volumes:
-          - /path/to/edx-platform/:/openedx/edx-platform
+          - /path/to/edx-platform:/openedx/edx-platform
 
 This override file will be loaded when running any ``tutor dev ..`` command. The edx-platform repo mounted at the specified path will be automatically mounted inside all LMS and CMS containers. With this file, you should no longer specify the ``-v/--volume`` option from the command line with the ``run`` or ``runserver`` commands.
 

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -7,9 +7,9 @@ x-openedx-service:
     SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.development}
   volumes:
     # Settings & config
-    - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-    - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-    - ../apps/openedx/config/:/openedx/config/:ro
+    - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+    - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+    - ../apps/openedx/config:/openedx/config:ro
     # theme files
     - ../build/openedx/themes:/openedx/themes
     # editable requirements

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -11,9 +11,9 @@ services:
         SERVICE_VARIANT: lms
         SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
       volumes:
-        - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-        - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-        - ../apps/openedx/config/:/openedx/config/:ro
+        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+        - ../apps/openedx/config:/openedx/config:ro
       depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
 
     cms-job:
@@ -22,9 +22,9 @@ services:
         SERVICE_VARIANT: cms
         SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
       volumes:
-        - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-        - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-        - ../apps/openedx/config/:/openedx/config/:ro
+        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+        - ../apps/openedx/config:/openedx/config:ro
       depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
 
     forum-job:

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -30,7 +30,7 @@ services:
           {{ patch("local-docker-compose-nginx-aliases")|indent(10) }}
     {% endif %}
     volumes:
-      - ../apps/nginx:/etc/nginx/conf.d/:ro
+      - ../apps/nginx:/etc/nginx/conf.d:ro
     depends_on: {{ [("lms", RUN_LMS), ("cms", RUN_CMS)]|list_if }}
 
   {{ patch("local-docker-compose-prod-services")|indent(2) }}

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -85,9 +85,9 @@ services:
       SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-      - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-      - ../apps/openedx/config/:/openedx/config/:ro
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+      - ../apps/openedx/config:/openedx/config:ro
       - ../../data/lms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:
@@ -109,9 +109,9 @@ services:
       SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-      - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-      - ../apps/openedx/config/:/openedx/config/:ro
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+      - ../apps/openedx/config:/openedx/config:ro
       - ../../data/cms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:
@@ -136,9 +136,9 @@ services:
     command: celery worker --app=lms.celery --loglevel=info --hostname=edx.lms.core.default.%%h --maxtasksperchild=100 --exclude-queues=edx.cms.core.default
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-      - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-      - ../apps/openedx/config/:/openedx/config/:ro
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+      - ../apps/openedx/config:/openedx/config:ro
       - ../../data/lms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:
@@ -155,9 +155,9 @@ services:
     command: celery worker --app=cms.celery --loglevel=info --hostname=edx.cms.core.default.%%h --maxtasksperchild 100 --exclude-queues=edx.lms.core.default
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/:ro
-      - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/:ro
-      - ../apps/openedx/config/:/openedx/config/:ro
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+      - ../apps/openedx/config:/openedx/config:ro
       - ../../data/cms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:


### PR DESCRIPTION
Remove trailing slashes in volume paths for docker-compose v2 compatibility.

@overhangio/tutor-developers this is ready for review.