### PR TITLE
fix: "unexpected keyword argument" during quickstart upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix `local/k8s quickstart` commands when upgrading from an older release (#595).
 - [Bugfix] Fix running the default exim-relay SMTP server on arm64 (#600).
 - [Feature] Add `tutor k8s apply` comand, which is a direct interface with `kubectl apply`.
 - [Feature] Add `openedx-dockerfile-minimal` patch, which you can use to install custom packages and run commands as root in the Docker image.

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -160,7 +160,7 @@ def quickstart(context: click.Context, non_interactive: bool) -> None:
         click.echo(fmt.title("Upgrading from an older release"))
         context.invoke(
             upgrade,
-            from_version=tutor_env.get_env_release(context.obj.root),
+            from_release=tutor_env.get_env_release(context.obj.root),
         )
 
     click.echo(fmt.title("Interactive platform configuration"))

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -79,7 +79,7 @@ Are you sure you want to continue?"""
             )
         context.invoke(
             upgrade,
-            from_version=run_upgrade_from_release,
+            from_release=run_upgrade_from_release,
             non_interactive=non_interactive,
         )
 


### PR DESCRIPTION
Close #595.