### PR TITLE
chore: resolve "deprecated django-admin.py is deprecated" warning

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -155,7 +155,7 @@ COPY --chown=app:app settings/cms/*.py ./cms/envs/tutor/
 RUN mkdir /openedx/locale/user
 COPY --chown=app:app ./locale/ /openedx/locale/user/locale/
 RUN cd /openedx/locale/user && \
-    django-admin.py compilemessages -v1
+    django-admin compilemessages -v1
 
 # Compile i18n strings: in some cases, js locales are not properly compiled out of the box
 # and we need to do a pass ourselves. Also, we need to compile the djangojs.js files for


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0