### PR TITLE
fix: `k8s start caddy` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix `k8s start caddy` command.
+
 ## v13.1.2 (2022-01-30)
 
 - [Bugfix] Fix auto-renewal of certificates revoked by Let's Encrypt (see [discussion](https://community.letsencrypt.org/t/questions-about-renewing-before-tls-alpn-01-revocations/170449/21)).

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -30,6 +30,9 @@ configMapGenerator:
 - name: caddy-config
   files:
   - apps/caddy/Caddyfile
+  options:
+    labels:
+        app.kubernetes.io/name: caddy
 - name: openedx-settings-lms
   files:{% for file in "apps/openedx/settings/lms"|walk_templates %}
   - {{ file }}{% endfor %}


### PR DESCRIPTION
Caddy was not properly starting because its associated configmap was not
starting.

Close #577.