### PR TITLE
Improvement: `settheme` now works with preview domain and `NGINX_HTTP_PORT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 - [Bugfix] Remove trailing slashes in docker-compose files for [compatibility with docker-compose v2 in WSL](https://github.com/docker/compose/issues/8558).
+- [Improvement] `settheme` now works with preview domain.
 
 ## v12.1.7 (2021-11-18)
 

--- a/tutor/jobs.py
+++ b/tutor/jobs.py
@@ -147,4 +147,6 @@ def get_all_openedx_domains(config: Config) -> List[str]:
         get_typed(config, "LMS_HOST", str) + ":8000",
         get_typed(config, "CMS_HOST", str),
         get_typed(config, "CMS_HOST", str) + ":8001",
+        get_typed(config, "PREVIEW_LMS_HOST", str),
+        get_typed(config, "PREVIEW_LMS_HOST", str) + ":8000",
     ]


### PR DESCRIPTION
https://discuss.overhang.io/t/settheme-not-applied-to-preview-site/2144