### PR TITLE
Tutorial: how to run Tutor on ARM-based systems

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -24,5 +24,6 @@ System administration
    tutorials/datamigration
    tutorials/multiplatforms
    tutorials/oldreleases
+   tutorials/arm64
 
 Other tutorials can be found in the official Tutor forums, `in the "Tutorials" category <https://discuss.overhang.io/c/tutor/tutorials/13>`__.

--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -1,6 +1,6 @@
 .. _arm64:
 
-Running Tutor on ARM based Systems
+Running Tutor on ARM-based systems
 ==================================
 
 Tutor can be used on ARM64 systems, although support for that platform is currently experimental.
@@ -12,7 +12,7 @@ There are currently no official ARM64 images provided for Tutor, but Tutor makes
 Building the images
 -------------------
 
-Start by :ref:`installing <install>` Tutor and its depdencies (e.g. Docker) onto your system.
+Start by :ref:`installing <install>` Tutor and its dependencies (e.g. Docker) onto your system.
 
 .. note:: For Open edX developers, if you want to use the :ref:`nightly <nightly>` version of Tutor to "run master", install Tutor using git and check out the ``nightly`` branch of Tutor at this point. See the :ref:`nightly documentation <nightly>` for details.
 
@@ -28,9 +28,6 @@ Then, build the Open edX image::
 
 If you want to use Tutor as an Open edX development environment, you should also build the development images::
 
-    # If you are using a regular Tutor release:
-    tutor images build openedx-dev
-    # Or if you are using Tutor nightly:
     tutor dev dc build lms
 
 Change the database server

--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -1,0 +1,67 @@
+.. _arm64:
+
+Running Tutor on ARM based Systems
+==================================
+
+Tutor can be used on ARM64 systems, although support for that platform is currently experimental.
+
+There are generally two ways to run Tutor on am ARM system - using qemu to run x86_64 images using emulation or running native ARM images. Since emulation can be quite slow, this Tutorial will focus on using native images where possible.
+
+There are currently no official ARM64 images provided for Tutor, but Tutor makes it easy to build them yourself.
+
+Building the images
+-------------------
+
+Start by :ref:`installing <install>` Tutor and its depdencies (e.g. Docker) onto your system.
+
+.. note:: For Open edX developers, if you want to use the :ref:`nightly <nightly>` version of Tutor to "run master", install Tutor using git and check out the ``nightly`` branch of Tutor at this point. See the :ref:`nightly documentation <nightly>` for details.
+
+Next, configure Tutor::
+
+    tutor config save --interactive
+
+Go through the configuration process, answering each question.
+
+Then, build the Open edX image::
+
+    tutor images build openedx
+
+If you want to use Tutor as an Open edX development environment, you should also build the development images::
+
+    # If you are using a regular Tutor release:
+    tutor images build openedx-dev
+    # Or if you are using Tutor nightly:
+    tutor dev dc build lms
+
+Change the database server
+--------------------------
+
+The version of MySQL that Open edX uses by default does not support the ARM architecture. Our current recommendation is to use MariaDB instead, which should be largely compatible.
+
+.. warning::
+    Note that using MariaDB is experimental and incompatibilites may exist, so this should only be used for local development - not for production instances.
+
+Configure Tutor to use MariaDB::
+
+    tutor config save --set DOCKER_IMAGE_MYSQL=mariadb:10.4
+
+Finish setup and start Tutor
+----------------------------
+
+From this point on, use Tutor as normal.
+
+For example, to apply migrations and start Open edX::
+
+    tutor local init
+    tutor local start
+
+Or for a development environment::
+
+    tutor local init
+    tutor local stop
+    tutor dev start
+
+Using with tutor-mfe
+--------------------
+
+You may wish to use `tutor-mfe <https://github.com/overhangio/tutor-mfe>`_ to run the Open edX microfrontends. If so, be aware that there is a known issue with ``tutor-mfe`` on ARM systems. See `this GitHub issue <https://github.com/overhangio/tutor-mfe/issues/31>`_ for details and known workarounds.


### PR DESCRIPTION
Per the discussion on https://github.com/overhangio/tutor/issues/510 and https://github.com/overhangio/tutor/pull/543, here is a tutorial for the docs that explains how to run Tutor on ARM-based systems like M1 MacBooks.

I wasn't sure exactly where to put it, so let me know if it should be moved somewhere else.

Screenshot:
<img width="1101" alt="Screen Shot 2021-12-15 at 12 21 50 PM" src="https://user-images.githubusercontent.com/945577/146259440-571a7f96-12ad-4331-a232-4b87293d4d1d.png">

