### PR TITLE
fix `tutor local importdemocourse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix `tutor local importdemocourse` fails when platform is not up.
+
 ## v13.1.0 (2022-01-08)
 
 - [Improvement] Provide much more comprehensive instructions when upgrading.

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -25,6 +25,6 @@ services:
         - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
         - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
         - ../apps/openedx/config:/openedx/config:ro
-      depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
+      depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB), ("elasticsearch", RUN_ELASTICSEARCH), ("redis", RUN_REDIS)]|list_if }}
 
     {{ patch("local-docker-compose-jobs-services")|indent(4) }}


### PR DESCRIPTION
Currently running `tutor local importdemocourse` would fail when the platform is not up. I'm a bit curious why we need redis though, as I'm not sure what role it plays.