### PR TITLE
Bugfix: A migration on nightly/master Open edX now requires MongoDB

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Bugfix] Start MongoDB when running migrations, because a new data migration fails if MongoDB is not running
 - [Feature] Better support of Caddy as a load balancer in Kubernetes:
   - Make it possible to start/stop a selection of resources with ``tutor k8s start/stop [names...]``.
   - Make it easy to deploy an independent LoadBalancer by converting the caddy service to a ClusterIP when ``ENABLE_WEB_PROXY=false``.

--- a/tutor/templates/hooks/lms/init
+++ b/tutor/templates/hooks/lms/init
@@ -1,4 +1,5 @@
 dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
+dockerize -wait tcp://{{ MONGODB_HOST }}:{{ MONGODB_PORT }} -timeout 20s
 
 echo "Loading settings $DJANGO_SETTINGS_MODULE"
 

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -14,7 +14,7 @@ services:
         - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
         - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
         - ../apps/openedx/config:/openedx/config:ro
-      depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
+      depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB)]|list_if }}
 
     cms-job:
       image: {{ DOCKER_IMAGE_OPENEDX }}
@@ -25,6 +25,6 @@ services:
         - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
         - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
         - ../apps/openedx/config:/openedx/config:ro
-      depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
+      depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB)]|list_if }}
 
     {{ patch("local-docker-compose-jobs-services")|indent(4) }}


### PR DESCRIPTION
In the latest master version of Open edX (post-Maple), some course data has moved from MongoDB to MySQL. There is [a data migration which automatically moves this data over](https://github.com/edx/edx-platform/blob/master/common/djangoapps/split_modulestore_django/migrations/0002_data_migration.py), but it currently causes Tutor nightly `tutor local init` to fail when running migrations, because MongoDB is not running.

Without this fix, `tutor local init` fails on Tutor nightly.