### PR TITLE
docs: Update ARM64 tutorial to reference new plugin

### DIFF
--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -1,22 +1,36 @@
 .. _arm64:
 
+==================================
 Running Tutor on ARM-based systems
 ==================================
 
 Tutor can be used on ARM64 systems, although support for that platform is currently experimental.
 
-There are generally two ways to run Tutor on an ARM system - using qemu to run x86_64 images using emulation or running native ARM images. Since emulation can be quite slow, this Tutorial will focus on using native images where possible.
-
-There are currently no official ARM64 images provided for Tutor, but Tutor makes it easy to build them yourself.
-
-Building the images
--------------------
-
-Start by :ref:`installing <install>` Tutor and its dependencies (e.g. Docker) onto your system.
+In any case, start by :ref:`installing <install>` Tutor and its dependencies (e.g. Docker) onto your system.
 
 .. note:: For Open edX developers, if you want to use the :ref:`nightly <nightly>` version of Tutor to "run master", install Tutor using git and check out the ``nightly`` branch of Tutor at this point. See the :ref:`nightly documentation <nightly>` for details.
 
-Next, configure Tutor::
+Then, follow one of the options in this tutorial:
+
+The easy way: tutor-contrib-arm64
+=================================
+
+The easiest way to start using Tutor on ARM64 systems is through a community plugin which will automatically set the necessary configuration and which provides pre-built images.
+
+To use the `tutor-contrib-arm64 plugin <https://github.com/open-craft/tutor-contrib-arm64>`_ to start using Tutor, run these commands::
+
+    pip install git+https://github.com/open-craft/tutor-contrib-arm64
+    tutor plugins enable arm64
+    tutor local quickstart
+
+That's it! You can now use the LMS at http://local.overhang.io/ and you're done with this tutorial.
+
+The less easy way: building your own images
+===========================================
+
+If you want more flexibility than the plugin or its prebuilt images provide, you can build and run your own ARM64 images and change the database configuration yourself.
+
+First, configure Tutor::
 
     tutor config save --interactive
 
@@ -33,30 +47,31 @@ If you want to use Tutor as an Open edX development environment, you should also
 Change the database server
 --------------------------
 
-The version of MySQL that Open edX uses by default does not support the ARM architecture. Our current recommendation is to use MariaDB instead, which should be largely compatible.
+The version of MySQL that Open edX uses by default does not support the ARM architecture. You'll need to use a different database server/version, depending on which Open edX release you want to run.
 
-.. warning::
-    Note that using MariaDB is experimental and incompatibilities may exist, so this should only be used for local development - not for production instances.
+For the **Maple** release of Open edX, we recommend using MariaDB, which should be largely compatible.
 
 Configure Tutor to use MariaDB::
 
     tutor config save --set DOCKER_IMAGE_MYSQL=mariadb:10.4
+
+.. warning::
+    Note that using MariaDB is experimental and incompatibilities may exist, so this should only be used for local development - not for production instances.
+
+For the **Nutmeg** release as well as **Tutor Nightly**, we recommend using MySQL 8::
+
+    tutor config save --set DOCKER_IMAGE_MYSQL=mysql:8.0-oracle
+
+If you aren't sure which of these applies, use MariaDB.
 
 Finish setup and start Tutor
 ----------------------------
 
 From this point on, use Tutor as normal. For example, start Open edX and run migrations with::
 
-    tutor local start -d
     tutor local init
 
 Or for a development environment::
 
     tutor local stop
-    tutor dev start -d
     tutor dev init
-
-Using with tutor-mfe
---------------------
-
-You may wish to use `tutor-mfe <https://github.com/overhangio/tutor-mfe>`_ to run the Open edX microfrontends. If so, be aware that there is a known issue with ``tutor-mfe`` on ARM systems. See `this GitHub issue <https://github.com/overhangio/tutor-mfe/issues/31>`_ for details and known workarounds.


### PR DESCRIPTION
This updates the documentation to point to https://github.com/open-craft/tutor-contrib-arm64 as the easiest way to get Tutor working on ARM64 systems for now. It also recommends using MySQL 8 instead of MariaDB for newer platform versions that are compatible.