### PR TITLE
fix broken quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix "TypeError: upgrade() got an unexpected keyword argument 'non_interactive'" during `local upgrade`.
+
+
 ## v13.1.7 (2022-03-17)
 
 - [Bugfix] Fix dockerize on arm64 by switching to the [powerman/dockerize](https://github.com/powerman/dockerize) fork (#591).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix "evalsymlink failure" during `k8s quickstart` (#611).
 - [Bugfix] Fix "TypeError: upgrade() got an unexpected keyword argument 'non_interactive'" during `local upgrade`.
 
 

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -224,6 +224,7 @@ def start(context: Context, names: List[str]) -> None:
     except exceptions.TutorError:
         fmt.echo_info("Namespace does not exist: now creating it...")
         kubectl_apply(
+            context.root,
             "--wait",
             "--selector",
             "app.kubernetes.io/component=namespace",

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -80,7 +80,6 @@ Are you sure you want to continue?"""
         context.invoke(
             upgrade,
             from_release=run_upgrade_from_release,
-            non_interactive=non_interactive,
         )
 
     click.echo(fmt.title("Interactive platform configuration"))


### PR DESCRIPTION
- [Bugfix] Fix "evalsymlink failure" during `k8s quickstart` (#611).
- [Bugfix] Fix "TypeError: upgrade() got an unexpected keyword argument 'non_interactive'" during `local upgrade`.

See:
https://github.com/overhangio/tutor/issues/611#issuecomment-1076536420
https://discuss.overhang.io/t/upgrade-error-upgrade-got-an-unexpected-keyword-argument-non-interactive/2582