### PR TITLE
fix: skip waiting for mongodb SRV records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 - [Feature] Add default PYTHONBREAKPOINT to openedx/Dockerfile (by @Carlos-Muniz)
 
 - [Bugfix] Fix smtp server port in `cms.yml` which was causing email sending failures in the Studio. (by @regisb)
+- [Bugfix] Skip waiting for MongoDB if it is served using SRV records. (by @gabor-boros)
 - [Improvement] Use `git am` instead of `cherry-pick` to simplify patching process.
 - [Improvement] Tutor is now compatible with Docker Compose subcommand.
 

--- a/tutor/templates/hooks/lms/init
+++ b/tutor/templates/hooks/lms/init
@@ -43,4 +43,3 @@ fi
 # Create waffle switches to enable some features, if they have not been explicitly defined before
 # Completion tracking: add green ticks to every completed unit
 (./manage.py lms waffle_switch --list | grep completion.enable_completion_tracking) || ./manage.py lms waffle_switch --create completion.enable_completion_tracking on
-

--- a/tutor/templates/hooks/lms/init
+++ b/tutor/templates/hooks/lms/init
@@ -1,5 +1,10 @@
 dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
+
+{%- if MONGODB_HOST.startswith("mongodb+srv://") %}
+echo "MongoDB is using SRV records, so we cannot wait for it to be ready"
+{%- else %}
 dockerize -wait tcp://{{ MONGODB_HOST }}:{{ MONGODB_PORT }} -timeout 20s
+{%- endif %}
 
 echo "Loading settings $DJANGO_SETTINGS_MODULE"
 
@@ -38,3 +43,4 @@ fi
 # Create waffle switches to enable some features, if they have not been explicitly defined before
 # Completion tracking: add green ticks to every completed unit
 (./manage.py lms waffle_switch --list | grep completion.enable_completion_tracking) || ./manage.py lms waffle_switch --create completion.enable_completion_tracking on
+


### PR DESCRIPTION
## Description

This PR fixes the dockerize wait command execution on SRV records by not waiting for the resource.

## Supporting information

MongoDB clusters with connection string starting with `mongodb+srv` would connect to an cluster behind an SRV record. Since `dockerize` cannot "ping" SRV records, it waits until a timeout and the job fails.

### Dependencies

N/A

### Screenshots

<details>
<summary>job output</summary>
<pre>
2022/06/23 14:12:17 Ready: tcp://oc-stage-nyc3-mysql-do-user-9002811-0.b.db.ondigitalocean.com:25060.
MongoDB is using SRV records, so we cannot wait for it to be ready
Loading settings lms.envs.tutor.production
2022-06-23 14:12:24,768 WARNING 12 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/boto/plugin.py:40: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp

2022-06-23 14:12:24,928 WARNING 12 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  from collections import Mapping, MutableMapping

2022-06-23 14:12:29,157 WARNING 12 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/edx-platform/openedx/core/types/admin.py:49: DeprecationWarning: Django 3.2+ available: the _admin_display method and the AdminMethodclass should be removed from openedx.core.types
  warnings.warn(

2022-06-23 14:12:30,608 WARNING 12 [py.warnings] [user None] [ip None] warnings.py:109 - /openedx/venv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

Operations to perform:
  Apply all migrations: admin, agreements, announcements, api_admin, assessment, auth, badges, blackboard, block_structure, bookmarks, branding, bulk_email, bulk_grades, bundles, calendar_sync, canvas, catalog, celery_utils, certificates, commerce, completion, consent, content_libraries, content_type_gating, contentserver, contenttypes, cornerstone, cors_csrf, course_action_state, course_apps, course_date_signals, course_duration_limits, course_goals, course_groups, course_home_api, course_live, course_modes, course_overviews, courseware, crawlers, credentials, credit, dark_lang, database_fixups, degreed, degreed2, demographics, discounts, discussions, django_celery_results, django_comment_common, django_notify, edx_name_affirmation, edx_proctoring, edx_when, edxval, email_marketing, embargo, enterprise, entitlements, experiments, external_user_ids, grades, instructor_task, integrated_channel, learning_sequences, lms_xblock, lti1p3_tool_config, lti_consumer, milestones, mobile_api, moodle, oauth2_provider, oauth_dispatch, organizations, program_enrollments, programs, redirects, rss_proxy, sap_success_factors, save_for_later, schedules, self_paced, sessions, site_configuration, sites, social_django, splash, split_modulestore_django, staffgrader, static_replace, status, student, submissions, super_csv, survey, system_wide_roles, teams, theming, third_party_auth, thumbnail, track, user_api, user_authn, user_tours, util, verified_track_content, verify_student, video_config, video_pipeline, waffle, waffle_utils, wiki, workflow, xapi, xblock_django
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying admin.0003_logentry_add_action_flag_choices... OK
  Applying agreements.0001_initial... OK
  Applying announcements.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying api_admin.0001_initial... OK
  Applying api_admin.0002_auto_20160325_1604... OK
  Applying api_admin.0003_auto_20160404_1618... OK
  Applying api_admin.0004_auto_20160412_1506... OK
  Applying api_admin.0005_auto_20160414_1232... OK
  Applying api_admin.0006_catalog... OK
  Applying api_admin.0007_delete_historical_api_records... OK
  Applying assessment.0001_initial... OK
  Applying assessment.0002_staffworkflow... OK
  Applying assessment.0003_expand_course_id... OK
  Applying assessment.0004_historicalsharedfileupload_sharedfileupload... OK
  Applying assessment.0005_add_filename_to_sharedupload... OK
  Applying assessment.0006_TeamWorkflows... OK
  Applying assessment.0007_staff_workflow_blank... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying instructor_task.0001_initial... OK
  Applying certificates.0001_initial... OK
  Applying certificates.0002_data__certificatehtmlviewconfiguration_data... OK
System check identified some issues:

WARNINGS:
?: (2_0.W001) Your URL pattern 'edx_name_affirmation/v1/verified_name/(?P<verified_name_id>\d+)$' [name='verified_name_by_id'] has a route that contains '(?P<', begins with a '^', or ends with a '$'. This was likely an oversight when migrating to django.urls.path().
consent.DataSharingConsent.granted: (fields.W903) NullBooleanField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
	HINT: Use BooleanField(null=True) instead.
consent.HistoricalDataSharingConsent.granted: (fields.W903) NullBooleanField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
	HINT: Use BooleanField(null=True) instead.
2022-06-23 14:12:44,999 INFO 12 [botocore.vendored.requests.packages.urllib3.connectionpool] [user None] [ip None] connectionpool.py:734 - Starting new HTTPS connection (1): edx-oc-stage-nyc3-gabor-test-17657576598964744743.nyc3.digitaloceanspaces.com
  Applying certificates.0003_data__default_modes... OK
  Applying certificates.0004_certificategenerationhistory... OK
  Applying certificates.0005_auto_20151208_0801... OK
  Applying certificates.0006_certificatetemplateasset_asset_slug... OK
  Applying certificates.0007_certificateinvalidation... OK
  Applying badges.0001_initial... OK
  Applying badges.0002_data__migrate_assertions... OK
  Applying badges.0003_schema__add_event_configuration... OK
  Applying badges.0004_badgeclass_badgr_server_slug... OK
  Applying waffle.0001_initial... OK
  Applying sites.0002_alter_domain_unique... OK
  Applying enterprise.0001_squashed_0092_auto_20200312_1650... OK
  Applying enterprise.0093_add_use_enterprise_catalog_flag... OK
  Applying enterprise.0094_add_use_enterprise_catalog_sample... OK
  Applying enterprise.0095_auto_20200507_1138... OK
  Applying enterprise.0096_enterprise_catalog_admin_role... OK
  Applying enterprise.0097_auto_20200619_1130... OK
  Applying enterprise.0098_auto_20200629_1756... OK
  Applying enterprise.0099_auto_20200702_1537... OK
  Applying enterprise.0100_add_licensed_enterprise_course_enrollment... OK
  Applying enterprise.0101_move_data_to_saved_for_later... OK
  Applying enterprise.0102_auto_20200708_1615... OK
  Applying enterprise.0103_remove_marked_done... OK
  Applying enterprise.0104_sync_query_field... OK
  Applying enterprise.0105_add_branding_config_color_fields... OK
  Applying enterprise.0106_move_branding_config_colors... OK
  Applying enterprise.0107_remove_branding_config_banner_fields... OK
  Applying enterprise.0108_add_licensed_enrollment_is_revoked... OK
  Applying enterprise.0109_remove_use_enterprise_catalog_sample... OK
  Applying enterprise.0110_add_default_contract_discount... OK
  Applying enterprise.0111_pendingenterprisecustomeradminuser... OK
  Applying enterprise.0112_auto_20200914_0926... OK
  Applying enterprise.0113_auto_20200914_2054... OK
  Applying enterprise.0114_auto_20201020_0142... OK
  Applying enterprise.0115_enterpriseanalyticsuser_historicalenterpriseanalyticsuser... OK
  Applying enterprise.0116_auto_20201116_0400... OK
  Applying enterprise.0116_auto_20201208_1759... OK
  Applying enterprise.0117_auto_20201215_0258... OK
  Applying enterprise.unique_constraints_pending_users... OK
  Applying enterprise.0001_auto_20210111_1253... OK
  Applying enterprise.0120_systemwiderole_applies_to_all_contexts... OK
  Applying enterprise.0121_systemwiderole_add_ent_cust_field... OK
  Applying enterprise.0122_remove_field_sync_enterprise_catalog_query... OK
  Applying enterprise.0123_enterprisecustomeridentityprovider_default_provider... OK
  Applying enterprise.0124_auto_20210301_1309... OK
  Applying enterprise.0125_add_config_for_role_assign_backfill... OK
  Applying enterprise.0126_auto_20210308_1522... OK
  Applying enterprise.0127_enterprisecatalogquery_uuid... OK
  Applying enterprise.0128_enterprisecatalogquery_generate_uuids... OK
  Applying enterprise.0129_enterprisecatalogquery_uuid_unique... OK
  Applying enterprise.0130_lms_customer_lp_search_help_text... OK
  Applying enterprise.0131_auto_20210517_0924... OK
  Applying enterprise.0132_auto_20210608_1921... OK
  Applying enterprise.0133_auto_20210608_1931... OK
  Applying enterprise.0134_enterprisecustomerreportingconfiguration_enable_compression... OK
  Applying enterprise.0135_adminnotification_adminnotificationfilter_adminnotificationread... OK
  Applying enterprise.0136_auto_20210629_2129... OK
  Applying enterprise.0137_enrollment_email_update... OK
  Applying enterprise.0138_bulkcatalogqueryupdatecommandconfiguration... OK
  Applying enterprise.0139_auto_20210803_1854... OK
  Applying enterprise.0140_update_enrollment_sources... OK
  Applying enterprise.0141_make_enterprisecatalogquery_title_unique... OK
  Applying enterprise.0142_auto_20210907_2059... OK
  Applying enterprise.0143_auto_20210908_0559... OK
  Applying enterprise.0144_auto_20211011_1030... OK
  Applying enterprise.0145_auto_20211013_1018... OK
  Applying enterprise.0146_enterprise_customer_invite_key... OK
  Applying enterprise.0147_auto_20211129_1949... OK
  Applying enterprise.0148_auto_20211129_2114... OK
  Applying enterprise.0149_invite_key_required_default_expiry_backfill... OK
  Applying enterprise.0150_invite_key_expiry_required... OK
  Applying enterprise.0151_add_is_active_to_invite_key... OK
  Applying blackboard.0001_initial_squashed_0014_alter_blackboardlearnerassessmentdatatransmissionaudit_enterprise_course_enrollment_id... OK
  Applying blackboard.0002_auto_20220302_2231... OK
  Applying blackboard.0003_alter_blackboardlearnerdatatransmissionaudit_completed_timestamp... OK
  Applying blackboard.0004_auto_20220324_1550... OK
  Applying blackboard.0005_auto_20220325_1757... OK
  Applying blackboard.0006_auto_20220405_2311... OK
  Applying block_structure.0001_config... OK
  Applying block_structure.0002_blockstructuremodel... OK
  Applying block_structure.0003_blockstructuremodel_storage... OK
  Applying block_structure.0004_blockstructuremodel_usagekeywithrun... OK
  Applying block_structure.0005_trim_leading_slashes_in_data_path... OK
  Applying bookmarks.0001_initial... OK
  Applying branding.0001_initial... OK
  Applying course_modes.0001_initial... OK
  Applying course_modes.0002_coursemode_expiration_datetime_is_explicit... OK
  Applying course_modes.0003_auto_20151113_1443... OK
  Applying course_modes.0004_auto_20151113_1457... OK
  Applying course_modes.0005_auto_20151217_0958... OK
  Applying course_modes.0006_auto_20160208_1407... OK
  Applying course_modes.0007_coursemode_bulk_sku... OK
  Applying course_groups.0001_initial... OK
  Applying bulk_email.0001_initial... OK
  Applying bulk_email.0002_data__load_course_email_template...Installed 2 object(s) from 1 fixture(s)
 OK
  Applying bulk_email.0003_config_model_feature_flag... OK
  Applying bulk_email.0004_add_email_targets... OK
  Applying bulk_email.0005_move_target_data... OK
  Applying bulk_email.0006_course_mode_targets... OK
  Applying bulk_email.0007_disabledcourse... OK
  Applying courseware.0001_initial... OK
  Applying bulk_grades.0001_initial... OK
  Applying bulk_grades.0002_auto_20190703_1526... OK
  Applying bundles.0001_initial... OK
  Applying bundles.0002_create_drafts... OK
  Applying bundles.0003_update_character_set... OK
  Applying calendar_sync.0001_initial... OK
  Applying calendar_sync.0002_auto_20200709_1743... OK
  Applying canvas.0001_initial... OK
  Applying canvas.0002_auto_20200806_1632... OK
  Applying canvas.0003_delete_canvasglobalconfiguration... OK
  Applying canvas.0004_adding_learner_data_to_canvas... OK
  Applying canvas.0005_auto_20200909_1534... OK
  Applying canvas.0006_canvaslearnerassessmentdatatransmissionaudit... OK
  Applying canvas.0007_auto_20210222_2225... OK
  Applying canvas.0008_auto_20210707_0815... OK
  Applying canvas.0009_auto_20210708_1639... OK
  Applying canvas.0010_auto_20210909_1536... OK
  Applying canvas.0011_auto_20210923_1727... OK
  Applying canvas.0012_alter_canvasenterprisecustomerconfiguration_enterprise_customer... OK
  Applying canvas.0013_auto_20211221_1535... OK
  Applying canvas.0014_auto_20220126_1837... OK
  Applying canvas.0015_auto_20220127_1605... OK
  Applying canvas.0016_auto_20220131_1539... OK
  Applying canvas.0017_auto_20220302_2231... OK
  Applying canvas.0018_alter_canvaslearnerdatatransmissionaudit_completed_timestamp... OK
  Applying canvas.0019_auto_20220324_1550... OK
  Applying canvas.0020_auto_20220325_1757... OK
  Applying canvas.0021_auto_20220405_2311... OK
  Applying catalog.0001_initial... OK
  Applying catalog.0002_catalogintegration_username... OK
  Applying catalog.0003_catalogintegration_page_size... OK
  Applying catalog.0004_auto_20170616_0618... OK
  Applying catalog.0005_catalogintegration_long_term_cache_ttl... OK
  Applying celery_utils.0001_initial... OK
  Applying celery_utils.0002_chordable_django_backend... OK
  Applying certificates.0008_schema__remove_badges... OK
  Applying certificates.0009_certificategenerationcoursesetting_language_self_generation... OK
  Applying certificates.0010_certificatetemplate_language... OK
  Applying certificates.0011_certificatetemplate_alter_unique... OK
  Applying certificates.0012_certificategenerationcoursesetting_include_hours_of_effort... OK
  Applying certificates.0013_remove_certificategenerationcoursesetting_enabled... OK
  Applying certificates.0014_change_eligible_certs_manager... OK
  Applying certificates.0015_add_masters_choice... OK
  Applying certificates.0016_historicalgeneratedcertificate... OK
  Applying certificates.0017_add_mode_20201118_1725... OK
  Applying certificates.0018_historicalcertificateinvalidation... OK
  Applying certificates.0019_allowlistgenerationconfiguration... OK
  Applying certificates.0020_remove_existing_mgmt_cmd_args... OK
  Applying certificates.0021_remove_certificate_allowlist_duplicate_records... OK
  Applying certificates.0022_add_unique_constraints_to_certificatewhitelist_model... OK
  Applying certificates.0023_certificategenerationcommandconfiguration... OK
  Applying certificates.0024_delete_allowlistgenerationconfiguration... OK
  Applying certificates.0025_cleanup_certificate_errors... OK
  Applying certificates.0026_certificateallowlist... OK
  Applying certificates.0027_historicalcertificateallowlist... OK
  Applying certificates.0028_allowlist_data_20210615_2033... OK
  Applying certificates.0029_allowlist_created_20210623_1417... OK
  Applying certificates.0030_delete_certificatewhitelist... OK
  Applying certificates.0031_certificatedateoverride_historicalcertificatedateoverride... OK
  Applying certificates.0032_change_certificatedateoverride_date... OK
  Applying certificates.0033_auto_20220307_1100... OK
  Applying certificates.0034_auto_20220401_1213... OK
  Applying user_api.0001_initial... OK
  Applying user_api.0002_retirementstate_userretirementstatus... OK
  Applying commerce.0001_data__add_ecommerce_service_user... OK
  Applying commerce.0002_commerceconfiguration... OK
  Applying commerce.0003_auto_20160329_0709... OK
  Applying commerce.0004_auto_20160531_0950... OK
  Applying commerce.0005_commerceconfiguration_enable_automatic_refund_approval... OK
  Applying commerce.0006_auto_20170424_1734... OK
  Applying commerce.0007_auto_20180313_0609... OK
  Applying commerce.0008_auto_20191024_2048... OK
  Applying completion.0001_initial... OK
  Applying completion.0002_auto_20180125_1510... OK
  Applying completion.0003_learning_context... OK
  Applying consent.0001_initial... OK
  Applying consent.0002_migrate_to_new_data_sharing_consent... OK
  Applying consent.0003_historicaldatasharingconsent_history_change_reason... OK
  Applying consent.0004_datasharingconsenttextoverrides... OK
  Applying lti1p3_tool_config.0001_initial... OK
  Applying organizations.0001_squashed_0007_historicalorganization... OK
  Applying content_libraries.0001_initial... OK
  Applying content_libraries.0002_group_permissions... OK
  Applying content_libraries.0003_contentlibrary_type... OK
  Applying content_libraries.0004_contentlibrary_license... OK
  Applying content_libraries.0005_ltigradedresource_ltiprofile... OK
  Applying content_libraries.0006_auto_20210615_1916... OK
  Applying content_libraries.0005_contentlibraryblockimporttask... OK
  Applying content_libraries.0007_merge_20210818_0614... OK
  Applying content_libraries.0008_auto_20210818_2148... OK
  Applying course_overviews.0001_initial... OK
  Applying course_overviews.0002_add_course_catalog_fields... OK
  Applying course_overviews.0003_courseoverviewgeneratedhistory... OK
  Applying course_overviews.0004_courseoverview_org... OK
  Applying course_overviews.0005_delete_courseoverviewgeneratedhistory... OK
  Applying course_overviews.0006_courseoverviewimageset... OK
  Applying course_overviews.0007_courseoverviewimageconfig... OK
  Applying course_overviews.0008_remove_courseoverview_facebook_url... OK
  Applying course_overviews.0009_readd_facebook_url... OK
  Applying course_overviews.0010_auto_20160329_2317... OK
  Applying course_overviews.0011_courseoverview_marketing_url... OK
  Applying course_overviews.0012_courseoverview_eligible_for_financial_aid... OK
  Applying course_overviews.0013_courseoverview_language... OK
  Applying course_overviews.0014_courseoverview_certificate_available_date... OK
  Applying content_type_gating.0001_initial... OK
  Applying content_type_gating.0002_auto_20181119_0959... OK
  Applying content_type_gating.0003_auto_20181128_1407... OK
  Applying content_type_gating.0004_auto_20181128_1521... OK
  Applying content_type_gating.0005_auto_20190306_1547... OK
  Applying content_type_gating.0006_auto_20190308_1447... OK
  Applying content_type_gating.0007_auto_20190311_1919... OK
  Applying content_type_gating.0008_auto_20190313_1634... OK
  Applying contentserver.0001_initial... OK
  Applying contentserver.0002_cdnuseragentsconfig... OK
  Applying cornerstone.0001_initial... OK
  Applying cornerstone.0002_cornerstoneglobalconfiguration_subject_mapping... OK
  Applying cornerstone.0003_auto_20190621_1000... OK
  Applying cornerstone.0004_cornerstoneglobalconfiguration_languages... OK
  Applying cornerstone.0005_auto_20190925_0730... OK
  Applying cornerstone.0006_auto_20191001_0742... OK
  Applying cornerstone.0007_auto_20210708_1446... OK
  Applying cornerstone.0008_auto_20210909_1536... OK
  Applying cornerstone.0009_auto_20210923_1727... OK
  Applying cornerstone.0010_cornerstonecoursekey... OK
  Applying cornerstone.0011_auto_20211103_1855... OK
  Applying cornerstone.0012_alter_cornerstoneenterprisecustomerconfiguration_enterprise_customer... OK
  Applying cornerstone.0013_auto_20220126_1837... OK
  Applying cornerstone.0014_auto_20220131_1539... OK
  Applying cornerstone.0015_auto_20220302_2231... OK
  Applying cornerstone.0016_auto_20220324_1550... OK
  Applying cornerstone.0017_alter_cornerstonelearnerdatatransmissionaudit_course_completed... OK
  Applying cornerstone.0018_auto_20220325_1757... OK
  Applying cornerstone.0019_auto_20220405_2311... OK
  Applying cors_csrf.0001_initial... OK
  Applying course_action_state.0001_initial... OK
  Applying course_apps.0001_initial... OK
  Applying course_overviews.0015_historicalcourseoverview... OK
  Applying course_overviews.0016_simulatecoursepublishconfig... OK
  Applying course_overviews.0017_auto_20191002_0823... OK
  Applying course_overviews.0018_add_start_end_in_CourseOverview... OK
  Applying course_overviews.0019_improve_courseoverviewtab... OK
  Applying course_date_signals.0001_initial... OK
  Applying course_duration_limits.0001_initial... OK
  Applying course_duration_limits.0002_auto_20181119_0959... OK
  Applying course_duration_limits.0003_auto_20181128_1407... OK
  Applying course_duration_limits.0004_auto_20181128_1521... OK
  Applying course_duration_limits.0005_auto_20190306_1546... OK
  Applying course_duration_limits.0006_auto_20190308_1447... OK
  Applying course_duration_limits.0007_auto_20190311_1919... OK
  Applying course_duration_limits.0008_auto_20190313_1634... OK
  Applying course_goals.0001_initial... OK
  Applying course_goals.0002_auto_20171010_1129... OK
  Applying course_goals.0003_historicalcoursegoal... OK
  Applying course_goals.0004_auto_20210806_0137... OK
  Applying course_goals.0005_useractivity... OK
  Applying course_goals.0006_add_unsubscribe_token... OK
  Applying course_goals.0007_set_unsubscribe_token_default... OK
  Applying course_goals.0008_coursegoalreminderstatus... OK
  Applying course_groups.0002_change_inline_default_cohort_value... OK
  Applying course_groups.0003_auto_20170609_1455... OK
  Applying course_overviews.0020_courseoverviewtab_url_slug... OK
  Applying course_overviews.0021_courseoverviewtab_link... OK
  Applying course_overviews.0022_courseoverviewtab_is_hidden... OK
  Applying course_overviews.0023_courseoverview_banner_image_url... OK
  Applying course_overviews.0024_overview_adds_has_highlights... OK
  Applying course_home_api.0001_initial... OK
  Applying lti_consumer.0001_initial... OK
  Applying lti_consumer.0002_ltiagslineitem... OK
  Applying lti_consumer.0003_ltiagsscore... OK
  Applying lti_consumer.0004_keyset_mgmt_to_model... OK
  Applying lti_consumer.0005_migrate_keyset_to_model... OK
  Applying lti_consumer.0006_add_on_model_config_for_lti_1p1... OK
  Applying lti_consumer.0007_ltidlcontentitem... OK
  Applying lti_consumer.0008_fix_uuid_backfill... OK
  Applying lti_consumer.0009_backfill-empty-string-config-id... OK
  Applying lti_consumer.0010_backfill-empty-string-lti-config... OK
  Applying lti_consumer.0011_courseeditltifieldsenabledflag... OK
  Applying lti_consumer.0012_rename_courseeditltifieldsenabledflag_model... OK
  Applying lti_consumer.0013_auto_20210712_1352... OK
  Applying course_live.0001_initial... OK
  Applying course_modes.0008_course_key_field_to_foreign_key... OK
  Applying course_modes.0009_suggested_prices_to_charfield... OK
  Applying course_modes.0010_archived_suggested_prices_to_charfield... OK
  Applying course_modes.0011_change_regex_for_comma_separated_ints... OK
  Applying course_modes.0012_historicalcoursemode... OK
  Applying course_modes.0013_auto_20200115_2022... OK
  Applying course_overviews.0025_auto_20210702_1602... OK
  Applying course_overviews.0026_courseoverview_entrance_exam... OK
  Applying courseware.0002_coursedynamicupgradedeadlineconfiguration_dynamicupgradedeadlineconfiguration... OK
  Applying courseware.0003_auto_20170825_0935... OK
  Applying courseware.0004_auto_20171010_1639... OK
  Applying courseware.0005_orgdynamicupgradedeadlineconfiguration... OK
</pre>
</details>

## Testing instructions

1. Proofread
2. Create a cluster with and gather a connection string starting with `mongodb+srv`
3. Initiate a new deployment using the `mongodb+srv` connection string as mongodb schema