### PR TITLE
chore: drop python 3.5 compatibility

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- 💥[Improvement] Drop Python 3.5 compatibility.
 - [Bugfix] Fix docker-compose project name in development on nightly branch.
 - 💥[Bugfix] No longer track the Tutor version number in resource labels (and label selectors, which breaks the update of Deployment resources), but instead do so in resource annotations.
 - [Bugfix] Make it possible for plugins to implement the "caddyfile" patch without relying on the "port" local variable.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=load_requirements(),
     entry_points={"console_scripts": ["tutor=tutor.commands.cli:main"]},
     classifiers=[
@@ -61,7 +61,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.5 has reached end of life in September 3.5. Anyway, Tutor was not
compatible because some dev dependencies, such as astroid 2.8.3, are no longer
available in 3.5.

This means that we can now start using many python 3.6 niceties, such as
f-strings \o/