### PR TITLE
feat: add `dev/local copyfrom` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Feature] Introduce `local/dev copyfrom` command to copy contents from a container.
 - [Bugfix] Fix a race condition that could prevent a newly provisioned LMS container from starting due to a `FileExistsError` when creating data folders.
 - [Deprecation] Mark `tutor dev runserver` as deprecated in favor of `tutor dev start`. Since `start` now supports bind-mounting and breakpoint debugging, `runserver` is redundant and will be removed in a future release.
 - [Improvement] Allow breakpoint debugging when attached to a service via `tutor dev start SERVICE`.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -139,10 +139,23 @@ So, when should you *not* be using the implicit form? That would be when Tutor d
 
 .. note:: Remember to setup your edx-platform repository for development! See :ref:`edx_platform_dev_env`.
 
+Copy files from containers to the local filesystem
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, you may want to modify some of the files inside a container for which you don't have a copy on the host. A typical example is when you want to troubleshoot a Python dependency that is installed inside the application virtual environment. In such cases, you want to first copy the contents of the virtual environment from the container to the local filesystem. To that end, Tutor provides the ``tutor dev copyfrom`` command. First, copy the contents of the container folder to the local filesystem::
+
+    tutor dev copyfrom lms /openedx/venv ~
+
+Then, bind-mount that folder back in the container with the ``--mount`` option (described :ref:`above <mount_option>`)::
+
+    tutor dev start --mount lms:~/venv:/openedx/venv lms
+
+You can then edit the files in ``~/venv`` on your local filesystem and see the changes live in your container.
+
 Bind-mount from the "volumes/" directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning:: Bind-mounting volumes with the ``bindmount`` command is no longer the default, recommended way of bind-mounting volumes from the host. Instead, see the :ref:`mount option <mount_option>`.
+.. warning:: Bind-mounting volumes with the ``bindmount`` command is no longer the default, recommended way of bind-mounting volumes from the host. Instead, see the :ref:`mount option <mount_option>` and the ``tutor dev/local copyfrom`` commands.
 
 Tutor makes it easy to create a bind-mount from an existing container. First, copy the contents of a container directory with the ``bindmount`` command. For instance, to copy the virtual environment of the "lms" container::
 
@@ -230,6 +243,7 @@ After running all these commands, your edx-platform repository will be ready for
     tutor dev start --mount=/path/to/edx-platform lms
 
 If LMS isn't running, this will start it in your terminal. If an LMS container is already running background, this command will stop it, recreate it, and attach your terminal to it. Later, to detach your terminal without stopping the container, just hit ``Ctrl+z``.
+
 
 XBlock and edx-platform plugin development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/commands/test_compose.py
+++ b/tests/commands/test_compose.py
@@ -1,6 +1,7 @@
 import unittest
 
 from click.exceptions import ClickException
+
 from tutor.commands import compose
 
 

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -1,4 +1,9 @@
+import os
+import tempfile
 import unittest
+from unittest.mock import patch
+
+from tests.helpers import temporary_root
 
 from .base import TestCommandMixin
 
@@ -18,3 +23,46 @@ class LocalTests(unittest.TestCase, TestCommandMixin):
         result = self.invoke(["local", "upgrade", "--help"])
         self.assertIsNone(result.exception)
         self.assertEqual(0, result.exit_code)
+
+    def test_copyfrom(self) -> None:
+        with temporary_root() as root:
+            with tempfile.TemporaryDirectory() as directory:
+                with patch("tutor.utils.docker_compose") as mock_docker_compose:
+                    self.invoke_in_root(root, ["config", "save"])
+
+                    # Copy to existing directory
+                    result = self.invoke_in_root(
+                        root, ["local", "copyfrom", "lms", "/openedx/venv", directory]
+                    )
+                    self.assertIsNone(result.exception)
+                    self.assertEqual(0, result.exit_code)
+                    self.assertIn(
+                        f"--volume={directory}:/tmp/mount",
+                        mock_docker_compose.call_args.args,
+                    )
+                    self.assertIn(
+                        "cp --recursive --preserve /openedx/venv /tmp/mount",
+                        mock_docker_compose.call_args.args,
+                    )
+
+                    # Copy to non-existing directory
+                    result = self.invoke_in_root(
+                        root,
+                        [
+                            "local",
+                            "copyfrom",
+                            "lms",
+                            "/openedx/venv",
+                            os.path.join(directory, "venv2"),
+                        ],
+                    )
+                    self.assertIsNone(result.exception)
+                    self.assertEqual(0, result.exit_code)
+                    self.assertIn(
+                        f"--volume={directory}:/tmp/mount",
+                        mock_docker_compose.call_args.args,
+                    )
+                    self.assertIn(
+                        "cp --recursive --preserve /openedx/venv /tmp/mount/venv2",
+                        mock_docker_compose.call_args.args,
+                    )

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -6,8 +6,9 @@ import click
 
 from tutor import config as tutor_config
 from tutor import env as tutor_env
+from tutor import exceptions, fmt
 from tutor import interactive as interactive_config
-from tutor import exceptions, fmt, jobs, serialize, utils
+from tutor import jobs, serialize, utils
 from tutor.commands.config import save as config_save_command
 from tutor.commands.context import BaseJobContext
 from tutor.commands.upgrade.k8s import upgrade_from

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -4,8 +4,9 @@ import click
 
 from tutor import config as tutor_config
 from tutor import env as tutor_env
-from tutor import exceptions, fmt, utils
+from tutor import exceptions, fmt
 from tutor import interactive as interactive_config
+from tutor import utils
 from tutor.commands import compose
 from tutor.commands.config import save as config_save_command
 from tutor.commands.upgrade.local import upgrade_from

--- a/tutor/commands/plugins.py
+++ b/tutor/commands/plugins.py
@@ -1,6 +1,6 @@
 import os
-import urllib.request
 import typing as t
+import urllib.request
 
 import click
 


### PR DESCRIPTION
`copyfrom` copies data from a container to the local filesystem. It's similar
to bindmount, but less clunky, and more intuitive. Also, it plays along great
with `--mount`. Eventually we'll just get rid of the `bindmount` command and
the `--volume` option.