### PR TITLE
fix: `--mount` should accept service names with hyphens

### DIFF
--- a/tests/commands/test_compose.py
+++ b/tests/commands/test_compose.py
@@ -26,5 +26,12 @@ class ComposeTests(unittest.TestCase):
             ],
             param("lms, cms:/path/to/edx-platform:/openedx/edx-platform"),
         )
+        self.assertEqual(
+            [
+                ("lms", "/path/to/edx-platform", "/openedx/edx-platform"),
+                ("lms-worker", "/path/to/edx-platform", "/openedx/edx-platform"),
+            ],
+            param("lms,lms-worker:/path/to/edx-platform:/openedx/edx-platform"),
+        )
         with self.assertRaises(ClickException):
             param("lms,:/path/to/edx-platform:/openedx/edx-platform")

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -102,7 +102,7 @@ class MountParam(click.ParamType):
     MountType = t.Tuple[str, str, str]
     # Note that this syntax does not allow us to include colon ':' characters in paths
     PARAM_REGEXP = (
-        r"(?P<services>[a-zA-Z0-9_, ]+):(?P<host_path>[^:]+):(?P<container_path>[^:]+)"
+        r"(?P<services>[a-zA-Z0-9-_, ]+):(?P<host_path>[^:]+):(?P<container_path>[^:]+)"
     )
 
     def convert(

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -115,6 +115,7 @@ def runserver(
     for option in options:
         if option.startswith("-v") or option.startswith("--volume"):
             depr_warning += " Bind-mounts can be specified using '-m/--mount'."
+            break
     fmt.echo_alert(depr_warning)
     config = tutor_config.load(context.obj.root)
     if service in ["lms", "cms"]:


### PR DESCRIPTION
I didn't include a changelog entry, as this fixes a feature that hasn't yet been released.

Also included, in a second commit: a drive by fix to the `runserver` deprecation warning.