### PR TITLE
docs: fix typo in skip email validation plugin example

### DIFF
--- a/docs/plugins/examples.rst
+++ b/docs/plugins/examples.rst
@@ -18,7 +18,7 @@ Skip email validation for new users
             "common-env-features",
             """
     "SKIP_EMAIL_VALIDATION": true
-    """"
+    """
         )
     )
 


### PR DESCRIPTION
I was reading the new plugin documentation to migrate from v0 to v1 and see this typo.
I copied and pasted the example to test and it took me a few minutes to find the error. :grimacing:

I don't know if just this change is a valid PR ...
[Documentation link](https://docs.tutor.overhang.io/plugins/examples.html#skip-email-validation-for-new-users)