### PR TITLE
fix: lms authenticaton in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix authentication in development due to missing SameSite policy on session ID cookie.
 - [Bugfix] Display properly themed favicon.ico image in LMS, Studio and microfrontends.
 - [Bugfix] Fix "LazyStaticAbsoluteUrl is not JSON serializable" error when sending bulk emails.
 - [Bugfix] Fix `tutor local importdemocourse` fails when platform is not up.

--- a/tutor/templates/apps/openedx/settings/lms/development.py
+++ b/tutor/templates/apps/openedx/settings/lms/development.py
@@ -7,8 +7,6 @@ from lms.envs.devstack import *
 # Setup correct webpack configuration file for development
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
 
-SESSION_COOKIE_DOMAIN = ".{{ LMS_HOST|common_domain(CMS_HOST) }}"
-
 LMS_BASE = "{{ LMS_HOST}}:8000"
 LMS_ROOT_URL = "http://{}".format(LMS_BASE)
 LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
@@ -16,6 +14,12 @@ SITE_NAME = LMS_BASE
 CMS_BASE = "{{ CMS_HOST}}:8001"
 CMS_ROOT_URL = "http://{}".format(CMS_BASE)
 LOGIN_REDIRECT_WHITELIST.append(CMS_BASE)
+
+# Session cookie
+SESSION_COOKIE_DOMAIN = "{{ LMS_HOST }}"
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SAMESITE = "Lax"
 
 # CMS authentication
 IDA_LOGOUT_URI_LIST.append("http://{{ CMS_HOST }}:8001/complete/logout")


### PR DESCRIPTION
In development, it was no longer possible to authenticate to the lms. Ater
signing in, the session ID could not be dropped, and thus the user was not
signed in, although no error was logged -- just a warning in the browser
console.
This problem was caused by the fact that the SameSite policy was set to "None"
in development.