### PR TITLE
fix: celery workers in dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
-- [Fix] Fix studio logout issue. (by @Alec4r) [PR #680](https://github.com/overhangio/tutor/pull/680)
+- [Fix] Crashing celery workers in development (#681). (by @regisb)
+- [Fix] Fix studio logout issue. (by @Alec4r)
 
 ## v13.3.0 (2022-06-03)
 

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -49,9 +49,13 @@ services:
 
   lms-worker:
     <<: *openedx-service
+    # Note: we should get rid of this once celery is upgraded to 5.0.0+ after maple
+    # (same below in cms-worker)
+    tty: false
 
   cms-worker:
     <<: *openedx-service
+    tty: false
 
   # Additional service for watching theme changes
   watchthemes:


### PR DESCRIPTION
Celery workers failed to start in development with the following stacktrace:

    cms-worker_1                 | Traceback (most recent call last):
    cms-worker_1                 |   File "/openedx/venv/bin/celery", line 8, in <module>
    cms-worker_1                 |     sys.exit(main())
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/__main__.py", line 16, in main
    cms-worker_1                 |     _main()
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 322, in main
    cms-worker_1                 |     cmd.execute_from_commandline(argv)
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 499, in execute_from_commandline
    cms-worker_1                 |     super(CeleryCommand, self).execute_from_commandline(argv)))
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/base.py", line 305, in execute_from_commandline
    cms-worker_1                 |     return self.handle_argv(self.prog_name, argv[1:])
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 491, in handle_argv
    cms-worker_1                 |     return self.execute(command, argv)
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 415, in execute
    cms-worker_1                 |     return cls(
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/worker.py", line 221, in run_from_argv
    cms-worker_1                 |     *self.parse_options(prog_name, argv, command))
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/base.py", line 428, in parse_options
    cms-worker_1                 |     self.parser = self.create_parser(prog_name, command)
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/base.py", line 440, in create_parser
    cms-worker_1                 |     description=self._format_description(self.description),
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/bin/base.py", line 462, in _format_description
    cms-worker_1                 |     text.fill_paragraphs(text.dedent(description), width))
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/utils/text.py", line 58, in fill_paragraphs
    cms-worker_1                 |     return sep.join(fill(p, width) for p in s.split(sep))
    cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/celery/utils/text.py", line 58, in <genexpr>
    cms-worker_1                 |     return sep.join(fill(p, width) for p in s.split(sep))
    cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/textwrap.py", line 391, in fill
    cms-worker_1                 |     return w.fill(text)
    cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/textwrap.py", line 363, in fill
    cms-worker_1                 |     return "\n".join(self.wrap(text))
    cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/textwrap.py", line 354, in wrap
    cms-worker_1                 |     return self._wrap_chunks(chunks)
    cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/textwrap.py", line 248, in _wrap_chunks
    cms-worker_1                 |     raise ValueError("invalid width %r (must be > 0)" % self.width)
    cms-worker_1                 | ValueError: invalid width -2 (must be > 0)

This issue was reported upstream here: https://github.com/celery/celery/issues/6302

It is caused by the `tty: true` statement, for some reason. It will be fixed in
Nutmeg, after celery is upgraded to 5.2.6.

Close #681.