### PR TITLE
docs: move forum to discuss.openedx.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,6 +4,6 @@ about: This is not the appropriate channel
 
 ---
 
-Please post on our forums: https://discuss.overhang.io for questions about using `tutor`.
+Please post on our forums: https://discuss.openedx.org/tag/tutor for questions about using `tutor`.
 
 Posts that are not a bug report or a feature/enhancement request will not be addressed on this issue tracker.

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Tutor: the Docker-based Open edX distribution designed for peace of mind
   :alt: Source code
   :target: https://github.com/overhangio/tutor
 
-.. image:: https://img.shields.io/static/v1?logo=discourse&label=Forums&style=flat-square&color=ff0080&message=discuss.overhang.io
+.. image:: https://img.shields.io/static/v1?logo=discourse&label=Forums&style=flat-square&color=ff0080&message=discuss.openedx.org
   :alt: Forums
-  :target: https://discuss.overhang.io
+  :target: https://discuss.openedx.org/tag/tutor
 
 .. image:: https://img.shields.io/static/v1?logo=readthedocs&label=Documentation&style=flat-square&color=blue&message=docs.tutor.overhang.io
   :alt: Documentation
@@ -82,7 +82,7 @@ Please follow the instructions from the `troubleshooting section <https://docs.t
 Support
 -------
 
-To get community support, go to the official discussion forums: https://discuss.overhang.io. For official support, please subscribe to a Long Term Support (LTS) license at https://overhang.io/tutor/pricing.
+To get community support, go to the official Open edX discussion forum: https://discuss.openedx.org. For official support, please subscribe to a Long Term Support (LTS) license at https://overhang.io/tutor/pricing.
 
 .. _readme_support_end:
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -291,4 +291,4 @@ Then, run unit tests with ``pytest`` commands::
     pytest cms
 
 .. note::
-    Getting all edx-platform unit tests to pass on Tutor is currently a work-in-progress. Some unit tests are still failing. If you manage to fix some of these, please report your findings in the `Tutor forums <https://discuss.overhang.io>`__.
+    Getting all edx-platform unit tests to pass on Tutor is currently a work-in-progress. Some unit tests are still failing. If you manage to fix some of these, please report your findings in the `Open edX forum <https://discuss.openedx.org/tag/tutor>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@
    :caption: Project links
 
    Source code <https://github.com/overhangio/tutor>
-   Community forums <https://discuss.overhang.io>
+   Community forums <https://discuss.openedx.org/tag/tutor>
    Pypi releases <https://pypi.org/project/tutor>
    Changelog <https://github.com/overhangio/tutor/blob/master/CHANGELOG.md>
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -11,9 +11,10 @@ What should you do if you have a problem?
 1. Read the error logs that appear in the console. When running a single server platform as daemon, you can view the logs with the ``tutor local logs`` command. (see :ref:`logging` below)
 2. Check if your problem already has a solution right here in the :ref:`troubleshooting` section.
 3. Search for your problem in the `open and closed Github issues <https://github.com/overhangio/tutor/issues?utf8=%E2%9C%93&q=is%3Aissue>`_.
-4. Search for your problem in the `community forums <https://discuss.overhang.io>`__.
-5. If despite all your efforts, you can't solve the problem by yourself, you should discuss it in the `community forums <https://discuss.overhang.io>`__. Please give as many details about your problem as possible! As a rule of thumb, **people will not dedicate more time to solving your problem than you took to write your question**.
-6. If you are *absolutely* positive that you are facing a technical issue with Tutor, and not with Open edX, not with your server, not your custom configuration, then, and only then, should you open an issue on `Github <https://github.com/overhangio/tutor/issues/>`__. You *must* follow the instructions from the issue template!!! If you do not follow this procedure, your Github issues will be mercilessly closed 🤯.
+4. Search for your problem in the (now legacy) `Tutor community forums <https://discuss.overhang.io>`__.
+5. Search for your problem in the `Open edX community forum <https://discuss.openedx.org/>`__.
+6. If despite all your efforts, you can't solve the problem by yourself, you should discuss it in the `Open edX community forum <https://discuss.openedx.org>`__. Please give as many details about your problem as possible! As a rule of thumb, **people will not dedicate more time to solving your problem than you took to write your question**. You should tag your topic with "tutor" or the corresponding Tutor plugin name ("tutor-discovery", etc.) in order to notify the maintainers.
+7. If you are *absolutely* positive that you are facing a technical issue with Tutor, and not with Open edX, not with your server, not your custom configuration, then, and only then, should you open an issue on `Github <https://github.com/overhangio/tutor/issues/>`__. You *must* follow the instructions from the issue template!!! If you do not follow this procedure, your Github issues will be mercilessly closed 🤯.
 
 Do you need professional assistance with your tutor-managed Open edX platform? Overhang.IO offers online support as part of its `Long Term Support (LTS) offering <https://overhang.io/tutor/pricing>`__.
 
@@ -23,7 +24,7 @@ Logging
 -------
 
 .. note::
-    Logs are of paramount importance for debugging Tutor. When asking for help on the `Tutor forums <https://discuss.overhang.io>`__, **you should always include the unedited logs of your app**. You can get those with::
+    Logs are of paramount importance for debugging Tutor. When asking for help on the `Open edX forum <https://discuss.openedx.org>`__, **you should always include the unedited logs of your app**. You can get those with::
 
          tutor local logs --tail=100 -f
 

--- a/docs/tutor.rst
+++ b/docs/tutor.rst
@@ -99,7 +99,7 @@ Contributing to Tutor
 
 Third-party contributions to Tutor and its plugins are more than welcome! Just make sure to follow these guidelines:
 
-- Outside of obvious bugs, contributions should be discussed first in the `official Tutor forums <https://discuss.overhang.io>`__.
+- Outside of obvious bugs, contributions should be discussed first in the `official Open edX forum <https://discuss.openedx.org>`__.
 - Once we agree on a high-level solution, you should open a pull request on the `Tutor repository <https://github.com/overhangio/tutor/pulls>`__ or the corresponding plugin.
 - Make sure that all tests pass by running ``make test`` (see above).
 - If your PR is in the Tutor core repository, add an item to the CHANGELOG file, in the "Unreleased" section. Use the same format as the other items::
@@ -117,4 +117,4 @@ Happy hacking! ☘️
 Joining the team of Tutor Maintainers
 -------------------------------------
 
-We have an open team of volunteers who help support the project. You can read all about it `here <https://discuss.overhang.io/t/the-tutor-maintainer-handbook/1375>`__ -- and we hope that you'll consider joining us 😉
+We have an open team of volunteers who help support the project. You can read all about it `here <https://discuss.openedx.org/t/tutor-maintainers/7287>`__ -- and we hope that you'll consider joining us 😉

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -28,4 +28,5 @@ System administration
    oldreleases
    arm64
 
-Other tutorials can be found in the official Tutor forums, `in the "Tutorials" category <https://discuss.overhang.io/c/tutor/tutorials/13>`__.
+.. Note: maybe we should create a dedicated tutorial category in the Open edX forum?
+.. Other tutorials can be found in the official Tutor forums, `in the "Tutorials" category <https://discuss.overhang.io/c/tutor/tutorials/13>`__.

--- a/docs/whatnext.rst
+++ b/docs/whatnext.rst
@@ -43,4 +43,4 @@ Check out `Cairn <https://overhang.io/tutor/plugin/cairn>`__, the next-generatio
 Meeting the community
 ---------------------
 
-Ask your questions and chat with the Tutor community on the official community forums: https://discuss.overhang.io
+Ask your questions and chat with the Tutor community on the official Open edX community forum: https://discuss.openedx.org

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Documentation": "https://docs.tutor.overhang.io/",
         "Code": "https://github.com/overhangio/tutor",
         "Issue tracker": "https://github.com/overhangio/tutor/issues",
-        "Community": "https://discuss.overhang.io",
+        "Community": "https://discuss.openedx.org/tag/tutor",
     },
     license="AGPLv3",
     author="Overhang.io",


### PR DESCRIPTION
Now that Tutor is the official community installation for Open edX, it no
longer makes sense to host a forum that is separate from the general Open edX
forum. Moving conversations there will encourage cross-communication between
projects and maintainers. This change is part of a larger overhaul described in
this Tutor enhancement proposal (TEP):
https://discuss.overhang.io/t/tep-rethinking-the-tutor-maintainers-program/2724

In the future, plugin maintainers should point their users to the Open edX
forum as well. They are encouraged to create dedicated "tutor-pluginnname" tags
on the forum and to set their notification level to "watching".