### PR TITLE
feat: Make the platform repository and NPM registry configurable from config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] In addition to the Docker build arguments `EDX_PLATFORM_REPOSITORY` and `NPM_REGISTRY`, also support two corresponding and identically-named `config.yml` values serving the same purpose.
+
 ## v13.1.10 (2022-04-11)
 
 - [Feature] Upgrade all applications to open-release/maple.3.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,7 +79,11 @@ You may want to pull/push images from/to a custom docker registry. For instance,
 Open edX customisation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- ``OPENEDX_COMMON_VERSION`` (default: ``"open-release/maple.2"``)
+- ``EDX_PLATFORM_REPOSITORY`` (default: ``"https://github.com/openedx/edx-platform.git"``)
+
+This defines the git repository from which you install Open edX platform code. If you run an Open edX fork with custom patches, set this to your own git repository. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
+
+- ``OPENEDX_COMMON_VERSION`` (default: ``"open-release/maple.3"``)
 
 This defines the default version that will be pulled from all Open edX git repositories.
 
@@ -98,6 +102,11 @@ These two configuration parameters define which Redis database to use for Open e
 - ``OPENEDX_EXTRA_PIP_REQUIREMENTS`` (default: ``openedx-scorm-xblock<13.0.0,>=12.0.0``)
 
 This defines extra pip packages that are going to be installed for Open edX.
+
+- ``NPM_REGISTRY`` (default: ``"https://registry.npmjs.org/"``)
+
+This defines the registry from which you'll be pulling NPM packages when building Docker images. Like ``EDX_PLATFORM_REPOSITORY``, this can be overridden at build time with a ``--build-arg`` option.
+
 
 Vendor services
 ~~~~~~~~~~~~~~~
@@ -212,9 +221,9 @@ openedx Docker Image build arguments
 
 When building the "openedx" Docker image, it is possible to specify a few `arguments <https://docs.docker.com/engine/reference/builder/#arg>`__:
 
-- ``EDX_PLATFORM_REPOSITORY`` (default: ``"https://github.com/openedx/edx-platform.git"``)
+- ``EDX_PLATFORM_REPOSITORY`` (default: ``"{{ EDX_PLATFORM_REPOSITORY }}"``)
 - ``EDX_PLATFORM_VERSION`` (default: ``"{{ OPENEDX_COMMON_VERSION }}"``)
-- ``NPM_REGISTRY`` (default: ``"https://registry.npmjs.org/"``)
+- ``NPM_REGISTRY`` (default: ``"{{ NPM_REGISTRY }}"``)
 
 These arguments can be specified from the command line, `very much like Docker <https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg>`__. For instance::
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -32,7 +32,7 @@ RUN dockerize_url="https://github.com/powerman/dockerize/releases/download/$DOCK
 
 ###### Checkout edx-platform code
 FROM minimal as code
-ARG EDX_PLATFORM_REPOSITORY=https://github.com/openedx/edx-platform.git
+ARG EDX_PLATFORM_REPOSITORY={{ EDX_PLATFORM_REPOSITORY }}
 ARG EDX_PLATFORM_VERSION={{ OPENEDX_COMMON_VERSION }}
 RUN mkdir -p /openedx/edx-platform && \
     git clone $EDX_PLATFORM_REPOSITORY --branch $EDX_PLATFORM_VERSION --depth 1 /openedx/edx-platform
@@ -110,7 +110,7 @@ RUN pip install nodeenv==1.6.0
 RUN nodeenv /openedx/nodeenv --node=12.13.0 --prebuilt
 
 # Install nodejs requirements
-ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 COPY --from=code /openedx/edx-platform/package.json /openedx/edx-platform/package.json
 WORKDIR /openedx/edx-platform
 RUN npm install --verbose --registry=$NPM_REGISTRY

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -18,6 +18,7 @@ DOCKER_IMAGE_MYSQL: "docker.io/mysql:5.7.35"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_REDIS: "docker.io/redis:6.2.6"
 DOCKER_IMAGE_SMTP: "docker.io/devture/exim-relay:4.95-r0-2"
+EDX_PLATFORM_REPOSITORY: "https://github.com/openedx/edx-platform.git"
 ELASTICSEARCH_HOST: "elasticsearch"
 ELASTICSEARCH_PORT: 9200
 ELASTICSEARCH_SCHEME: "http"
@@ -51,6 +52,7 @@ OPENEDX_EXTRA_PIP_REQUIREMENTS:
 MYSQL_HOST: "mysql"
 MYSQL_PORT: 3306
 MYSQL_ROOT_USERNAME: "root"
+NPM_REGISTRY: "https://registry.npmjs.org/"
 PLATFORM_NAME: "My Open edX"
 PREVIEW_LMS_HOST: "preview.{{ LMS_HOST }}"
 REDIS_HOST: "redis"


### PR DESCRIPTION
Previously, the only way for Tutor users to use a fork of `edx-platform` or a custom NPM registry was to use build args during the image build.

This is suboptimal in the case of automatically building images from CI pipelines, which may want to auto-detect when an image needs to be rebuilt based on `config.yml` changes.

In addition, the `EDX_PLATFORM_VERSION` build argument can already be set via a corresponding `config.yml` parameter (`OPENEDX_COMMON_VERSION`), so it's reasonable to follow that precedent and also introduce `config.yml` parameters to correspond with the `EDX_PLATFORM_REPOSITORY` and `NPM_REGISTRY` build arguments.

Thus, introduce two new configuration parameters:

- `OPENEDX_PLATFORM_REPOSITORY`
- `OPENEDX_NPM_REGISTRY`

These parameters can now optionally be used instead of the aforementioned build args.