### PR TITLE
fix: update problem with hint according newer python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 -->
 
 ## Unreleased
+- [Fix] Update problem with hint template so it works with newer python versions. (by @mariajgrimaldi)
 - [Feature] Add default PYTHONBREAKPOINT to openedx/Dockerfile (by @Carlos-Muniz)
 
 - [Bugfix] Fix smtp server port in `cms.yml` which was causing email sending failures in the Studio. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -50,6 +50,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Fix broken "Pages" view in Studio
 # https://github.com/openedx/edx-platform/pull/30550
 RUN curl -fsSL https://github.com/open-craft/edx-platform/commit/3d54f284f82b61e693ad652d8d6e46a226fcb36d.patch | git am
+# fix: add () to print statement so problem with hint template works in newer versions
+# https://github.com/openedx/edx-platform/pull/30585
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/468036b3085adbe77a2dbb4a1c3bd88ab831f7b0.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
**Description**
This PR adds a commit that updates the problem with hint template so it works with newer python versions.

**Discussions**
https://github.com/openedx/edx-platform/pull/30570#issuecomment-1156420335

**How to test**
Refer to this [PR](https://github.com/openedx/edx-platform/pull/30585) for the testing instructions.