### PR TITLE
No module named 'third_party_auth' issue solved

### DIFF
--- a/docs/plugins/examples.rst
+++ b/docs/plugins/examples.rst
@@ -53,7 +53,7 @@ Enable SAML authentication
 
       openedx-lms-common-settings: |
         # saml special settings
-        AUTHENTICATION_BACKENDS += ["third_party_auth.saml.SAMLAuthBackend", "django.contrib.auth.backends.ModelBackend"]
+        THIRD_PARTY_AUTH_BACKENDS = ["third_party_auth.saml.SAMLAuthBackend"]
 
       openedx-auth: |
         "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY": "yoursecretkey",


### PR DESCRIPTION
Here is the fix for https://github.com/overhangio/tutor/issues/601
I tested  `THIRD_PARTY_AUTH_BACKENDS = ["third_party_auth.saml.SAMLAuthBackend"]` and it's working. yay