### PR TITLE
wip: fix: redundant commits for git cherry-picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Fix] Allow `--keep-redundant-commits` for `git cherry-pick`s as building the master branch of openedX may contain the referenced commit. (by @gabor-boros)
+
 ## v13.2.2 (2022-05-06)
 
 - [Fix] Mounts were broken in dev mode. (by @kdmccormick)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -49,19 +49,23 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Patch edx-platform
 # Fix forum notification for questions
 # https://github.com/openedx/edx-platform/pull/29611
-RUN git fetch --depth=2 https://github.com/open-craft/edx-platform/ 03731f19459e558f188c06aac5cc9ca1bbc675c2 && git cherry-pick 03731f19459e558f188c06aac5cc9ca1bbc675c2
+RUN git fetch --depth=2 https://github.com/open-craft/edx-platform/ 03731f19459e558f188c06aac5cc9ca1bbc675c2 \
+    && git cherry-pick --keep-redundant-commits 03731f19459e558f188c06aac5cc9ca1bbc675c2
 # SAML security fix
 # https://github.com/overhangio/edx-platform/tree/overhangio/sec-fix-saml-vulnerability
-RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ 3b985f207853e88090d68a81acd52866b71f5af7 && git cherry-pick 3b985f207853e88090d68a81acd52866b71f5af7
+RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ 3b985f207853e88090d68a81acd52866b71f5af7 \
+    && git cherry-pick --keep-redundant-commits 3b985f207853e88090d68a81acd52866b71f5af7
 # Rate limiting security fix
 # https://github.com/overhangio/edx-platform/tree/overhangio/sec-rate-limiting
-RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ b5723e416e628cac4fa84392ca13e1b72817674f && git cherry-pick b5723e416e628cac4fa84392ca13e1b72817674f
+RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ b5723e416e628cac4fa84392ca13e1b72817674f \
+    && git cherry-pick --keep-redundant-commits b5723e416e628cac4fa84392ca13e1b72817674f
 # Fix studio-frontend by pinning the installed version
 # https://github.com/openedx/edx-platform/pull/30309
-RUN git fetch --depth=2 https://github.com/uetuluk/edx-platform/ 53ea60eee86e094f35815ac1c4114d6811f4d458 && git cherry-pick 53ea60eee86e094f35815ac1c4114d6811f4d458
+RUN git fetch --depth=2 https://github.com/uetuluk/edx-platform/ 53ea60eee86e094f35815ac1c4114d6811f4d458 \
+    && git cherry-pick --keep-redundant-commits 53ea60eee86e094f35815ac1c4114d6811f4d458
 {%- endif %}
 
-{# Example: RUN git fetch --depth=2 https://github.com/openedx/edx-platform <GITSHA1> && git cherry-pick <GITSHA1> #}
+{# Example: RUN git fetch --depth=2 https://github.com/openedx/edx-platform <GITSHA1> && git cherry-pick --keep-redundant-commits <GITSHA1> #}
 {{ patch("openedx-dockerfile-post-git-checkout") }}
 
 ###### Download extra locales to /openedx/locale/contrib/locale


### PR DESCRIPTION
## Description

This PR redundant commits for git cherry-picks as cherry-picking may result in empty commits if the change is already applied on the given branch which breaks cherry-picking.

## Supporting information

Example output from our build logs (the build ran against the master branch of openedX):

```
#15 [code 4/5] RUN git fetch --depth=2 https://github.com/open-craft/edx-platform/ 03731f19459e558f188c06aac5cc9ca1bbc675c2 && git cherry-pick 03731f19459e558f188c06aac5cc9ca1bbc675c2
#15 sha256:6d26d234a9c613d0c1cbdae7a5c91beb75183487a7e8ea69a90f139b662d0291
#15 6.056 From https://github.com/open-craft/edx-platform
#15 6.056  * branch            03731f19459e558f188c06aac5cc9ca1bbc675c2 -> FETCH_HEAD
#15 7.592 Auto-merging lms/djangoapps/discussion/tests/test_tasks.py
#15 7.592 Auto-merging lms/djangoapps/discussion/tasks.py
#15 8.717 The previous cherry-pick is now empty, possibly due to conflict resolution.
#15 8.717 If you wish to commit it anyway, use:
#15 8.717 
#15 8.717     git commit --allow-empty
#15 8.717 
#15 8.717 Otherwise, please use 'git cherry-pick --skip'
#15 8.717 On branch master
#15 8.717 Your branch is up to date with 'origin/master'.
#15 8.717 
#15 8.717 You are currently cherry-picking commit 03731f1.
#15 8.717   (all conflicts fixed: run "git cherry-pick --continue")
#15 8.717   (use "git cherry-pick --skip" to skip this patch)
#15 8.717   (use "git cherry-pick --abort" to cancel the cherry-pick operation)
#15 8.717 
#15 8.717 nothing to commit, working tree clean
#15 ERROR: executor failed running [/bin/sh -c git fetch --depth=2 https://github.com/open-craft/edx-platform/ 03731f19459e558f188c06aac5cc9ca1bbc675c2 && git cherry-pick 03731f19459e558f188c06aac5cc9ca1bbc675c2]: exit code: 1
```

### Dependencies

N/A

### Screenshots

N/A

## Sandbox

N/A

## Testing instructions

* Run openedX image build for master branch