### PR TITLE
Include the forum job only if RUN_FORUM is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: Breaking changes between versions are indicated by "💥".
 - [Feature] Add [tutor-richie](https://github.com/overhangio/tutor-richie) to the plugins that are bundled with the tutor binary.
 - [Improvement] Make `tutor plugins list` print plugins sorted by name.
 - [Improvement] Ignore Python plugins which cannot be loaded.
+- [Bugfix] When configured with `RUN_FORUM: false`, omit forum-related [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) from the manifests that `tutor k8s` generates. (#525)
 
 ## v12.1.6 (2021-11-02)
 

--- a/tutor/templates/k8s/jobs.yml
+++ b/tutor/templates/k8s/jobs.yml
@@ -77,6 +77,7 @@ spec:
       containers:
       - name: mysql
         image: {{ DOCKER_IMAGE_MYSQL }}
+{% if RUN_FORUM %}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -102,5 +103,6 @@ spec:
             value: "{{ MONGODB_PORT }}"
           - name: MONGODB_DATABASE
             value: "{{ FORUM_MONGODB_DATABASE }}"
+{% endif %}
 
 {{ patch("k8s-jobs") }}


### PR DESCRIPTION
When running `tutor k8s` we can disable the forum deployment and service by setting `RUN_FORUM` to `false`, but the corresponding job is added to `jobs.yml` unconditionally.

Add a conditional to `tutor/templates/k8s/jobs.yml` so that the forum job definition is only included when `RUN_FORUM` is `true`.

Fixes #525.