### PR TITLE
fix: CSRF verification failed in development mode

### DIFF
--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -10,19 +10,6 @@ ALLOWED_HOSTS = [
     "lms",
 ]
 
-{% if ENABLE_HTTPS %}
-# Properly set the "secure" attribute on session/csrf cookies. This is required in
-# Chrome to support samesite=none cookies.
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
-SESSION_COOKIE_SAMESITE = "None"
-{% else %}
-# When we cannot provide secure session/csrf cookies, we must disable samesite=none
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
-SESSION_COOKIE_SAMESITE = "Lax"
-{% endif %}
-
 # CMS authentication
 IDA_LOGOUT_URI_LIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}/complete/logout")
 

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -46,4 +46,17 @@ for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_
 
 {{ patch("openedx-lms-common-settings") }}
 
+{% if ENABLE_HTTPS %}
+# Properly set the "secure" attribute on session/csrf cookies. This is required in
+# Chrome to support samesite=none cookies.
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SAMESITE = "None"
+{% else %}
+# When we cannot provide secure session/csrf cookies, we must disable samesite=none
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SAMESITE = "Lax"
+{% endif %}
+
 ######## End of common LMS settings


### PR DESCRIPTION
This issue was introduced in https://github.com/overhangio/tutor/releases/tag/v10.2.0
The code changes here https://github.com/overhangio/tutor/commit/9a6439b08ca67322cc4732efb3750e9d25be512d

We are trying to use openedx dev to debug and develop a feature. 
The LMS domain in development mode looks like this:
 {LMS_HOST}:8000/login?next=%2F

However, a user could not log in into LMS due to issue 403 Forbidden
<img width="1456" alt="Screen Shot 2021-12-24 at 16 50 54" src="https://user-images.githubusercontent.com/75977044/147342621-ae2668bb-da2e-4d9f-9efe-c0318cd26038.png">

