### PR TITLE
fix: Correct EDX_PLATFORM_VERSION default for local edx-platform forks

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -87,6 +87,10 @@ This defines the git repository from which you install Open edX platform code. I
 
 This defines the default version that will be pulled from all Open edX git repositories.
 
+- ``EDX_PLATFORM_VERSION`` (default: the value of ``OPENEDX_COMMON_VERSION``)
+
+This defines the version that will be pulled from just the Open edX platform git repositories. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
+
 - ``OPENEDX_CMS_UWSGI_WORKERS`` (default: ``2``)
 - ``OPENEDX_LMS_UWSGI_WORKERS`` (default: ``2``)
 
@@ -222,7 +226,7 @@ openedx Docker Image build arguments
 When building the "openedx" Docker image, it is possible to specify a few `arguments <https://docs.docker.com/engine/reference/builder/#arg>`__:
 
 - ``EDX_PLATFORM_REPOSITORY`` (default: ``"{{ EDX_PLATFORM_REPOSITORY }}"``)
-- ``EDX_PLATFORM_VERSION`` (default: ``"{{ OPENEDX_COMMON_VERSION }}"``)
+- ``EDX_PLATFORM_VERSION`` (default: ``"{{ EDX_PLATFORM_VERSION }}"``, which if unset defaults to ``{{ OPENEDX_COMMON_VERSION }}``)
 - ``NPM_REGISTRY`` (default: ``"{{ NPM_REGISTRY }}"``)
 
 These arguments can be specified from the command line, `very much like Docker <https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg>`__. For instance::

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -33,7 +33,7 @@ RUN dockerize_url="https://github.com/powerman/dockerize/releases/download/$DOCK
 ###### Checkout edx-platform code
 FROM minimal as code
 ARG EDX_PLATFORM_REPOSITORY={{ EDX_PLATFORM_REPOSITORY }}
-ARG EDX_PLATFORM_VERSION={{ OPENEDX_COMMON_VERSION }}
+ARG EDX_PLATFORM_VERSION={{ EDX_PLATFORM_VERSION }}
 RUN mkdir -p /openedx/edx-platform && \
     git clone $EDX_PLATFORM_REPOSITORY --branch $EDX_PLATFORM_VERSION --depth 1 /openedx/edx-platform
 WORKDIR /openedx/edx-platform

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -19,6 +19,7 @@ DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{
 DOCKER_IMAGE_REDIS: "docker.io/redis:6.2.6"
 DOCKER_IMAGE_SMTP: "docker.io/devture/exim-relay:4.95-r0-2"
 EDX_PLATFORM_REPOSITORY: "https://github.com/openedx/edx-platform.git"
+EDX_PLATFORM_VERSION: "{{ OPENEDX_COMMON_VERSION }}"
 ELASTICSEARCH_HOST: "elasticsearch"
 ELASTICSEARCH_PORT: 9200
 ELASTICSEARCH_SCHEME: "http"


### PR DESCRIPTION
PR #619 set the `EDX_PLATFORM_VERSION` build arg's default to `OPENEDX_COMMON_VERSION`. While this works fine for setting a non-default branch to run edx code from (say, `master`), it may break if the user sets `OPENEDX_COMMON_VERSION` to a branch or tag name that does not exist upstream in repositories *other than* `EDX_PLATFORM_REPOSITORY`.

Thus, introduce a separate configuration parameter, `EDX_PLATFORM_VERSION`, to match the build arg of the same name. Set its default to `OPENEDX_COMMON_VERSION`.

This way, the user can deploy an arbitrarily-named fork of `edx-platform`, while retaining the default  `OPENEDX_COMMON_VERSION` (like, for example `open-release/maple.3`) for everything else.