### PR TITLE
feat: `local stop` on `dev start` (and vice versa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Improvement] Add the `COMPOSE_PROJECT_STARTED` action and run `dev stop` on `local start` (and vice versa).
 - [Feature] Introduce `local/dev copyfrom` command to copy contents from a container.
 - [Bugfix] Fix a race condition that could prevent a newly provisioned LMS container from starting due to a `FileExistsError` when creating data folders.
 - [Deprecation] Mark `tutor dev runserver` as deprecated in favor of `tutor dev start`. Since `start` now supports bind-mounting and breakpoint debugging, `runserver` is redundant and will be removed in a future release.

--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -52,7 +52,6 @@ From this point on, use Tutor as normal. For example, start Open edX and run mig
 
 Or for a development environment::
 
-    tutor local stop
     tutor dev start -d
     tutor dev init
 

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -24,6 +24,12 @@ class ComposeJobRunner(jobs.BaseComposeJobRunner):
         """
         Run docker-compose with the right yml files.
         """
+        if "start" in command or "up" in command or "restart" in command:
+            # Note that we don't trigger the action on "run". That's because we
+            # don't want to trigger the action for every initialization script.
+            hooks.Actions.COMPOSE_PROJECT_STARTED.do(
+                self.root, self.config, self.project_name
+            )
         self.__update_docker_compose_tmp()
         args = []
         for docker_compose_path in self.docker_compose_files:

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -25,6 +25,13 @@ class Actions:
             # Do stuff here
     """
 
+    #: Triggered whenever a "docker-compose start", "up" or "restart" command is executed.
+    #:
+    #: :parameter: str root: project root.
+    #: :parameter: dict[str, ...] config: project configuration.
+    #: :parameter: str name: docker-compose project name.
+    COMPOSE_PROJECT_STARTED = actions.get("compose:project:started")
+
     #: Called whenever the core project is ready to run. This action is called as soon
     #: as possible. This is the right time to discover plugins, for instance. In
     #: particular, we auto-discover the following plugins:


### PR DESCRIPTION
Running `local start` while a dev platform is still running is a common sourse
of mistakes. Here we introduce a new action to automatically stop local and dev
projects whenever a project with a different name is started.