### PR TITLE
Multiple improvements to the Caddy load balancer in Kubernetes

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Security] On Kubernetes, convert all NodePort services to ClusterIP to guarantee network isolation from outside the cluster.
 - 💥[Improvement] Drop Python 3.5 compatibility.
 - [Bugfix] Fix docker-compose project name in development on nightly branch.
 - 💥[Bugfix] No longer track the Tutor version number in resource labels (and label selectors, which breaks the update of Deployment resources), but instead do so in resource annotations.

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,13 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Feature] Better support of Caddy as a load balancer in Kubernetes:
+  - Make it possible to start/stop a selection of resources with ``tutor k8s start/stop [names...]``.
+  - Make it easy to deploy an independent LoadBalancer by converting the caddy service to a ClusterIP when ``ENABLE_WEB_PROXY=false``.
+  - Add a ``app.kubernetes.io/component: loadbalancer`` label to the LoadBalancer service.
+  - Add ``app.kubernetes.io/name`` labels to all services.
+  - Preserve the LoadBalancer service in ``tutor k8s stop`` commands.
+  - Wait for the caddy deployment to be ready before running initialisation jobs.
 - [Security] On Kubernetes, convert all NodePort services to ClusterIP to guarantee network isolation from outside the cluster.
 - 💥[Improvement] Drop Python 3.5 compatibility.
 - [Bugfix] Fix docker-compose project name in development on nightly branch.

--- a/docs/k8s.rst
+++ b/docs/k8s.rst
@@ -27,10 +27,22 @@ The Kubernetes cluster should have at least 4Gb of RAM on each node. When runnin
 .. image:: img/virtualbox-minikube-system.png
     :alt: Virtualbox memory settings for Minikube
 
-Ingress controller and SSL/TLS certificates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Load Balancer and SSL/TLS certificates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of Tutor v11, it is no longer required to setup an Ingress controller to access your platform. Instead Caddy exposes a LoadBalancer service and SSL/TLS certificates are transparently generated at runtime.
+By default, Tutor deploys a `LoadBalancer <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`__ service that exposes the Caddy deployment to the outside world. As in the local installation, this service is responsible for transparently generating SSL/TLS certificates at runtime. You will need to point your DNS records to this LoadBalancer object before the platform can work correctly. Thus, you should first start the Caddy load balancer, with::
+
+    tutor k8s start caddy
+
+Get the external IP of this services::
+
+    kubectl --namespace openedx get services/caddy
+
+Use this external IP to configure your DNS records. Once the DNS records are configured, you should verify that the Caddy container has properly generated the SSL/TLS certificates by checking the container logs::
+
+    tutor k8s logs -f caddy
+
+If, for some reason, you would like to deploy your own load balancer, you should set ``ENABLE_WEB_PROXY=false`` just like in the :ref:`local installation <web_proxy>`. Then, point your load balancer at the "caddy" service, which will be a `ClusterIP <https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types>`__.
 
 S3-like object storage with `MinIO <https://www.minio.io/>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tutor/templates/k8s/services.yml
+++ b/tutor/templates/k8s/services.yml
@@ -21,7 +21,7 @@ kind: Service
 metadata:
   name: cms
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8000
       protocol: TCP
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   name: lms
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8000
       protocol: TCP
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: elasticsearch
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9200
       protocol: TCP
@@ -63,7 +63,7 @@ kind: Service
 metadata:
   name: mongodb
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 27017
       protocol: TCP
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: mysql
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 3306
       protocol: TCP
@@ -91,7 +91,7 @@ kind: Service
 metadata:
   name: redis
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: {{ REDIS_PORT }}
       protocol: TCP
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: smtp
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8025
       protocol: TCP

--- a/tutor/templates/k8s/services.yml
+++ b/tutor/templates/k8s/services.yml
@@ -4,13 +4,33 @@ apiVersion: v1
 kind: Service
 metadata:
   name: caddy
+  labels:
+    app.kubernetes.io/name: caddy
+    app.kubernetes.io/component: loadbalancer
 spec:
   type: LoadBalancer
   ports:
     - port: 80
       name: http
+    {%- if ENABLE_HTTPS %}
     - port: 443
       name: https
+    {%- endif %}
+  selector:
+    app.kubernetes.io/name: caddy
+{% else %}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy
+  labels:
+    app.kubernetes.io/name: caddy
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ CADDY_HTTP_PORT }}
+      name: http
   selector:
     app.kubernetes.io/name: caddy
 {% endif %}
@@ -20,6 +40,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cms
+  labels:
+    app.kubernetes.io/name: cms
 spec:
   type: ClusterIP
   ports:
@@ -34,6 +56,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: lms
+  labels:
+    app.kubernetes.io/name: lms
 spec:
   type: ClusterIP
   ports:
@@ -48,6 +72,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch
+  labels:
+    app.kubernetes.io/name: elasticsearch
 spec:
   type: ClusterIP
   ports:
@@ -62,6 +88,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb
 spec:
   type: ClusterIP
   ports:
@@ -76,6 +104,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mysql
+  labels:
+    app.kubernetes.io/name: mysql
 spec:
   type: ClusterIP
   ports:
@@ -90,6 +120,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
+  labels:
+    app.kubernetes.io/name: redis
 spec:
   type: ClusterIP
   ports:
@@ -104,6 +136,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: smtp
+  labels:
+    app.kubernetes.io/name: smtp
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
See the changelog for a detailed review of changes.

Close #532, except for this item:

>  Somehow, find a way to run in non-production mode on a local cluster. If not, we should not be asking the user if they want to run in non-production mode during tutor save -i.

I think that we should stop asking the user whether they want to run in production when they run `tutor k8s quickstart`, but I'd like to merge #537 before we make this change. I'll open another PR later.

cc @fghaas who started the conversation around these issues.