### PR TITLE
Fix arm64 image build - open-release/lilac.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+## Unreleased
+
+- [Bugfix] Fix building of the `openedx` image on ARM64 due to missing `libgeos-dev`
+
 ## v12.2.0 (2021-12-08)
 
 - [Bugfix] Fix incorrect "from" address in course bulk emails (see [pull request](https://github.com/edx/edx-platform/pull/29001)).

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -74,7 +74,7 @@ FROM python as python-requirements
 ENV PATH /openedx/venv/bin:${PATH}
 ENV VIRTUAL_ENV /openedx/venv/
 
-RUN apt update && apt install -y software-properties-common libmysqlclient-dev libxmlsec1-dev
+RUN apt update && apt install -y software-properties-common libmysqlclient-dev libxmlsec1-dev libgeos-dev
 
 # Note that this means that we need to reinstall all requirements whenever there is a
 # change in edx-platform, which sucks. But there is no obvious alternative, as we need


### PR DESCRIPTION
When I tried building the `openedx` image on an ARM64 Mac, this line of the `Dockerfile` failed:

https://github.com/overhangio/tutor/blob/19157d94bca8a4998271082045448a919bcd4761/tutor/templates/build/openedx/Dockerfile#L81-L82

[The error message was that `libgeos` could not be found while installing `shapely`.](https://stackoverflow.com/questions/19742406/could-not-find-library-geos-c-or-load-any-of-its-variants)

I am not sure why this would differ between arm64 and amd64 builds, but in any case this PR fixes the issue.

With this fix, `tutor images build openedx` works and is sufficient to build the LMS image for the `arm64/v8` architecture without any other changes.