### PR TITLE
fix: race condition could cause mkdirs() to fail with "dir exists"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: Breaking changes between versions are indicated by "💥".
 
 ## Unreleased
 
+- [Bugfix] Fix a race condition that could prevent a newly provisioned LMS container from starting due to a `FileExistsError` when creating data folders.
 - [Deprecation] Mark `tutor dev runserver` as deprecated in favor of `tutor dev start`. Since `start` now supports bind-mounting and breakpoint debugging, `runserver` is redundant and will be removed in a future release.
 - [Improvement] Allow breakpoint debugging when attached to a service via `tutor dev start SERVICE`.
 - [Security] Apply rate limiting security fix (see [commit](https://github.com/overhangio/edx-platform/commit/b5723e416e628cac4fa84392ca13e1b72817674f)).

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -24,7 +24,7 @@ DEFAULT_EMAIL_LOGO_URL = LMS_ROOT_URL + "/theming/asset/images/logo.png"
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:
     if not os.path.exists(folder):
-        os.makedirs(folder)
+        os.makedirs(folder, exist_ok=True)
 
 {{ patch("openedx-lms-common-settings") }}
 


### PR DESCRIPTION
When launching a new instance of Tutor just now, I had the LMS fail to start (Studio worked fine). The error was:

```
lms_1 | Traceback (most recent call last):
lms_1 |   File "lms/wsgi.py", line 18, in <module>
lms_1 |     import lms.startup as startup  # lint-amnesty, pylint: disable=wrong-import-position
lms_1 |   File "/openedx/edx-platform/./lms/startup.py", line 10, in <module>
lms_1 |     settings.INSTALLED_APPS  # pylint: disable=pointless-statement
lms_1 |   File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 82, in __getattr__
lms_1 |     self._setup(name)
lms_1 |   File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 69, in _setup
lms_1 |     self._wrapped = Settings(settings_module)
lms_1 |   File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 170, in __init__
lms_1 |     mod = importlib.import_module(self.SETTINGS_MODULE)
lms_1 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/importlib/__init__.py", line 127, in import_module
lms_1 |     return _bootstrap._gcd_import(name[level:], package, level)
lms_1 |   File "/openedx/edx-platform/./lms/envs/tutor/production.py", line 202, in <module>
lms_1 |     os.makedirs(folder)
lms_1 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/os.py", line 223, in makedirs
lms_1 |     mkdir(name, mode)
lms_1 | FileExistsError: [Errno 17] File exists: '/openedx/data/ora2'
lms_1 | unable to load app 0 (mountpoint='') (callable not found or import error)
```

I'm not sure exactly why this happened but it's likely some race condition, with two containers both attempting to create the same data directory at the same time, or something like that. In any case, the fix is easy - tell mkdirs() not to throw an error if the directory already exists.