### PR TITLE
fix: build openedx-dev image when host user is root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 -->
 
 ## Unreleased
+
+- [Bugfix] Build openedx-dev Docker image even when the host user is root, for instance on Windows. (by @regisb)
 - [Bugfix] Patch nutmeg.1 release with [LTI 1.3 fix](https://github.com/openedx/edx-platform/pull/30716). (by @ormsbee)
 - [Improvement] Make it possible to override k8s resources in plugins using `k8s-override` patch. (by @foadlind)
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -140,7 +140,9 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 # From then on, run as unprivileged "app" user
+# Note that this must always be different from root (APP_USER_ID=0)
 ARG APP_USER_ID=1000
+RUN if [ "$APP_USER_ID" = 0 ]; then echo "app user may not be root" && false; fi
 RUN useradd --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -7,7 +7,8 @@ x-openedx-service:
     context: ../build/openedx/
     target: development
     args:
-      APP_USER_ID: "{{ HOST_USER_ID }}"
+      # Note that we never build the openedx-dev image with root user ID, as it would simply fail.
+      APP_USER_ID: "{{ HOST_USER_ID or 1000 }}"
   stdin_open: true
   tty: true
   volumes:


### PR DESCRIPTION
Sometimes, the host user is root: this may happen when tutor is run with
"sudo" (which is not recommended) or on Windows. In such cases, building
the image should not fail, but default to a reasonable user. Also, when
we pass an invalid APP_USER_ID as a build arg, then we should fail with
an explicit message.

See this conversation:
https://discuss.overhang.io/t/problem-with-dev-image-build-useradd-uid-0-is-not-unique/2406