### PR TITLE
chore: set CMS_CFG instead of STUDIO_CFG

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Improvement] Point CMS at its config file using ``CMS_CFG`` environment variable instead of deprecated ``STUDIO_CFG``.
 - [Bugfix] Start MongoDB when running migrations, because a new data migration fails if MongoDB is not running
 - [Feature] Better support of Caddy as a load balancer in Kubernetes:
   - Make it possible to start/stop a selection of resources with ``tutor k8s start/stop [names...]``.

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -143,7 +143,7 @@ RUN pip install -r requirements/edx/local.in
 RUN mkdir -p /openedx/config ./lms/envs/tutor ./cms/envs/tutor
 COPY --chown=app:app revisions.yml /openedx/config/
 ENV LMS_CFG /openedx/config/lms.env.json
-ENV STUDIO_CFG /openedx/config/cms.env.json
+ENV CMS_CFG /openedx/config/cms.env.json
 ENV REVISION_CFG /openedx/config/revisions.yml
 COPY --chown=app:app settings/lms/*.py ./lms/envs/tutor/
 COPY --chown=app:app settings/cms/*.py ./cms/envs/tutor/


### PR DESCRIPTION
## Description 

In the LMS/CMS Dockerfile, the env var STUDIO_CFG is set
in order to point CMS at its configuration json/yaml file.

Since https://github.com/edx/edx-platform/pull/29534
(which introduced 0013-cms-vs-studio.rst), the STUDIO_CFG
variable has been deprecated in favor of CMS_CFG.
This change updates the Dockerfile to reflect the new
preferred environment variable.

The only noticeable impact of this change is that it
will remove a depreation warning from Django startup
for tutor uses running off of Open edX master.

## Considerations

~This will **not work** with Maple, since Maple was cut before the CMS_CFG environment variable was introduced. This shouldn't be merged until no further Maple-supporting point releases are planned to be cut from Tutor master.~

Will be merged to `nightly` branch so that this ^ isn't an issue.