### PR TITLE
Learning MFE issue with certificates

### DIFF
--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -26,6 +26,9 @@ for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_
     if not os.path.exists(folder):
         os.makedirs(folder, exist_ok=True)
 
+# Resolve the certificate issue on Learning MFE
+FEATURES["PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS"] = True
+
 {{ patch("openedx-lms-common-settings") }}
 
 ######## End of common LMS settings


### PR DESCRIPTION
as mentioned [here](https://github.com/overhangio/tutor-mfe/issues/45), after migrating to MFEs, if PersistentGradesEnabledFlag is not enabled, after the certification creation request, an error will happen and it makes the pod restart.
this fix enables the PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS feature for lms. much much cleaner than creating a record that is not reversible.  