### PR TITLE
fix: lms-worker/cms-worker command update for Celery 5

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Bugfix] Update ``celery`` invocations for lms-worker and cms-worker to be compatible with Celery 5 CLI.
 - [Improvement] Point CMS at its config file using ``CMS_CFG`` environment variable instead of deprecated ``STUDIO_CFG``.
 - [Bugfix] Start MongoDB when running migrations, because a new data migration fails if MongoDB is not running
 - [Feature] Better support of Caddy as a load balancer in Kubernetes:

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -113,7 +113,7 @@ spec:
       containers:
         - name: cms-worker
           image: {{ DOCKER_IMAGE_OPENEDX }}
-          args: ["celery", "worker", "--app=cms.celery", "--loglevel=info", "--hostname=edx.cms.core.default.%%h", "--maxtasksperchild", "100", "--exclude-queues=edx.lms.core.default"]
+          args: ["celery", "--app=cms.celery", "worker", "--loglevel=info", "--hostname=edx.cms.core.default.%%h", "--max-tasks-per-child", "100", "--exclude-queues=edx.lms.core.default"]
           env:
           - name: SERVICE_VARIANT
             value: cms
@@ -206,7 +206,7 @@ spec:
       containers:
         - name: lms-worker
           image: {{ DOCKER_IMAGE_OPENEDX }}
-          args: ["celery", "worker", "--app=lms.celery", "--loglevel=info", "--hostname=edx.lms.core.default.%%h", "--maxtasksperchild=100", "--exclude-queues=edx.cms.core.default"]
+          args: ["celery", "--app=lms.celery", "worker", "--loglevel=info", "--hostname=edx.lms.core.default.%%h", "--max-tasks-per-child=100", "--exclude-queues=edx.cms.core.default"]
           env:
           - name: SERVICE_VARIANT
             value: lms

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     environment:
       SERVICE_VARIANT: lms
       SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
-    command: celery worker --app=lms.celery --loglevel=info --hostname=edx.lms.core.default.%%h --maxtasksperchild=100 --exclude-queues=edx.cms.core.default
+    command: celery --app=lms.celery worker --loglevel=info --hostname=edx.lms.core.default.%%h --max-tasks-per-child=100 --exclude-queues=edx.cms.core.default
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
@@ -188,7 +188,7 @@ services:
     environment:
       SERVICE_VARIANT: cms
       SETTINGS: ${TUTOR_EDX_PLATFORM_SETTINGS:-tutor.production}
-    command: celery worker --app=cms.celery --loglevel=info --hostname=edx.cms.core.default.%%h --maxtasksperchild 100 --exclude-queues=edx.lms.core.default
+    command: celery --app=cms.celery worker --loglevel=info --hostname=edx.cms.core.default.%%h --max-tasks-per-child 100 --exclude-queues=edx.lms.core.default
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro


### PR DESCRIPTION
## Description
```
Before edx-platform was upgraded to Celery 5, lms-worker and
cms-worker could be invoked using this syntax:

  celery worker --app=APP <args> --maxtasksperchild=N <args>

Since the recent Celery 5 upgrade (edx-platform commit 0588c92),
though, this fails with the messages:

  You are using `--app` as an option of the worker sub-command:
  celery worker --app celeryapp <...>
  The support for this usage was removed in Celery 5.0.
  Instead you should use `--app` as a global option:
  celery --app celeryapp worker <...>

and:

  Error: No such option: --maxtasksperchild
  (Possible options: --max-memory-per-child, --max-tasks-per-child)

So, this commit changes the lms-worker and cms-worker invocations to:

  celery --app=APP <args> --max-tasks-per-child=N <args>
```

## Testing

As of 2022-03-18, the official overhangio/openedx image hasn't yet been built with the Celery 5 upgrade. So, for Nightly users who *aren't* bind-mounting the most recent edx-platform master, Tutor should currently work fine with or without this PR (I did check that the code in this PR works fine under Celery 4).

Below, I test how Tutor Nightly behaves when a master-versioned edx-platform is bind-mounted and requirements are updated in a bind-mounted virtual environment:

On branch `overhangio:nightly`:
```
$ tutor dev start -d
...
$ tutor dev logs lms-worker
docker-compose -f /home/kyle/.local/share/tutor-nightly/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor-nightly/env/dev/docker-compose.yml -f /home/kyle/.local/share/tutor-nightly/env/dev/docker-compose.override.yml --project-name tutor_nightly_dev logs lms-worker
Attaching to tutor_nightly_dev_lms-worker_1
lms-worker_1                 | You are using `--app` as an option of the worker sub-command:
lms-worker_1                 | celery worker --app celeryapp <...>
lms-worker_1                 | 
lms-worker_1                 | The support for this usage was removed in Celery 5.0. Instead you should use `--app` as a global option:
lms-worker_1                 | celery --app celeryapp worker <...>
lms-worker_1                 | Usage: celery worker [OPTIONS]
lms-worker_1                 | Try 'celery worker --help' for help.
lms-worker_1                 | 
lms-worker_1                 | Error: No such option: --app
$ tutor dev importdemocourse
... will exit successfully, but demo course wont be imported ...
```
On branch `kdmccormick:kdmccormick/celery5`:
```
$ tutor dev start -d
...
$ tutor dev logs lms-worker
Attaching to tutor_nightly_dev_lms-worker_1
lms-worker_1                 | 2022-03-18 15:48:14,725 INFO 1 [celery.worker.consumer.connection] [user None] [ip None] connection.py:24 - Connected to redis://redis:6379/0
...
$ tutor dev importdemocourse
... should successfully import a demo course (check Studio in browser to be sure) ...
```

## References

upstream edx-platform PR that upgraded Celery: https://github.com/openedx/edx-platform/pull/29046 (merged on 2022-03-09)

Celery docs that mention breaking CLI changes in 5.0 release: https://docs.celeryq.dev/en/stable/history/whatsnew-5.0.html#new-command-line-interface