### PR TITLE
feat: pinned nodejs requirements with `npm ci`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Improvement] Faster and more reliable builds with `npm clean-install` instead of `npm install`. (by @regisb. Thanks @ghassanmas!)
 - [Fix] Fix 500 error during studio login. (by @regisb)
 - [Fix] Fix updates for the Caddy deployment in multi-node Kubernetes clusters (#660). Previously, Caddy configuration updates might fail if the Kubernetes cluster had more than one worker node. (by @fghaas)
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -233,7 +233,7 @@ Then, you should run the following commands::
     pip install --requirement requirements/edx/development.txt
 
     # Install nodejs packages in node_modules/
-    npm install
+    npm clean-install
 
     # Rebuild static assets
     openedx-assets build --env=dev

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -56,9 +56,6 @@ RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ 3b985f207853
 # Rate limiting security fix
 # https://github.com/overhangio/edx-platform/tree/overhangio/sec-rate-limiting
 RUN git fetch --depth=2 https://github.com/overhangio/edx-platform/ b5723e416e628cac4fa84392ca13e1b72817674f && git cherry-pick b5723e416e628cac4fa84392ca13e1b72817674f
-# Fix studio-frontend by pinning the installed version
-# https://github.com/openedx/edx-platform/pull/30309
-RUN git fetch --depth=2 https://github.com/uetuluk/edx-platform/ 53ea60eee86e094f35815ac1c4114d6811f4d458 && git cherry-pick 53ea60eee86e094f35815ac1c4114d6811f4d458
 {%- endif %}
 
 {# Example: RUN git fetch --depth=2 https://github.com/openedx/edx-platform <GITSHA1> && git cherry-pick <GITSHA1> #}
@@ -121,8 +118,9 @@ RUN nodeenv /openedx/nodeenv --node=12.13.0 --prebuilt
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 COPY --from=code /openedx/edx-platform/package.json /openedx/edx-platform/package.json
+COPY --from=code /openedx/edx-platform/package-lock.json /openedx/edx-platform/package-lock.json
 WORKDIR /openedx/edx-platform
-RUN npm install --verbose --registry=$NPM_REGISTRY
+RUN npm clean-install --verbose --registry=$NPM_REGISTRY
 
 ###### Production image with system and python requirements
 FROM minimal as production


### PR DESCRIPTION
Contrary to what we might expect, `npm install` does not install pinned
requirements from a project's package-lock.json. That's the responsibility of
`npm ci`: https://docs.npmjs.com/cli/v8/commands/npm-ci

Running `npm ci` is also *much* faster than `npm install`, so that's a huge win.

See this issue for reference: https://github.com/openedx/frontend-wg/issues/100