### PR TITLE
fix: email sending from cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Bugfix] Fix smtp server port in `cms.yml` which was causing email sending failures in the Studio. (by @regisb)
 - [Improvement] Use `git am` instead of `cherry-pick` to simplify patching process.
 
 ## v14.0.1 (2022-06-13)

--- a/tutor/templates/apps/openedx/config/cms.env.yml
+++ b/tutor/templates/apps/openedx/config/cms.env.yml
@@ -31,7 +31,7 @@ COMPREHENSIVE_THEME_DIRS: ["/openedx/themes"]
 STATIC_ROOT_BASE: "/openedx/staticfiles"
 EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST: "{{ SMTP_HOST }}"
-EMAIL_PORT: {{ SMTP_PORT }},
+EMAIL_PORT: {{ SMTP_PORT }}
 EMAIL_USE_TLS: {{ "true" if SMTP_USE_TLS else "false" }}
 HTTPS: "{{ "on" if ENABLE_HTTPS else "off" }}"
 LANGUAGE_CODE: "{{ LANGUAGE_CODE }}"
@@ -49,7 +49,7 @@ CACHES:
     LOCATION: "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}"
   mongo_metadata_inheritance:
     KEY_PREFIX: "mongo_metadata_inheritance"
-    TIMEOUT: 300,
+    TIMEOUT: 300
     BACKEND: "django_redis.cache.RedisCache"
     LOCATION: "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}"
   staticfiles:


### PR DESCRIPTION
Incorrect format of cms.yml config file was causing the following error on course import:

	cms-worker_1                 | Traceback (most recent call last):
	cms-worker_1                 |   File "/openedx/edx-platform/cms/djangoapps/cms_user_tasks/tasks.py", line 53, in send_task_complete_email
	cms-worker_1                 |     mail.send_mail(subject, message, from_address, [dest_addr], fail_silently=False)
	cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/django/core/mail/__init__.py", line 61, in send_mail
	cms-worker_1                 |     return mail.send()
	cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/django/core/mail/message.py", line 284, in send
	cms-worker_1                 |     return self.get_connection(fail_silently).send_messages([self])
	cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/django/core/mail/backends/smtp.py", line 102, in send_messages
	cms-worker_1                 |     new_conn_created = self.open()
	cms-worker_1                 |   File "/openedx/venv/lib/python3.8/site-packages/django/core/mail/backends/smtp.py", line 62, in open
	cms-worker_1                 |     self.connection = self.connection_class(self.host, self.port, **connection_params)
	cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/smtplib.py", line 255, in __init__
	cms-worker_1                 |     (code, msg) = self.connect(host, port)
	cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/smtplib.py", line 339, in connect
	cms-worker_1                 |     self.sock = self._get_socket(host, port, self.timeout)
	cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/smtplib.py", line 310, in _get_socket
	cms-worker_1                 |     return socket.create_connection((host, port), timeout,
	cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/socket.py", line 787, in create_connection
	cms-worker_1                 |     for res in getaddrinfo(host, port, 0, SOCK_STREAM):
	cms-worker_1                 |   File "/opt/pyenv/versions/3.8.12/lib/python3.8/socket.py", line 918, in getaddrinfo
	cms-worker_1                 |     for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
	cms-worker_1                 | socket.gaierror: [Errno -8] Servname not supported for ai_socktype

The reason was that the trailing comma "," was interpreted as being part of the email port.