### PR TITLE
docs: complete uninstalling of tutor

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -167,3 +167,9 @@ Finally, uninstall Tutor itself::
 
     # If you downloaded the tutor binary
     sudo rm /usr/local/bin/tutor
+
+    # Optionally, you may want to remove Tutor plugins installed.
+    # You can get a list of the installed plugins:
+    pip freeze | grep tutor
+    # You can then remove them using the following command:
+    pip uninstall <plugin-name>


### PR DESCRIPTION
I noticed `pip uninstall -y tutor` will not uninstall the plugins, so I made this PR. I know it's ugly, but I don't find any other way of doing it. Let me know if there are better choices 😊