### PR TITLE
fix: nightly package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ ABOUT = load_about()
 
 setup(
     name="tutor",
-    version=ABOUT["__version__"],
+    version=ABOUT["__version__"].split("-")[0],  # drop "-nightly" suffix if present
     url="https://docs.tutor.overhang.io/",
     project_urls={
         "Documentation": "https://docs.tutor.overhang.io/",


### PR DESCRIPTION
The version of the nightly python package should not include the "-nightly"
suffix. That's because when we `pip install -e` tutor plugins, pip also
installs the latest tutor release, as part of the requirements. This overrides
the local (nightly) installation of tutor.

See: https://app.slack.com/client/T02SNA1T6/C02V3GHE3UP