### PR TITLE
chore: change default of catalog settings

### DIFF
--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -21,6 +21,11 @@ OAUTH_ENFORCE_SECURE = False
 # Email settings
 DEFAULT_EMAIL_LOGO_URL = LMS_ROOT_URL + "/theming/asset/images/logo.png"
 
+# This override make it possible to hide courses in /courses page
+# when the course discovery feature is enabled (its enabled by default with tutor)
+# Note: don't confuse this with "discovery service" which has a dedicated plugin.
+SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING = False
+
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:
     if not os.path.exists(folder):


### PR DESCRIPTION
This partialy fixes #openedx/build-test-release-wg/issues/164
 The flag would make it possible to hide courses in the /courses
 page when ENABLE_COURSE_DISCOVERY is true.
 For more context check the forum thread:
 https://discuss.openedx.org/t/request-for-feedbak-breaking-changes-for-course-visibility/7341
