### PR TITLE
feat: render files in ignored directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- 💥[Fix] Get rid of the `tutor config render` command, which is useless now that themes can be implemented as plugins. (by @regisb)
+
 ## v13.2.3 (2022-05-30)
 
 - [Fix] Truncate site display name to 50 characters with a warning, fixing data too long error for long site names. (by @navinkarkera)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Feature] Make it possible to force the rendering of a given template, even when the template path matches an ignore pattern. (by @regisb)
 - 💥[Fix] Get rid of the `tutor config render` command, which is useless now that themes can be implemented as plugins. (by @regisb)
 
 ## v13.2.3 (2022-05-30)

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,9 +1,6 @@
-import os
-import tempfile
 import unittest
 
 from tests.helpers import temporary_root
-from tutor import config as tutor_config
 
 from .base import TestCommandMixin
 
@@ -61,29 +58,3 @@ class ConfigTests(unittest.TestCase, TestCommandMixin):
         self.assertFalse(result.exception)
         self.assertEqual(0, result.exit_code)
         self.assertTrue(result.output)
-
-    def test_config_render(self) -> None:
-        with tempfile.TemporaryDirectory() as dest:
-            with temporary_root() as root:
-                self.invoke_in_root(root, ["config", "save"])
-                result = self.invoke_in_root(root, ["config", "render", root, dest])
-        self.assertEqual(0, result.exit_code)
-        self.assertFalse(result.exception)
-
-    def test_config_render_with_extra_configs(self) -> None:
-        with tempfile.TemporaryDirectory() as dest:
-            with temporary_root() as root:
-                self.invoke_in_root(root, ["config", "save"])
-                result = self.invoke_in_root(
-                    root,
-                    [
-                        "config",
-                        "render",
-                        "-x",
-                        os.path.join(root, tutor_config.CONFIG_FILENAME),
-                        root,
-                        dest,
-                    ],
-                )
-        self.assertEqual(0, result.exit_code)
-        self.assertFalse(result.exception)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -24,6 +24,20 @@ class EnvTests(PluginsTestCase):
         self.assertIn(template_name, renderer.environment.loader.list_templates())
         self.assertNotIn(template_name, templates)
 
+    def test_files_are_rendered(self) -> None:
+        self.assertTrue(env.is_rendered("some/file"))
+        self.assertFalse(env.is_rendered(".git"))
+        self.assertFalse(env.is_rendered(".git/subdir"))
+        self.assertFalse(env.is_rendered("directory/.git"))
+        self.assertFalse(env.is_rendered("directory/.git/somefile"))
+        self.assertFalse(env.is_rendered("directory/somefile.pyc"))
+        self.assertTrue(env.is_rendered("directory/somedir.pyc/somefile"))
+        self.assertFalse(env.is_rendered("directory/__pycache__"))
+        self.assertFalse(env.is_rendered("directory/__pycache__/somefile"))
+        self.assertFalse(env.is_rendered("directory/partials/extra.scss"))
+        self.assertFalse(env.is_rendered("directory/partials"))
+        self.assertFalse(env.is_rendered("partials/somefile"))
+
     def test_is_binary_file(self) -> None:
         self.assertTrue(env.is_binary_file("/home/somefile.ico"))
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -13,13 +13,13 @@ from tutor.types import Config
 
 class EnvTests(PluginsTestCase):
     def test_walk_templates(self) -> None:
-        renderer = env.Renderer({}, [env.TEMPLATES_ROOT])
+        renderer = env.Renderer()
         templates = list(renderer.walk_templates("local"))
         self.assertIn("local/docker-compose.yml", templates)
 
     def test_walk_templates_partials_are_ignored(self) -> None:
         template_name = "apps/openedx/settings/partials/common_all.py"
-        renderer = env.Renderer({}, [env.TEMPLATES_ROOT], ignore_folders=["partials"])
+        renderer = env.Renderer()
         templates = list(renderer.walk_templates("apps"))
         self.assertIn(template_name, renderer.environment.loader.list_templates())
         self.assertNotIn(template_name, templates)
@@ -28,7 +28,7 @@ class EnvTests(PluginsTestCase):
         self.assertTrue(env.is_binary_file("/home/somefile.ico"))
 
     def test_find_os_path(self) -> None:
-        renderer = env.Renderer({}, [env.TEMPLATES_ROOT])
+        renderer = env.Renderer()
         path = renderer.find_os_path("local/docker-compose.yml")
         self.assertTrue(os.path.exists(path))
 
@@ -180,14 +180,14 @@ class EnvTests(PluginsTestCase):
 
             # Load env once
             config: Config = {"PLUGINS": []}
-            env1 = env.Renderer.instance(config).environment
+            env1 = env.Renderer(config).environment
 
             # Enable plugins
             plugins.load("plugin1")
 
             # Load env a second time
             config["PLUGINS"] = ["myplugin"]
-            env2 = env.Renderer.instance(config).environment
+            env2 = env.Renderer(config).environment
 
             self.assertNotIn("plugin1/myplugin.txt", env1.loader.list_templates())
             self.assertIn("plugin1/myplugin.txt", env2.loader.list_templates())
@@ -199,7 +199,7 @@ class EnvTests(PluginsTestCase):
             "notsomething_test_app": 2,
             "something3_test_app": 3,
         }
-        renderer = env.Renderer.instance(config)
+        renderer = env.Renderer(config)
         self.assertEqual([2, 3], list(renderer.iter_values_named(suffix="test_app")))
         self.assertEqual([1, 3], list(renderer.iter_values_named(prefix="something")))
         self.assertEqual(

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -64,29 +64,6 @@ def save(
     env.save(context.root, config)
 
 
-@click.command(help="Render a template folder with eventual extra configuration files")
-@click.option(
-    "-x",
-    "--extra-config",
-    "extra_configs",
-    multiple=True,
-    type=click.Path(exists=True, resolve_path=True, dir_okay=False),
-    help="Load extra configuration file (can be used multiple times)",
-)
-@click.argument("src", type=click.Path(exists=True, resolve_path=True))
-@click.argument("dst")
-@click.pass_obj
-def render(context: Context, extra_configs: List[str], src: str, dst: str) -> None:
-    config = tutor_config.load(context.root)
-    for extra_config in extra_configs:
-        config.update(
-            env.render_unknown(config, tutor_config.get_yaml_file(extra_config))
-        )
-    renderer = env.Renderer(config, [src])
-    renderer.render_all_to(dst)
-    fmt.echo_info(f"Templates rendered to {dst}")
-
-
 @click.command(help="Print the project root")
 @click.pass_obj
 def printroot(context: Context) -> None:
@@ -106,6 +83,5 @@ def printvalue(context: Context, key: str) -> None:
 
 
 config_command.add_command(save)
-config_command.add_command(render)
 config_command.add_command(printroot)
 config_command.add_command(printvalue)

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -223,6 +223,23 @@ class Filters:
     #:   filter to modify the Tutor templates.
     ENV_PATCHES = filters.get("env:patches")
 
+    #: List of template path patterns to be ignored when rendering templates to the project root. By default, we ignore:
+    #:
+    #: - hidden files (``.*``)
+    #: - ``__pycache__`` directories and ``*.pyc`` files
+    #: - "partials" directories.
+    #:
+    #: Ignored patterns are overridden by include patterns; see :py:data:`ENV_PATTERNS_INCLUDE`.
+    #:
+    #: :parameter list[str] patterns: list of regular expression patterns. E.g: ``r"(.*/)?ignored_file_name(/.*)?"``.
+    ENV_PATTERNS_IGNORE = filters.get("env:patterns:ignore")
+
+    #: List of template path patterns to be included when rendering templates to the project root.
+    #: Patterns from this list will take priority over the patterns from :py:data:`ENV_PATTERNS_IGNORE`.
+    #:
+    #: :parameter list[str] patterns: list of regular expression patterns. See :py:data:`ENV_PATTERNS_IGNORE`.
+    ENV_PATTERNS_INCLUDE = filters.get("env:patterns:include")
+
     #: List of all template root folders.
     #:
     #: :parameter list[str] templates_root: absolute paths to folders which contain templates.


### PR DESCRIPTION
When rendering theme files in a plugin, the *.scss files are stored in a
"partials" subdirectory, which was ignored by the environment rendering logic.
To render these files, we move the path ignoring logic to a filter, which is a
list of regular expressions. Values in this filter can be overridden by another
filter.

See the corresponding issue in the indigo theme plugin:
https://github.com/overhangio/tutor-indigo/issues/24
