### PR TITLE
feat: add `tutor [dev|local|k8s] status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Feature] Add `tutor [dev|local|k8s] status` command, which provides basic information about the platform's status.
+
 ## v13.1.11 (2022-04-12)
 
 - [Security] Apply SAML security fix.

--- a/docs/k8s.rst
+++ b/docs/k8s.rst
@@ -64,6 +64,10 @@ On Minikube, the dashboard is already installed. To access the dashboard, run::
 
     minikube dashboard
 
+Lastly, Tutor itself provides a rudimentary listing of your cluster's nodes, workloads, and services::
+
+    tutor k8s status
+
 Technical details
 -----------------
 

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -98,6 +98,14 @@ Finally, tracking logs that store `user events <https://edx.readthedocs.io/proje
     $(tutor config printroot)/data/lms/logs/tracking.log
     $(tutor config printroot)/data/cms/logs/tracking.log
 
+Status
+~~~~~~
+
+You can view your platform's containers::
+
+    tutor local status
+
+Notice the **State** column in the output. It will tell you whether each container is starting, restarting, running (``Up``), cleanly stopped (``Exit 0``), or stopped on error (``Exit N``, where N ≠ 0).
 
 Common tasks
 ------------

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -263,6 +263,12 @@ def logs(context: click.Context, follow: bool, tail: bool, service: str) -> None
     context.invoke(dc_command, command="logs", args=args)
 
 
+@click.command(help="Print status information for containers")
+@click.pass_context
+def status(context: click.Context) -> None:
+    context.invoke(dc_command, command="ps")
+
+
 @click.command(
     short_help="Direct interface to docker-compose.",
     help=(
@@ -307,3 +313,4 @@ def add_commands(command_group: click.Group) -> None:
     command_group.add_command(bindmount_command)
     command_group.add_command(execute)
     command_group.add_command(logs)
+    command_group.add_command(status)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -484,6 +484,13 @@ def kubectl_apply(root: str, *args: str) -> None:
     utils.kubectl("apply", "--kustomize", tutor_env.pathjoin(root), *args)
 
 
+@click.command(help="Print status information for all k8s resources")
+@click.pass_obj
+def status(context: Context) -> int:
+    config = tutor_config.load(context.root)
+    return utils.kubectl("get", "all", *resource_namespace_selector(config))
+
+
 def kubectl_exec(
     config: Config, service: str, command: str, attach: bool = False
 ) -> int:
@@ -561,3 +568,4 @@ k8s.add_command(logs)
 k8s.add_command(wait)
 k8s.add_command(upgrade)
 k8s.add_command(apply_command)
+k8s.add_command(status)


### PR DESCRIPTION
## Description

Resolves https://github.com/overhangio/2u-tutor-adoption/issues/28

## Notes

My implementation translates:
```
tutor k8s status
```
into:
```
kubectl get nodes,deployments,replicasets,pods,services --namespace openedx
```
I think this leads to a nice dashboard-like output. But, I have never operated k8s in production myself, so if it would make sense to show fewer/different/more resource types (for example: maybe we should only show workloads, or only pods?), I am happy to incorporate that feedback.

## Testing & Example output

### dev

```
$ tutor dev status
docker-compose -f /home/kyle/.local/share/tutor/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor/env/dev/docker-compose.yml --project-name tutor_dev ps
Name   Command   State   Ports
------------------------------


$ tutor dev start
...
$ tutor dev status
docker-compose -f /home/kyle/.local/share/tutor/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor/env/dev/docker-compose.yml --project-name tutor_dev ps
             Name                           Command               State                Ports            
--------------------------------------------------------------------------------------------------------
tutor_dev_cms-permissions_1      setowner 1000 /openedx/dat ...   Exit 0                                
tutor_dev_cms-worker_1           docker-entrypoint.sh celer ...   Up       8000/tcp                     
tutor_dev_cms_1                  docker-entrypoint.sh ./man ...   Up       0.0.0.0:8001->8000/tcp,:::800
                                                                           1->8000/tcp                  
tutor_dev_elasticsearch-         setowner 1000 /usr/share/e ...   Exit 0                                
permissions_1                                                                                           
tutor_dev_elasticsearch_1        /tini -- /usr/local/bin/do ...   Up       9200/tcp, 9300/tcp           
tutor_dev_lms-permissions_1      setowner 1000 /openedx/dat ...   Exit 0                                
tutor_dev_lms-worker_1           docker-entrypoint.sh celer ...   Up       8000/tcp                     
tutor_dev_lms_1                  docker-entrypoint.sh ./man ...   Up       0.0.0.0:8000->8000/tcp,:::800
                                                                           0->8000/tcp                  
tutor_dev_mongodb-               setowner 999 /data/db            Exit 0                                
permissions_1                                                                                           
tutor_dev_mongodb_1              docker-entrypoint.sh mongo ...   Up       27017/tcp                    
tutor_dev_mysql-permissions_1    setowner 999 /var/lib/mysql      Exit 0                                
tutor_dev_mysql_1                docker-entrypoint.sh mysql ...   Up       3306/tcp, 33060/tcp          
tutor_dev_redis-permissions_1    setowner 1000 /openedx/red ...   Exit 0                                
tutor_dev_redis_1                docker-entrypoint.sh redis ...   Up       6379/tcp                     
tutor_dev_smtp_1                 /sbin/tini -- exim -bdf -q15m    Up       8025/tcp                     
tutor_dev_watchthemes_1          docker-entrypoint.sh opene ...   Up       8000/tcp 


$ tutor dev stop
...
$ tutor dev status
docker-compose -f /home/kyle/.local/share/tutor/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor/env/dev/docker-compose.yml --project-name tutor_dev ps
                Name                               Command                State     Ports
-----------------------------------------------------------------------------------------
tutor_dev_cms-permissions_1             setowner 1000 /openedx/dat ...   Exit 0          
tutor_dev_cms-worker_1                  docker-entrypoint.sh celer ...   Exit 0          
tutor_dev_cms_1                         docker-entrypoint.sh ./man ...   Exit 0          
tutor_dev_elasticsearch-permissions_1   setowner 1000 /usr/share/e ...   Exit 0          
tutor_dev_elasticsearch_1               /tini -- /usr/local/bin/do ...   Exit 143        
tutor_dev_lms-permissions_1             setowner 1000 /openedx/dat ...   Exit 0          
tutor_dev_lms-worker_1                  docker-entrypoint.sh celer ...   Exit 0          
tutor_dev_lms_1                         docker-entrypoint.sh ./man ...   Exit 0          
tutor_dev_mongodb-permissions_1         setowner 999 /data/db            Exit 0          
tutor_dev_mongodb_1                     docker-entrypoint.sh mongo ...   Exit 0          
tutor_dev_mysql-permissions_1           setowner 999 /var/lib/mysql      Exit 0          
tutor_dev_mysql_1                       docker-entrypoint.sh mysql ...   Exit 0          
tutor_dev_redis-permissions_1           setowner 1000 /openedx/red ...   Exit 0          
tutor_dev_redis_1                       docker-entrypoint.sh redis ...   Exit 0          
tutor_dev_smtp_1                        /sbin/tini -- exim -bdf -q15m    Exit 0          
tutor_dev_watchthemes_1                 docker-entrypoint.sh opene ...   Exit 137     
```

### k8s

```
$ tutor k8s status  # minikube is running in the background
kubectl get all --namespace openedx
NAME            STATUS   ROLES                  AGE   VERSION
node/minikube   Ready    control-plane,master   35d   v1.23.3

NAME            TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        AGE
service/caddy   LoadBalancer   10.111.24.176   10.111.24.176   80:30125/TCP   35d


$ tutor k8s start
...
$ tutor k8s status
kubectl get all --namespace openedx
NAME                                 READY   STATUS              RESTARTS   AGE
pod/caddy-88d6f8bd6-78jsh            1/1     Running             0          7s
pod/cms-db7975745-rjs2m              0/1     ContainerCreating   0          7s
pod/cms-worker-65866b4586-krns8      1/1     Running             0          7s
pod/discovery-59f8f48cb7-vv7f7       0/1     ContainerCreating   0          7s
pod/elasticsearch-748cb4f6df-vwxjf   0/1     Pending             0          7s
pod/lms-6bc9f9758c-tlrsz             0/1     Pending             0          6s
pod/lms-worker-f7869b457-nbfkd       0/1     Pending             0          6s
pod/mongodb-5554fd9d46-ldcdw         0/1     Pending             0          6s
pod/mysql-547d857cfc-ltkz8           0/1     Pending             0          6s
pod/redis-685948b964-h7xvp           0/1     Pending             0          6s
pod/smtp-6c9dc4b787-w4jjd            0/1     Pending             0          6s

NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)          AGE
service/caddy           LoadBalancer   10.111.24.176    10.111.24.176   80:30125/TCP     39d
service/cms             ClusterIP      10.98.124.234    <none>          8000/TCP         7s
service/discovery       NodePort       10.109.65.146    <none>          8000:32365/TCP   7s
service/elasticsearch   ClusterIP      10.103.95.165    <none>          9200/TCP         7s
service/lms             ClusterIP      10.98.119.137    <none>          8000/TCP         7s
service/mongodb         ClusterIP      10.96.248.144    <none>          27017/TCP        7s
service/mysql           ClusterIP      10.107.128.186   <none>          3306/TCP         7s
service/redis           ClusterIP      10.99.245.186    <none>          6379/TCP         7s
service/smtp            ClusterIP      10.108.141.242   <none>          8025/TCP         7s

NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/caddy           1/1     1            1           7s
deployment.apps/cms             0/1     1            0           7s
deployment.apps/cms-worker      1/1     1            1           7s
deployment.apps/discovery       0/1     1            0           7s
deployment.apps/elasticsearch   0/1     1            0           7s
deployment.apps/lms             0/1     1            0           7s
deployment.apps/lms-worker      0/1     1            0           6s
deployment.apps/mongodb         0/1     1            0           6s
deployment.apps/mysql           0/1     1            0           6s
deployment.apps/redis           0/1     1            0           6s
deployment.apps/smtp            0/1     1            0           6s

NAME                                       DESIRED   CURRENT   READY   AGE
replicaset.apps/caddy-88d6f8bd6            1         1         1       7s
replicaset.apps/cms-db7975745              1         1         0       7s
replicaset.apps/cms-worker-65866b4586      1         1         1       7s
replicaset.apps/discovery-59f8f48cb7       1         1         0       7s
replicaset.apps/elasticsearch-748cb4f6df   1         1         0       7s
replicaset.apps/lms-6bc9f9758c             1         1         0       6s
replicaset.apps/lms-worker-f7869b457       1         1         0       6s
replicaset.apps/mongodb-5554fd9d46         1         1         0       6s
replicaset.apps/mysql-547d857cfc           1         1         0       6s
replicaset.apps/redis-685948b964           1         1         0       6s
replicaset.apps/smtp-6c9dc4b787            1         1         0       6s


$ tutor k8s stop
...
$ tutor k8s status
kubectl get all --namespace openedx
NAME                             READY   STATUS        RESTARTS   AGE
pod/cms-db7975745-rjs2m          1/1     Terminating   0          3m21s
pod/discovery-59f8f48cb7-vv7f7   1/1     Terminating   0          3m21s
pod/lms-6bc9f9758c-tlrsz         1/1     Terminating   0          3m20s

NAME            TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        AGE
service/caddy   LoadBalancer   10.111.24.176   10.111.24.176   80:30125/TCP   39d
...

