### PR TITLE
docs: update Nightly docs to reference [full] installation 

### DIFF
--- a/docs/_release_description.md
+++ b/docs/_release_description.md
@@ -1,6 +1,6 @@
 Install this version from pip with::
 
-    pip install tutor[full]==TUTOR_VERSION
+    pip install "tutor[full]==TUTOR_VERSION"
 
 Or download the compiled binaries::
 

--- a/docs/download/pip.rst
+++ b/docs/download/pip.rst
@@ -1,3 +1,3 @@
 .. parsed-literal::
 
-    pip install tutor[full]
+    pip install "tutor[full]"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -89,7 +89,7 @@ Upgrading
 
 To upgrade Open edX or benefit from the latest features and bug fixes, you should simply upgrade Tutor. Start by upgrading the "tutor" package and its dependencies::
 
-    pip install --upgrade tutor[full]
+    pip install --upgrade "tutor[full]"
 
 Then run the ``quickstart`` command again. Depending on your deployment target, run either::
 

--- a/docs/tutorials/nightly.rst
+++ b/docs/tutorials/nightly.rst
@@ -11,16 +11,16 @@ Installing Tutor Nightly
 Running Tutor Nightly requires more than setting a few configuration variables: because there are so many Open edX settings, version numbers, etc. which may change between the latest release and the current master branch, Tutor Nightly is actually maintained as a separate branch of the Tutor repository. To install Tutor Nightly, you should install Tutor from the "nightly" branch of the source repository. To do so, run::
 
     git clone --branch=nightly https://github.com/overhangio/tutor.git
-    pip install -e ./tutor
+    pip install -e "./tutor[full]"
 
 As usual, it is strongly recommended to run the command above in a `Python virtual environment <https://docs.python.org/3/tutorial/venv.html>`__.
 
-All Tutor plugins that you wish to use should likewise be installed from the "nightly branch". For instance, the `MFE plugin <https://github.com/overhangio/tutor-mfe>`__::
+In addition to installing Tutor Nightly itself, this will install automatically the nightly versions of all official Tutor plugins (which are enumerated in `plugins.txt <https://github.com/overhangio/tutor/tree/nightly/requirements/plugins.txt>`_). Alternatively, if you wish to hack on an official plugin or install a custom plugin, you can clone that plugin's repository and install it. For instance::
 
-    git clone --branch=nightly https://github.com/overhangio/tutor-mfe.git
-    pip install -e ./tutor-mfe
+    git clone --branch=nightly https://github.com/myorganization/tutor-contrib-myplugin.git
+    pip install -e ./tutor-contrib-myplugin
 
-You can then run the usual ``tutor`` commands::
+Once Tutor Nightly is installed, you can run the usual ``tutor`` commands::
 
     tutor local quickstart
     tutor local stop


### PR DESCRIPTION
## Description

This PR is a companion to https://github.com/overhangio/tutor/pull/626. In that PR, we change Nightly's `[full]` installation to point to the `nightly` branches of official plugins on GitHub (instead of the stable version of plugins from PyPI). This allows Nightly users to make use of the plugins-included `[full]` installation. In this PR, we update the documentation to reflect the improvement.

Blocked by https://github.com/overhangio/tutor/pull/626
This PR is part of https://github.com/overhangio/2u-tutor-adoption/issues/41

### Screenshot of modified docs

![image](https://user-images.githubusercontent.com/3628148/162471895-0ead4852-c56d-4be1-8604-5cc11fc282b0.png)

## Testing

See **Testing** on https://github.com/overhangio/tutor/pull/626

## Notes

I included a ride-along docs improvement in a second commit: **docs: wrap tutor[full] in quotes for zsh compatibility**. Check out its commit message for details.