### PR TITLE
feat: patch for openedx-dockerfile-final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Feature] Add patch to allow overriding final openedx docker image CMD
 - [Fix] Ignore Python plugins that cannot be loaded. (by @regisb)
 - [Improvement] Faster and more reliable builds with `npm clean-install` instead of `npm install`. (by @regisb. Thanks @ghassanmas!)
 - [Fix] Fix 500 error during studio login. (by @regisb)

--- a/docs/reference/patches.rst
+++ b/docs/reference/patches.rst
@@ -266,6 +266,13 @@ Files: ``apps/openedx/settings/cms/development.py``, ``apps/openedx/settings/lms
 
 File: ``build/openedx/Dockerfile``
 
+.. patch:: openedx-dockerfile-final
+
+``openedx-dockerfile-final``
+============================
+
+File: ``build/openedx/Dockerfile``
+
 .. patch:: openedx-dockerfile-git-patches-default
 
 ``openedx-dockerfile-git-patches-default``

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -255,3 +255,6 @@ CMD uwsgi \
     --processes=${UWSGI_WORKERS:-2} \
     --buffer-size=8192 \
     --wsgi-file $SERVICE_VARIANT/wsgi.py
+
+{{ patch("openedx-dockerfile-final") }}
+


### PR DESCRIPTION
Building on the work done in https://github.com/overhangio/tutor/pull/427. This PR allows you to configure the uWSGI buffer size in `config.yml`

From the [uWSGI docs](https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html):

> If you start receiving “invalid request block size” in your logs, it could mean you need a bigger buffer. Increase it (up to 65535) with the buffer-size option.

One of our deployments uses SAML for authentication so the request headers and body for the authentication requests can get pretty verbose. We started receiving the "invalid request block size" error, so we bumped the buffer size to `32768`.


Does it make sense to bump the default from `8192` to `32768` (or something else)?