### PR TITLE
fix: ignore plugins that cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Fix] Ignore Python plugins that cannot be loaded. (by @regisb)
 - [Improvement] Faster and more reliable builds with `npm clean-install` instead of `npm install`. (by @regisb. Thanks @ghassanmas!)
 - [Fix] Fix 500 error during studio login. (by @regisb)
 - [Fix] Fix updates for the Caddy deployment in multi-node Kubernetes clusters (#660). Previously, Caddy configuration updates might fail if the Kubernetes cluster had more than one worker node. (by @fghaas)

--- a/tutor/plugins/__init__.py
+++ b/tutor/plugins/__init__.py
@@ -72,8 +72,8 @@ def load_all(names: t.Iterable[str]) -> None:
     for name in names:
         try:
             load(name)
-        except exceptions.TutorError as e:
-            fmt.echo_alert(f"Failed to enable plugin '{name}': {e.args[0]}")
+        except Exception as e:
+            fmt.echo_alert(f"Failed to enable plugin '{name}': {e}")
     hooks.Actions.PLUGINS_LOADED.do()
 
 


### PR DESCRIPTION
When running multiple concurrent versions of a plugin there are sometimes
version conflicts that prevent the plugin from being loaded. Prior to v1, Tutor
was correctly ignoring plugins that could not be loaded. During the transition
to v1 we lost that feature because we only captured TutorErrors.