### PR TITLE
fix: display themed favicon across all apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Display properly themed favicon.ico image in LMS, Studio and microfrontends.
 - [Bugfix] Fix "LazyStaticAbsoluteUrl is not JSON serializable" error when sending bulk emails.
 - [Bugfix] Fix `tutor local importdemocourse` fails when platform is not up.
 

--- a/tutor/templates/apps/caddy/Caddyfile
+++ b/tutor/templates/apps/caddy/Caddyfile
@@ -27,9 +27,9 @@
 
 {{ LMS_HOST }}{$default_site_port}, {{ PREVIEW_LMS_HOST }}{$default_site_port} {
     @favicon_matcher {
-        path_regexp ^(.*)/favicon.ico$
+        path_regexp ^/favicon.ico$
     }
-    rewrite @favicon_matcher /static/images/favicon.ico
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
 
     # Limit profile image upload size
     request_body /api/profile_images/*/*/upload {
@@ -46,9 +46,9 @@
 
 {{ CMS_HOST }}{$default_site_port} {
     @favicon_matcher {
-        path_regexp ^(.*)/favicon.ico$
+        path_regexp ^/favicon.ico$
     }
-    rewrite @favicon_matcher /static/images/favicon.ico
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
 
     request_body {
         max_size 250MB


### PR DESCRIPTION
Previously, we were redirecting all /*favicon.ico requests to the default
favicon. This meant that the favicon might not necessarily be correctly themed,
most notably in MFEs. Here, we resolve this issue by redirecting to the
theme-agnostic theming/asset/* url. Also, we restrict the overly generic regexp
for favicon url matching. We verified that we did not miss any url by running
the following command on the demo server:

    tutor local logs caddy | grep --only-matching "host.*favicon.ico" | sort | uniq