### PR TITLE
Add PYTHONBREAKPOINT as exposed config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 -->
 
 ## Unreleased
-- [Feature] Add PYTHONBREAKPOINT as an exposed config variable for custom debugging.(by @Carlos-Muniz)
+- [Feature] Add default PYTHONBREAKPOINT to openedx/Dockerfile (by @Carlos-Muniz)
 
 ## v14.0.0 (2022-06-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 -->
 
 ## Unreleased
+- [Feature] Add PYTHONBREAKPOINT as an exposed config variable for custom debugging.(by @Carlos-Muniz)
 
 ## v14.0.0 (2022-06-09)
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -161,7 +161,7 @@ Tutor makes it easy to create a bind-mount from an existing container. First, co
 
     tutor dev bindmount lms /openedx/venv
 
-This command recursively copies the contents of the ``/opendedx/venv`` directory to ``$(tutor config printroot)/volumes/venv``. The code of any Python dependency can then be edited -- for instance, you can then add a ``import ipdb; ipdb.set_trace()`` statement for step-by-step debugging, or implement a custom feature.
+This command recursively copies the contents of the ``/opendedx/venv`` directory to ``$(tutor config printroot)/volumes/venv``. The code of any Python dependency can then be edited -- for instance, you can then add a ``breakpoint()`` statement for step-by-step debugging, or implement a custom feature.
 
 Then, bind-mount the directory back in the container with the ``--mount`` option::
 
@@ -238,9 +238,11 @@ Then, you should run the following commands::
     # Rebuild static assets
     openedx-assets build --env=dev
 
-After running all these commands, your edx-platform repository will be ready for local development. To debug a local edx-platform repository, you can then add a ``import ipdb; ipdb.set_trace()`` breakpoint anywhere in your code and run::
+After running all these commands, your edx-platform repository will be ready for local development. To debug a local edx-platform repository, you can then add a `python breakpoint <https://docs.python.org/3/library/functions.html#breakpoint>`__ with ``breakpoint()`` anywhere in your code and run::
 
     tutor dev start --mount=/path/to/edx-platform lms
+
+``PYTHONBREAKPOINT`` can be modified in the `config.yml` in order to use a custom debugger. The default debugger is ``pdb.set_trace``.
 
 If LMS isn't running, this will start it in your terminal. If an LMS container is already running background, this command will stop it, recreate it, and attach your terminal to it. Later, to detach your terminal without stopping the container, just hit ``Ctrl+z``.
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -242,7 +242,7 @@ After running all these commands, your edx-platform repository will be ready for
 
     tutor dev start --mount=/path/to/edx-platform lms
 
-``PYTHONBREAKPOINT`` can be modified in the `config.yml` in order to use a custom debugger. The default debugger is ``pdb.set_trace``.
+The default debugger is ``ipdb.set_trace``. ``PYTHONBREAKPOINT`` can be modified by setting an environment variable in the Docker imamge.
 
 If LMS isn't running, this will start it in your terminal. If an LMS container is already running background, this command will stop it, recreate it, and attach your terminal to it. Later, to detach your terminal without stopping the container, just hit ``Ctrl+z``.
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -230,8 +230,8 @@ USER app
 RUN pip install -r requirements/edx/development.txt
 RUN pip install ipdb==0.13.4 ipython==7.27.0
 
-# Add PYTHONBREAKPOINT from config.yml
-ENV PYTHONBREAKPOINT={{ PYTHONBREAKPOINT }}
+# Add ipdb as default PYTHONBREAKPOINT
+ENV PYTHONBREAKPOINT=ipdb.set_trace
 
 # Recompile static assets: in development mode all static assets are stored in edx-platform,
 # and the location of these files is stored in webpack-stats.json. If we don't recompile

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -230,6 +230,9 @@ USER app
 RUN pip install -r requirements/edx/development.txt
 RUN pip install ipdb==0.13.4 ipython==7.27.0
 
+# Add PYTHONBREAKPOINT from config.yml
+ENV PYTHONBREAKPOINT={{ PYTHONBREAKPOINT }}
+
 # Recompile static assets: in development mode all static assets are stored in edx-platform,
 # and the location of these files is stored in webpack-stats.json. If we don't recompile
 # static assets, then production assets will be served instead.

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -57,7 +57,6 @@ MYSQL_ROOT_USERNAME: "root"
 NPM_REGISTRY: "https://registry.npmjs.org/"
 PLATFORM_NAME: "My Open edX"
 PREVIEW_LMS_HOST: "preview.{{ LMS_HOST }}"
-PYTHONBREAKPOINT:
 REDIS_HOST: "redis"
 REDIS_PORT: 6379
 REDIS_USERNAME: ""

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -57,6 +57,7 @@ MYSQL_ROOT_USERNAME: "root"
 NPM_REGISTRY: "https://registry.npmjs.org/"
 PLATFORM_NAME: "My Open edX"
 PREVIEW_LMS_HOST: "preview.{{ LMS_HOST }}"
+PYTHONBREAKPOINT:
 REDIS_HOST: "redis"
 REDIS_PORT: 6379
 REDIS_USERNAME: ""


### PR DESCRIPTION
## Criteria

- Exposes `PYTHONBREAKPOINT` as a Tutor configuration variable
- Sets `ENV PYTHONBREAKPOINT={{ PYTHONBREAKPOINT }}` in the openedx dockerfile
- Changes the docs to recommend using `breakpoint()`. Explains that `PYTHONBREAKPOINT` can be modified in order to use a custom debugger.

### Testing

1. Build openedx: `tutor images build openedx`
2. Build openedx-dev: `tutor dev dc build`
3. Run bash in lms: `tutor dev run lms bash`
4. Within bash, check for `PYTHONBREAKPOINT`: `env | grep PYTHONBREAKPOINT`

And `make test`

Closes https://github.com/overhangio/2u-tutor-adoption/issues/45