### PR TITLE
Improvement: `settheme` now works with preview domain and `NGINX_HTTP_PORT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: Breaking changes between versions are indicated by "💥".
 - [Feature] Add [tutor-richie](https://github.com/overhangio/tutor-richie) to the plugins that are bundled with the tutor binary.
 - [Improvement] Make `tutor plugins list` print plugins sorted by name.
 - [Improvement] Ignore Python plugins which cannot be loaded.
+- [Improvement] `settheme` now works with preview domain and `NGINX_HTTP_PORT`.
 
 ## v12.1.6 (2021-11-02)
 

--- a/tutor/jobs.py
+++ b/tutor/jobs.py
@@ -144,7 +144,11 @@ site.themes.create(theme_dir_name='{theme_name}')
 def get_all_openedx_domains(config: Config) -> List[str]:
     return [
         get_typed(config, "LMS_HOST", str),
+        get_typed(config, "LMS_HOST", str) + ":" + get_typed(config, "NGINX_HTTP_PORT", str),
         get_typed(config, "LMS_HOST", str) + ":8000",
         get_typed(config, "CMS_HOST", str),
+        get_typed(config, "CMS_HOST", str) + ":" + get_typed(config, "NGINX_HTTP_PORT", str),
         get_typed(config, "CMS_HOST", str) + ":8001",
+        get_typed(config, "PREVIEW_LMS_HOST", str),
+        get_typed(config, "PREVIEW_LMS_HOST", str) + ":" + get_typed(config, "NGINX_HTTP_PORT", str),
     ]


### PR DESCRIPTION
ref: https://discuss.overhang.io/t/settheme-not-applied-to-preview-site/2144