### PR TITLE
fix: Disable rolling upgrades for Caddy Kubernetes deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note: Breaking changes between versions are indicated by "💥".
 - [Improvement] Make `tutor plugins list` print plugins sorted by name.
 - [Improvement] Ignore Python plugins which cannot be loaded.
 - [Bugfix] When configured with `RUN_FORUM: false`, omit forum-related [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) from the manifests that `tutor k8s` generates. (#525)
+- [Bugfix] Disable rolling upgrades for the Caddy Kubernetes deployment (which is a [single-instance stateful application](https://kubernetes.io/docs/tasks/run-application/run-single-instance-stateful-application/), and thus must be replaced on upgrade).
 
 ## v12.1.6 (2021-11-02)
 

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: caddy
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Caddy (as used by Tutor) is a single-instance stateful application, in that it uses a PersistentVolume that can only ever be mounted to one Pod. As such, it is unsuitable for rolling upgrades. In the course of an upgrade, we first need to terminate the existing Pod, then bring up its replacement (just like the other applications configured with PersistentVolumeClaims, like MySQL and MongoDB).

Streamline the `caddy` deployment with all others that use PVCs, and set its `strategy` to the `Recreate` type.

Reference: https://kubernetes.io/docs/tasks/run-application/run-single-instance-stateful-application/