### PR TITLE
fix: broken bulk emails because of LazyStaticAbsoluteUrl (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix "LazyStaticAbsoluteUrl is not JSON serializable" error when sending bulk emails.
 - [Bugfix] Fix `tutor local importdemocourse` fails when platform is not up.
 
 ## v13.1.0 (2022-01-08)

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -19,25 +19,7 @@ COURSE_ABOUT_VISIBILITY_PERMISSION = "see_about_page"
 OAUTH_ENFORCE_SECURE = False
 
 # Email settings
-class LazyStaticAbsoluteUrl:
-    """
-    Evaluates a static asset path lazily at runtime
-    """
-    def __init__(self, path):
-        self.path = path
-
-    def __str__(self):
-        from django.conf import settings
-        from django.contrib.staticfiles.storage import staticfiles_storage
-        return settings.LMS_ROOT_URL + staticfiles_storage.url(self.path)
-
-    def to_json(self):
-        # This method is required for json serialization by edx-ace, notably for
-        # serialization of the registration email. See
-        # edx_ace.serialization.MessageEncoder.
-        return str(self)
-# We need a lazily-computed logo url to capture the url of the theme-specific logo.
-DEFAULT_EMAIL_LOGO_URL = LazyStaticAbsoluteUrl("images/logo.png")
+DEFAULT_EMAIL_LOGO_URL = LMS_ROOT_URL + "/theming/asset/images/logo.png"
 
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:


### PR DESCRIPTION
The LazyStaticAbsoluteUrl object was breaking bulk emails again with the
following stacktrace:

    2022-01-11 13:50:10,591 ERROR 12 [celery.app.trace] [user None] [ip None] trace.py:255 - Task lms.djangoapps.instructor_task.tasks.send_bulk_course_email[26b93357-018a-408f-b3f7-b69722447c5b] raised unexpected: EncodeError(TypeError('Object of type LazyStaticAbsoluteUrl is not JSON serializable'))
    Traceback (most recent call last):
      File "/openedx/venv/lib/python3.8/site-packages/kombu/serialization.py", line 50, in _reraise_errors
	yield
      File "/openedx/venv/lib/python3.8/site-packages/kombu/serialization.py", line 221, in dumps
	payload = encoder(data)
      File "/openedx/venv/lib/python3.8/site-packages/kombu/utils/json.py", line 69, in dumps
	return _dumps(s, cls=cls or _default_encoder,
      File "/openedx/venv/lib/python3.8/site-packages/simplejson/__init__.py", line 398, in dumps
	return cls(
      File "/openedx/venv/lib/python3.8/site-packages/simplejson/encoder.py", line 296, in encode
	chunks = self.iterencode(o, _one_shot=True)
      File "/openedx/venv/lib/python3.8/site-packages/simplejson/encoder.py", line 378, in iterencode
	return _iterencode(o, 0)
      File "/openedx/venv/lib/python3.8/site-packages/kombu/utils/json.py", line 59, in default
	return super(JSONEncoder, self).default(o)
      File "/openedx/venv/lib/python3.8/site-packages/simplejson/encoder.py", line 272, in default
	raise TypeError('Object of type %s is not JSON serializable' %
    TypeError: Object of type LazyStaticAbsoluteUrl is not JSON serializable

The point of that lazy object was to link to the lms logo even when a custom
theme was enabled. Luckily, we no longer need this lazy evaluation because we
now have theme-agnostic urls that point to static asset (see
https://github.com/openedx/edx-platform/pull/29461).

See:
https://discuss.overhang.io/t/error-while-sending-bulk-emails-lazystaticabsoluteurl-is-not-json-serializable/2176/