### PR TITLE
build: NIGHTLY ONLY: install nightly branches of official plugins

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Improvement] For Tutor Nightly (and only Nightly), official plugins are now installed from their nightly branches on GitHub instead of a version range on PyPI. This will allow Nightly users to install all official plugins by running ``pip install -e ".[full]"``.
 - [Bugfix] Remove edX references from bulk emails ([issue](https://github.com/openedx/build-test-release-wg/issues/100)).
 - [Bugfix] Update ``celery`` invocations for lms-worker and cms-worker to be compatible with Celery 5 CLI.
 - [Improvement] Point CMS at its config file using ``CMS_CFG`` environment variable instead of deprecated ``STUDIO_CFG``.

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,12 +1,13 @@
-# change version ranges when upgrading from maple
-tutor-android>=13.0.0,<14.0.0
-tutor-discovery>=13.0.0,<14.0.0
-tutor-ecommerce>=13.0.0,<14.0.0
-tutor-forum>=13.0.0,<14.0.0
-tutor-license>=13.0.0,<14.0.0
-tutor-mfe>=13.0.0,<14.0.0
-tutor-minio>=13.0.0,<14.0.0
-tutor-notes>=13.0.0,<14.0.0
-tutor-richie>=13.0.0,<14.0.0
-tutor-webui>=13.0.0,<14.0.0
-tutor-xqueue>=13.0.0,<14.0.0
+# For Tutor Nightly, we install plugins from their nightly branches instead of from PyPI
+# (except tutor-license, for which we just want the latest version from PyPI).
+tutor-android @ git+https://github.com/overhangio/tutor-android@nightly
+tutor-discovery @ git+https://github.com/overhangio/tutor-discovery@nightly
+tutor-ecommerce @ git+https://github.com/overhangio/tutor-ecommerce@nightly
+tutor-forum @ git+https://github.com/overhangio/tutor-forum@nightly
+tutor-license
+tutor-mfe @ git+https://github.com/overhangio/tutor-mfe@nightly
+tutor-minio @ git+https://github.com/overhangio/tutor-minio@nightly
+tutor-notes @ git+https://github.com/overhangio/tutor-notes@nightly
+tutor-richie @ git+https://github.com/overhangio/tutor-richie@nightly
+tutor-webui @ git+https://github.com/overhangio/tutor-webui@nightly
+tutor-xqueue @ git+https://github.com/overhangio/tutor-xqueue@nightly


### PR DESCRIPTION
## Description

This fixes https://github.com/overhangio/2u-tutor-adoption/issues/41. Before this PR, Tutor Nightly users needed to install all the official plugins by hand (unlike Tutor Stable users, who have the plugins bundled in for them). After this PR, simply running `pip install -e "./tutor[full]"` on the nightly branch will install Tutor Nightly as well as Nightly versions of all plugins

Documentation changes have been made in a separate PR, so that they can be merged to `master` and reflected on the official documentation site as soon as this is merged to `nightly`: https://github.com/overhangio/tutor/pull/631

## Testing

From Tutor's `nightly` branch:

    pip uninstall --yes tutor-discovery tutor-mfe  # Or any other plugins
    tutor plugins list # Should be missing tutor-discovery and tutor-mfe
    pip install -e ".[full]"
    tutor plugins list # Should now include tutor-discovery and tutor-mfe
    pip freeze | grep "tutor-"  # All official plugins should be git-installed (except for tutor-license)

## Notes

A couple questions for you @regisb . From the first commit's message:

> * Unlike other plugins, tutor-license is still installed from PyPI, but without any version constraint. This is because tutor-license    is a simple, closed-source plugin which activates Wizard edition for subscribers. It should be available in Nightly but doesn't    need to be installed from its own bleeding-edge branch.

This ^ is just my best guess on how tutor-license should be installed for Nightly. Let me know if I should do something differently.

>  * Unlike most nightly commits, this commit should NOT ever be
>    reflected on master. When it comes time to merge nightly into
>    master during the release of Nutmeg, this commit will need to
>    be manually reverted from master.


Do I have this right?