### PR TITLE
fix: 500 error during studio login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Fix] Fix 500 error during studio login. (by @regisb)
+
 ## v13.2.2 (2022-05-06)
 
 - [Fix] Mounts were broken in dev mode. (by @kdmccormick)

--- a/tutor/templates/apps/openedx/settings/partials/common_cms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_cms.py
@@ -8,6 +8,7 @@ STUDIO_NAME = u"{{ PLATFORM_NAME }} - Studio"
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = "{{ CMS_OAUTH2_SECRET }}"
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://lms:8000"
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False  # scheme is correctly included in redirect_uri
+SESSION_COOKIE_NAME = "studio_session_id"
 
 MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 100
 


### PR DESCRIPTION
Login to the studio was causing a 500 error, although the user was correctly
connected. See the issue description here:
https://github.com/openedx/build-test-release-wg/issues/114

The error was caused by the fact that both LMS and CMS session cookies were
being sent to the CMS and the LMS session cookie was considered the "right"
one. To clarify between both cookies, we need to have different session cookie
names between the lms and the cms. This requirement was actually documented in
step 5 of this authentication migration document:
https://github.com/openedx/edx-platform/blob/master/docs/guides/studio_oauth.rst#migration

For more information, have a look at the live stream during which this issue
was debugged: https://youtu.be/m3t1U_y6F64

Close https://github.com/openedx/build-test-release-wg/issues/114