### PR TITLE
Add missing indentation in cms feature patches

### DIFF
--- a/tutor/templates/apps/openedx/config/cms.env.yml
+++ b/tutor/templates/apps/openedx/config/cms.env.yml
@@ -5,8 +5,8 @@ LOGGING_ENV: "sandbox"
 OAUTH_OIDC_ISSUER: "{{ JWT_COMMON_ISSUER }}"
 PLATFORM_NAME: "{{ PLATFORM_NAME }}"
 FEATURES:
-  {{ patch("common-env-features") }}
-  {{ patch("cms-env-features") }}
+  {{ patch("common-env-features")|indent(2) }}
+  {{ patch("cms-env-features")|indent(2) }}
   CERTIFICATES_HTML_VIEW: true
   PREVIEW_LMS_BASE: "{{ PREVIEW_LMS_HOST }}"
   ENABLE_COURSEWARE_INDEX: true


### PR DESCRIPTION
Add missing two spaces indentation to the features patches in the CMS configuration file.
This is causing a corrupt cms.env.yml configuration file.
Note that in the lms.env.yml template, the patches are properly indented.