### PR TITLE
fix: insecure http authentication in LMS

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Improvement] Get rid of many Django deprecation warnings that were printed in stdout for every LMS/CMS command.
 - [Bugfix] Fix authentication to LMS when HTTPS is disabled.
 - [Bugfix] Make it possible for plugins to implement the "caddyfile" patch without relying on the "port" local variable.
 - 💥[Improvement] Move the Open edX forum to a [dedicated plugin](https://github.com/overhangio/tutor-forum/) (#450).

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Bugfix] Fix authentication to LMS when HTTPS is disabled.
 - [Bugfix] Make it possible for plugins to implement the "caddyfile" patch without relying on the "port" local variable.
 - 💥[Improvement] Move the Open edX forum to a [dedicated plugin](https://github.com/overhangio/tutor-forum/) (#450).
 - [Bugfix] Fix frontend failure during login to the LMS.

--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -15,12 +15,12 @@ ALLOWED_HOSTS = [
 # Chrome to support samesite=none cookies.
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
-DCS_SESSION_COOKIE_SAMESITE = "None"
+SESSION_COOKIE_SAMESITE = "None"
 {% else %}
 # When we cannot provide secure session/csrf cookies, we must disable samesite=none
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
-DCS_SESSION_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_SAMESITE = "Lax"
 {% endif %}
 
 # CMS authentication

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -97,8 +97,11 @@ LOGGING["handlers"]["tracking"] = {
 }
 LOGGING["loggers"]["tracking"]["handlers"] = ["console", "local", "tracking"]
 # Silence some loggers (note: we must attempt to get rid of these when upgrading from one release to the next)
+
 import warnings
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="newrelic.console")
+from django.utils.deprecation import RemovedInDjango40Warning, RemovedInDjango41Warning
+warnings.filterwarnings("ignore", category=RemovedInDjango40Warning)
+warnings.filterwarnings("ignore", category=RemovedInDjango41Warning)
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="lms.djangoapps.course_wiki.plugins.markdownedx.wiki_plugin")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="wiki.plugins.links.wiki_plugin")
 

--- a/tutor/templates/apps/openedx/settings/partials/common_cms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_cms.py
@@ -7,6 +7,7 @@ STUDIO_NAME = u"{{ PLATFORM_NAME }} - Studio"
 # Authentication
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = "{{ CMS_OAUTH2_SECRET }}"
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://lms:8000"
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False  # scheme is correctly included in redirect_uri
 
 MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 100
 


### PR DESCRIPTION
When HTTPS was not enabled, it was not possible to login to the LMS in some browsers, such as Brave.

- The sessionid cookie was being set with SameSite=None.
- That's because we were setting the DCS_SESSION_COOKIE_SAMESITE but not the
  SESSION_COOKIE_SAMESITE setting.
- The DCS_* settings are ignored since edx-platform no longer makes use of
  django-cookies-samesite.

Close https://github.com/openedx/build-test-release-wg/issues/110
