### PR TITLE
draft: feat: move plugin CLIs under dev/local/k8s; let plugins run jobs

### DIFF
--- a/tests/commands/test_context.py
+++ b/tests/commands/test_context.py
@@ -1,16 +1,15 @@
 import os
 import unittest
 
-from tests.helpers import TestContext, TestJobRunner, temporary_root
+from tests.helpers import TestJobContext, TestJobRunner, temporary_root
 from tutor import config as tutor_config
 
 
-class TestContextTests(unittest.TestCase):
-    def test_create_testcontext(self) -> None:
+class TestJobContextTests(unittest.TestCase):
+    def test_create_testjobcontext(self) -> None:
         with temporary_root() as root:
-            context = TestContext(root)
-            config = tutor_config.load_full(root)
-            runner = context.job_runner(config)
+            context = TestJobContext(root, {})
+            runner = context.job_runner()
             self.assertTrue(os.path.exists(context.root))
             self.assertFalse(
                 os.path.exists(os.path.join(context.root, tutor_config.CONFIG_FILENAME))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-from tutor.commands.context import BaseJobContext
+from tutor.commands.context import BaseJobContext, Context
 from tutor.jobs import BaseJobRunner
 from tutor.types import Config
 
@@ -36,10 +36,16 @@ def temporary_root() -> "tempfile.TemporaryDirectory[str]":
     return tempfile.TemporaryDirectory(prefix="tutor-test-root-")
 
 
-class TestContext(BaseJobContext):
+class TestContext(Context):
+    """
+    Barebones click test context.
+    """
+
+
+class TestJobContext(TestContext, BaseJobContext):
     """
     Click context that will use only test job runners.
     """
 
-    def job_runner(self, config: Config) -> TestJobRunner:
-        return TestJobRunner(self.root, config)
+    def job_runner(self) -> TestJobRunner:
+        return TestJobRunner(self.root, self.config)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3,7 +3,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from tests.helpers import TestContext, temporary_root
+from tests.helpers import TestJobContext, temporary_root
 from tutor import config as tutor_config
 from tutor import jobs
 
@@ -12,9 +12,9 @@ class JobsTests(unittest.TestCase):
     @patch("sys.stdout", new_callable=StringIO)
     def test_initialise(self, mock_stdout: StringIO) -> None:
         with temporary_root() as root:
-            context = TestContext(root)
             config = tutor_config.load_full(root)
-            runner = context.job_runner(config)
+            context = TestJobContext(root, config)
+            runner = context.job_runner()
             jobs.initialise(runner)
 
             output = mock_stdout.getvalue().strip()
@@ -44,9 +44,9 @@ class JobsTests(unittest.TestCase):
     @patch("sys.stdout", new_callable=StringIO)
     def test_import_demo_course(self, mock_stdout: StringIO) -> None:
         with temporary_root() as root:
-            context = TestContext(root)
             config = tutor_config.load_full(root)
-            runner = context.job_runner(config)
+            context = TestJobContext(root, config)
+            runner = context.job_runner()
             jobs.import_demo_course(runner)
 
             output = mock_stdout.getvalue()
@@ -64,9 +64,10 @@ class JobsTests(unittest.TestCase):
     @patch("sys.stdout", new_callable=StringIO)
     def test_set_theme(self, mock_stdout: StringIO) -> None:
         with temporary_root() as root:
-            context = TestContext(root)
             config = tutor_config.load_full(root)
-            runner = context.job_runner(config)
+            context = TestJobContext(root, config)
+            config = tutor_config.load_full(root)
+            runner = context.job_runner()
             jobs.set_theme("sample_theme", ["domain1", "domain2"], runner)
 
             output = mock_stdout.getvalue()

--- a/tutor/commands/context.py
+++ b/tutor/commands/context.py
@@ -1,19 +1,37 @@
 from ..jobs import BaseJobRunner
 from ..types import Config
+from ..exceptions import TutorError
 
 
 class Context:
     """
     Context object that is passed to all subcommands.
 
-    The project `root` is passed to all subcommands of `tutor`; that's because
-    it is defined as an argument of the top-level command. For instance:
+    The project `root` and its loaded `config` are passed to all subcommands of `tutor`;
+    that's because it is defined as an argument of the top-level command. For instance:
 
         $ tutor --root=... local run ...
     """
 
     def __init__(self, root: str) -> None:
         self.root = root
+
+    def job_runner(self) -> BaseJobRunner:
+        """
+        We cannot run jobs in this context. Raise an error.
+        """
+        raise TutorError(
+            "Jobs may not be run under the root context. "
+            + "Please specify dev, local, or k8s context.\n"
+            + "\n"
+            + "For example, if you just ran:\n"
+            + "    tutor <command>\n"
+            + "\n"
+            + "then you should instead run one of:\n"
+            + "  tutor dev   <command>\n"
+            + "  tutor local <command>\n"
+            + "  tutor k8s   <command>"
+        )
 
 
 class BaseJobContext(Context):
@@ -23,8 +41,25 @@ class BaseJobContext(Context):
     For instance `dev`, `local` and `k8s` define custom runners to run jobs.
     """
 
-    def job_runner(self, config: Config) -> BaseJobRunner:
+    def __init__(self, root: str, config: Config) -> None:
+        super().__init__(root)
+        self._config = config
+
+    @property
+    def config(self) -> Config:
+        """
+        Return this context's configuration dictionary.
+
+        Mutations to the dictionary will not affect the context's underlying config.
+        """
+        return self._config.copy()
+
+    def job_runner(self) -> BaseJobRunner:
         """
         Return a runner capable of running docker-compose/kubectl commands.
+
+        All concrete subclasses of BaseJobContext should define this method,
+        so we raise a `NotImplementedError` here instead of falling back to the
+        `TutorError` that Context.job_runner raises.
         """
         raise NotImplementedError

--- a/tutor/commands/images.py
+++ b/tutor/commands/images.py
@@ -66,7 +66,7 @@ def build(
     target: str,
     docker_args: List[str],
 ) -> None:
-    config = tutor_config.load(context.root)
+    config = tutor_config.load_full(context.root)
     command_args = []
     if no_cache:
         command_args.append("--no-cache")

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -2,12 +2,13 @@ from typing import Optional
 
 import click
 
-from tutor import config as tutor_config
 from tutor import env as tutor_env
 from tutor import exceptions, fmt, utils
+from tutor import config as tutor_config
 from tutor.commands import compose
 from tutor.commands.config import save as config_save_command
 from tutor.commands.upgrade.local import upgrade_from
+from tutor.commands.plugins import add_plugin_commands
 from tutor.types import Config, get_typed
 
 
@@ -31,14 +32,14 @@ class LocalJobRunner(compose.ComposeJobRunner):
 
 # pylint: disable=too-few-public-methods
 class LocalContext(compose.BaseComposeContext):
-    def job_runner(self, config: Config) -> LocalJobRunner:
-        return LocalJobRunner(self.root, config)
+    def job_runner(self) -> LocalJobRunner:
+        return LocalJobRunner(self.root, self.config)
 
 
 @click.group(help="Run Open edX locally with docker-compose")
 @click.pass_context
 def local(context: click.Context) -> None:
-    context.obj = LocalContext(context.obj.root)
+    context.obj = LocalContext(context.obj.root, tutor_config.load(context.obj.root))
 
 
 @click.command(help="Configure and run Open edX from scratch")
@@ -112,7 +113,6 @@ Press enter when you are ready to continue"""
     click.echo(fmt.title("Database creation and migrations"))
     context.invoke(compose.init)
 
-    config = tutor_config.load(context.obj.root)
     fmt.echo_info(
         """The Open edX platform is now running in detached mode
 Your Open edX platform is ready and can be accessed at the following urls:
@@ -120,9 +120,9 @@ Your Open edX platform is ready and can be accessed at the following urls:
     {http}://{lms_host}
     {http}://{cms_host}
     """.format(
-            http="https" if config["ENABLE_HTTPS"] else "http",
-            lms_host=config["LMS_HOST"],
-            cms_host=config["CMS_HOST"],
+            http="https" if context.obj.config["ENABLE_HTTPS"] else "http",
+            lms_host=context.obj.config["LMS_HOST"],
+            cms_host=context.obj.config["CMS_HOST"],
         )
     )
 
@@ -154,4 +154,5 @@ def upgrade(context: click.Context, from_release: Optional[str]) -> None:
 
 local.add_command(quickstart)
 local.add_command(upgrade)
+add_plugin_commands(local)
 compose.add_commands(local)

--- a/tutor/commands/upgrade/k8s.py
+++ b/tutor/commands/upgrade/k8s.py
@@ -1,14 +1,13 @@
-from tutor import config as tutor_config
 from tutor import fmt
 from tutor.commands import k8s
 from tutor.commands.context import Context
+from tutor import config as tutor_config
 from tutor.types import Config
 from . import common as common_upgrade
 
 
 def upgrade_from(context: Context, from_release: str) -> None:
     config = tutor_config.load(context.root)
-
     running_release = from_release
     if running_release == "ironwood":
         upgrade_from_ironwood(config)


### PR DESCRIPTION
## Description

This is a potentially-overzealous yet backwards-compatible change to the Plugin API and Tutor Plugin CLI. Check out the commit message for the full description.

### Why?

In the tutor-coursegraph plugin I'm developing, I want to be able to [run a job against a service container from the plugin's custom CLI](https://github.com/kdmccormick/tutor-coursegraph/blob/6c327652c58b96a7ead075f91969ee5ebd167033/tutorcoursegraph/plugin.py#L64). As far as I could tell, there was no way to do that without this change.

If there's a way to do what I'm trying to achieve without this tutor PR, do enlighten me!

Related tutor-coursegraph issue: https://github.com/kdmccormick/tutor-coursegraph/issues/5

### Status

I'm not trying to get this reviewed and merged imminently; I'd like to go over the implementation with @regisb first.

Among other things, this PR still needs a couple unit tests and some documentation updates.

## Other information

Part of https://github.com/openedx/platform-roadmap/issues/11

## Testing instructions

Test instructions TBD.

I have manually tested the `dev` version of this but haven't tested out `local` or `k8s`.