### PR TITLE
feat: introduce 'tutor dev quickstart' (also, some extra docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Feature] Add `tutor dev quickstart` command, which is similar to `tutor local quickstart`, except that it uses dev containers instead of local production ones and includes some other small differences for the convience of Open edX developers. This should remove some friction from the Open edX development setup process, which previously required that users provision using local producation containers (`tutor local quickstart`) but then stop them and switch to dev containers (`tutor local stop && tutor dev start -d`).
 - 💥[Improvement] Make it possible to run `tutor k8s exec <command with multiple arguments>` (#636). As a consequence, it is no longer possible to run quoted commands: `tutor k8s exec "<some command>"`. Instead, you should remove the quotes: `tutor k8s exec <some command>`.
 - 💥[Deprecation] Drop support for the `TUTOR_EDX_PLATFORM_SETTINGS` environment variable. It is now recommended to create a plugin instead.
 - 💥[Improvement] Complete overhaul of the plugin extension mechanism. Tutor now has a hook-based Python API: actions can be triggered at different points of the application life cycle and data can be modified thanks to custom filters. The v0 plugin API is still supported, for backward compatibility, but plugin developers are encouraged to migrate their plugins to the new API. See the new plugin tutorial for more information.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,9 +91,10 @@ To upgrade Open edX or benefit from the latest features and bug fixes, you shoul
 
     pip install --upgrade "tutor[full]"
 
-Then run the ``quickstart`` command again. Depending on your deployment target, run either::
+Then run the ``quickstart`` command again. Depending on your deployment target, run one of::
 
     tutor local quickstart # for local installations
+    tutor dev quickstart   # for local development installations
     tutor k8s quickstart   # for Kubernetes installation
 
 Upgrading with custom Docker images

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -36,8 +36,8 @@ To learn more about Tutor, watch this 7-minute lightning talk that was made at t
 
 .. youtube:: Oqc7c-3qFc4
 
-How does Tutor work, technically speaking?
-------------------------------------------
+How does Tutor simplify Open edX deployment?
+--------------------------------------------
 
 Tutor simplifies the deployment of Open edX by:
 
@@ -102,6 +102,34 @@ You can now take advantage of the Tutor-powered CLI (item #3) to bootstrap your 
     tutor local quickstart
 
 Under the hood, Tutor simply runs ``docker-compose`` and ``docker`` commands to launch your platform. These commands are printed in the standard output, such that you are free to replicate the same behaviour by simply copying/pasting the same commands.
+
+How do I navigate Tutor's command-line interface?
+-------------------------------------------------
+
+Tutor commands are structured in an easy-to-follow hierarchy. At the top level, there are command trees for image and configuration management::
+
+    tutor config ...
+    tutor images ...
+
+as well as command trees for each mode in which Tutor can run::
+
+    tutor local ...  # Commands for managing a local Open edX deployment.
+    tutor k8s ...    # Commands for managing a Kubernetes Open edX deployment.
+    tutor dev ...    # Commands for hacking on Open edX in development mode.
+
+Within each mode, Tutor has subcommands for managing that type of Open edX instance. Many of them are common between modes, such as ``quickstart``, ``start``, ``stop``, ``exec``, and ``logs``. For example::
+
+    tutor local logs  # View logs of a local deployment.
+    tutor k8s logs    # View logs of a Kubernetes-managed deployment.
+    tutor dev logs    # View logs of a development platform.
+
+Many commands can be further parameterized to specify their target and options, for example::
+
+  tutor local logs cms          # View logs of the CMS container in a local deployment.
+  tutor k8s logs mysql          # View logs of MySQL in Kubernetes-managed deployment.
+  tutor dev logs lms --tail 10  # View ten lines of logs of the LMS container in development mode.
+
+And that's it! You do not need to understand Tutor's entire command-line interface to get started. Using the ``--help`` option that's availble on every command, it is easy to learn as you go. For an in-depth guide, you can also explore the `CLI Reference <reference/index>`_.
 
 I'm ready, where do I start?
 ----------------------------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -129,7 +129,7 @@ Many commands can be further parameterized to specify their target and options, 
   tutor k8s logs mysql          # View logs of MySQL in Kubernetes-managed deployment.
   tutor dev logs lms --tail 10  # View ten lines of logs of the LMS container in development mode.
 
-And that's it! You do not need to understand Tutor's entire command-line interface to get started. Using the ``--help`` option that's availble on every command, it is easy to learn as you go. For an in-depth guide, you can also explore the `CLI Reference <reference/index>`_.
+And that's it! You do not need to understand Tutor's entire command-line interface to get started. Using the ``--help`` option that's availble on every command, it is easy to learn as you go. For an in-depth guide, you can also explore the `CLI Reference <reference/index.rst>`_.
 
 I'm ready, where do I start?
 ----------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,8 @@ class ConfigTests(unittest.TestCase):
         with temporary_root() as rootdir:
             with patch.object(click, "prompt", new=mock_prompt):
                 with patch.object(click, "confirm", new=mock_prompt):
-                    config = interactive.load_user_config(rootdir, interactive=True)
+                    config = tutor_config.load_minimal(rootdir)
+                    interactive.ask_questions(config)
 
         self.assertIn("MYSQL_ROOT_PASSWORD", config)
         self.assertEqual(8, len(get_typed(config, "MYSQL_ROOT_PASSWORD", str)))

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -48,7 +48,9 @@ def save(
     unset_vars: List[str],
     env_only: bool,
 ) -> None:
-    config = interactive_config.load_user_config(context.root, interactive=interactive)
+    config = tutor_config.load_minimal(context.root)
+    if interactive:
+        interactive_config.ask_questions(config)
     if set_vars:
         for key, value in dict(set_vars).items():
             config[key] = env.render_unknown(config, value)

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -4,7 +4,9 @@ import click
 
 from .. import config as tutor_config
 from .. import env as tutor_env
-from .. import fmt
+from .. import exceptions, fmt
+from .. import interactive as interactive_config
+from .. import utils
 from ..types import Config, get_typed
 from . import compose
 
@@ -41,6 +43,58 @@ def dev(context: click.Context) -> None:
     context.obj = DevContext(context.obj.root)
 
 
+@click.command(help="Configure and run Open edX from scratch, for development")
+@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
+@click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
+@click.pass_context
+def quickstart(context: click.Context, non_interactive: bool, pullimages: bool) -> None:
+    try:
+        utils.check_macos_docker_memory()
+    except exceptions.TutorError as e:
+        fmt.echo_alert(
+            f"""Could not verify sufficient RAM allocation in Docker:
+    {e}
+Tutor may not work if Docker is configured with < 4 GB RAM. Please follow instructions from:
+    https://docs.tutor.overhang.io/install.html"""
+        )
+
+    click.echo(fmt.title("Interactive platform configuration"))
+    config = tutor_config.load_minimal(context.obj.root)
+    if not non_interactive:
+        interactive_config.ask_questions(config, run_for_prod=False)
+    tutor_config.save_config_file(context.obj.root, config)
+    config = tutor_config.load_full(context.obj.root)
+    tutor_env.save(context.obj.root, config)
+
+    click.echo(fmt.title("Stopping any existing platform"))
+    context.invoke(compose.stop)
+
+    if pullimages:
+        click.echo(fmt.title("Docker image updates"))
+        context.invoke(compose.dc_command, command="pull")
+
+    click.echo(fmt.title("Building Docker image for LMS and CMS development"))
+    context.invoke(compose.dc_command, command="build", args=["lms"])
+
+    click.echo(fmt.title("Starting the platform in detached mode"))
+    context.invoke(compose.start, detach=True)
+
+    click.echo(fmt.title("Database creation and migrations"))
+    context.invoke(compose.init)
+
+    fmt.echo_info(
+        """The Open edX platform is now running in detached mode
+Your Open edX platform is ready and can be accessed at the following urls:
+    {http}://{lms_host}:8000
+    {http}://{cms_host}:8001
+    """.format(
+            http="https" if config["ENABLE_HTTPS"] else "http",
+            lms_host=config["LMS_HOST"],
+            cms_host=config["CMS_HOST"],
+        )
+    )
+
+
 @click.command(
     help="Run a development server",
     context_settings={"ignore_unknown_options": True},
@@ -62,5 +116,6 @@ def runserver(context: click.Context, options: List[str], service: str) -> None:
     context.invoke(compose.run, args=args)
 
 
+dev.add_command(quickstart)
 dev.add_command(runserver)
 compose.add_commands(dev)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -6,6 +6,7 @@ import click
 
 from tutor import config as tutor_config
 from tutor import env as tutor_env
+from tutor import interactive as interactive_config
 from tutor import exceptions, fmt, jobs, serialize, utils
 from tutor.commands.config import save as config_save_command
 from tutor.commands.context import BaseJobContext
@@ -171,10 +172,12 @@ def quickstart(context: click.Context, non_interactive: bool) -> None:
         )
 
     click.echo(fmt.title("Interactive platform configuration"))
-    context.invoke(
-        config_save_command,
-        interactive=(not non_interactive),
-    )
+    config = tutor_config.load_minimal(context.obj.root)
+    if not non_interactive:
+        interactive_config.ask_questions(config, run_for_prod=True)
+    tutor_config.save_config_file(context.obj.root, config)
+    config = tutor_config.load_full(context.obj.root)
+    tutor_env.save(context.obj.root, config)
 
     if run_upgrade_from_release and not non_interactive:
         question = f"""Your platform is being upgraded from {run_upgrade_from_release.capitalize()}.

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -5,6 +5,7 @@ import click
 from tutor import config as tutor_config
 from tutor import env as tutor_env
 from tutor import exceptions, fmt, utils
+from tutor import interactive as interactive_config
 from tutor.commands import compose
 from tutor.commands.config import save as config_save_command
 from tutor.commands.upgrade.local import upgrade_from
@@ -83,7 +84,12 @@ Are you sure you want to continue?"""
         )
 
     click.echo(fmt.title("Interactive platform configuration"))
-    context.invoke(config_save_command, interactive=(not non_interactive))
+    config = tutor_config.load_minimal(context.obj.root)
+    if not non_interactive:
+        interactive_config.ask_questions(config)
+    tutor_config.save_config_file(context.obj.root, config)
+    config = tutor_config.load_full(context.obj.root)
+    tutor_env.save(context.obj.root, config)
 
     if run_upgrade_from_release and not non_interactive:
         question = f"""Your platform is being upgraded from {run_upgrade_from_release.capitalize()}.

--- a/tutor/interactive.py
+++ b/tutor/interactive.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -7,26 +7,26 @@ from . import env, exceptions, fmt
 from .types import Config, get_typed
 
 
-def load_user_config(root: str, interactive: bool = True) -> Config:
+def ask_questions(config: Config, run_for_prod: Optional[bool] = None) -> None:
     """
-    Load configuration and interactively ask questions to collect param values from the user.
+    Interactively ask questions to collect configuration values from the user.
+
+    Arguments:
+        config: Existing (or minimal) configuration. Modified in-place.
+        run_for_prod: Whether platform should be configured for production.
+            If None, then ask the user.
     """
-    config = tutor_config.load_minimal(root)
-    if interactive:
-        ask_questions(config)
-    return config
-
-
-def ask_questions(config: Config) -> None:
     defaults = tutor_config.get_defaults()
-    run_for_prod = config.get("LMS_HOST") != "local.overhang.io"
-    run_for_prod = click.confirm(
-        fmt.question(
-            "Are you configuring a production platform? Type 'n' if you are just testing Tutor on your local computer"
-        ),
-        prompt_suffix=" ",
-        default=run_for_prod,
-    )
+    if run_for_prod is None:
+        run_for_prod = config.get("LMS_HOST") != "local.overhang.io"
+        run_for_prod = click.confirm(
+            fmt.question(
+                "Are you configuring a production platform? "
+                "Type 'n' if you are just testing Tutor on your local computer"
+            ),
+            prompt_suffix=" ",
+            default=run_for_prod,
+        )
     if not run_for_prod:
         dev_values: Config = {
             "LMS_HOST": "local.overhang.io",


### PR DESCRIPTION
## Description

Fixes https://github.com/overhangio/2u-tutor-adoption/issues/58

There are three commits. The first two just add some supplementary doc updates, which I could remove from this changeset if they don't seem like a good idea. The third commit introduces `tutor dev quickstart` along with the most critical documentation updates.

## Implementation Notes

I wanted to tailor `tutor dev quickstart` to the development use case, so there are some differences between it and `tutor local quickstart`:
1. it starts dev containers instead of local ones (duh),
2. it builds the openedx-dev image, and
3. it assumes No for the the "Is this a production platform?" question,
4. it offers to import the demo course and create a supseruser.

Difference **1** is the only thing that _really_ needed to be changed, so if there are objections to **2-4** do let me know.

In order to implement differences **3-4** I needed some way of passing to `tutor config save` that fact that we're in a developer context. Instead of cluttering `tutor config save` with a new command-line option, I opted to expose an `is_dev()` method on the `Context` class, which is used to tell whether developer-mode assumptions should be made. Let me know if this seems like a bad idea.