### PR TITLE
Ensure edx-platform tests can run without fiddling with environment variables

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 Note: Breaking changes between versions are indicated by "💥".
 
+- [Improvement] edx-platform unit tests can now be run without needing to manually set environment variables.
 - [Improvement] For Tutor Nightly (and only Nightly), official plugins are now installed from their nightly branches on GitHub instead of a version range on PyPI. This will allow Nightly users to install all official plugins by running ``pip install -e ".[full]"``.
 - [Bugfix] Remove edX references from bulk emails ([issue](https://github.com/openedx/build-test-release-wg/issues/100)).
 - [Bugfix] Update ``celery`` invocations for lms-worker and cms-worker to be compatible with Celery 5 CLI.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -81,7 +81,7 @@ To collect assets, you can use the ``openedx-assets`` command that ships with Tu
     tutor dev run lms openedx-assets build --env=dev
 
 
-.. _specialized for developer usage: 
+.. _specialized for developer usage:
 
 Rebuilding the openedx-dev image
 --------------------------------
@@ -255,26 +255,30 @@ You should then run the development server as usual, with ``start``. Every chang
 Running edx-platform unit tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It's possible to run the full set of unit tests that ship with `edx-platform <https://github.com/openedx/edx-platform/>`__. To do so, run a shell in the LMS development container::
+It's possible to run the full set of unit tests that ship with `edx-platform <https://github.com/openedx/edx-platform/>`__. Some tests are intended to be run in an LMS context, some are intended for the CMS context, and some can be run in both. To run tests for the LMS, start a shell in the LMS container::
 
     tutor dev run lms bash
 
-Then, run unit tests with ``pytest`` commands::
+Then, simply `invoke pytest <https://docs.pytest.org/en/latest/how-to/usage.html>`_. For example::
 
-    # Run tests on common apps
-    unset DJANGO_SETTINGS_MODULE
-    unset SERVICE_VARIANT
-    export EDXAPP_TEST_MONGO_HOST=mongodb
-    pytest common
-    pytest openedx
+    pytest lms                                              # Run tests for the entire LMS source tree.
+    pytest lms/djangoapps/ccx                               # Run tests in a single LMS app.
+    pytest lms/djangoapps/ccx -k '_override or _structure'  # Run tests in a single LMS app with names matching substring(s).
+    pytest openedx common                                   # Run tests for both shared source trees.
+    pytest openedx/core/djangoapps/content/course_overviews # Run tests for a single shared app.
+    # ... etc.
 
-    # Run tests on LMS
-    export DJANGO_SETTINGS_MODULE=lms.envs.tutor.test
-    pytest lms
+To run CMS tests, start a shell in the CMS container::
 
-    # Run tests on CMS
-    export DJANGO_SETTINGS_MODULE=cms.envs.tutor.test
-    pytest cms
+    tutor dev run cms bash
+
+As before, simply invoke pytest. Tests under the cms/ source tree will automatically use CMS settings. For tests under the shared source trees, you will need to tell pytest to look in the cms/ directory for configuration by providing ``--rootdir`` option::
+
+    pytest cms                                                            # Run tests for the entire CMS source tree.
+    pytest cms/djangoapps/coursegraph                                     # Run tests in a single CMS app.
+    pytest --rootdir=cms openedx common                                   # Run tests for both shared source trees.
+    pytest --rootdir=cms openedx/core/djangoapps/content/course_overviews # Run tests for a single shared app.
+    # ... etc.
 
 .. note::
     Getting all edx-platform unit tests to pass on Tutor is currently a work-in-progress. Some unit tests are still failing. If you manage to fix some of these, please report your findings in the `Tutor forums <https://discuss.overhang.io>`__.

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     command: ./manage.py lms runserver 0.0.0.0:8000
     environment:
         DJANGO_SETTINGS_MODULE: lms.envs.tutor.development
+        EDXAPP_TEST_MONGO_HOST: mongodb
     ports:
         - "8000:8000"
     networks:
@@ -44,6 +45,7 @@ services:
     command: ./manage.py cms runserver 0.0.0.0:8000
     environment:
         DJANGO_SETTINGS_MODULE: lms.envs.tutor.development
+        EDXAPP_TEST_MONGO_HOST: mongodb
     ports:
         - "8001:8000"
 


### PR DESCRIPTION
## Description

See the commit message for details.
Blocked by https://github.com/openedx/edx-platform/pull/30298
Resolves https://github.com/overhangio/2u-tutor-adoption/issues/48

## Considerations 

This PR (and the linked edx-platform PR) would succeed at getting pytest to default to `[lms|cms].envs.tests`. However, I haven't come up with an elegant way of getting pytest to default to `[lms,cms].envs.tutor.test`, which adds this change to the upstream test settings:
```python
# Fix MongoDb connection credentials
DOC_STORE_CONFIG["user"] = None
DOC_STORE_CONFIG["password"] = None
```
In trying to find out why we need to change DOC_STORE_CONFIG connection credentials, git blame leads me to https://github.com/overhangio/tutor/commit/8d803fb08b13e2e20249b82c034483e61ec22795. @regisb , do you remember why you why need to change these credentials? Do you think it's possible we could work around this some other way, allowing us to use the upstream test settings?

## Screenshot of changed docs section

![image](https://user-images.githubusercontent.com/3628148/164564775-9a7d2ff6-cf11-4e67-8608-a776778726d3.png)
