### PR TITLE
fix: apply LTI 1.3 XBlock patch fix 3.4.7 over nutmeg.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 -->
 
 ## Unreleased
+- [Bugfix] Patch nutmeg.1 release with [LTI 1.3 fix](https://github.com/openedx/edx-platform/pull/30716). (by @ormsbee)
 - [Improvement] Make it possible to override k8s resources in plugins using `k8s-override` patch. (by @foadlind)
 
 ## v14.0.2 (2022-06-27)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -53,6 +53,9 @@ RUN curl -fsSL https://github.com/open-craft/edx-platform/commit/3d54f284f82b61e
 # fix: add () to print statement so problem with hint template works in newer versions
 # https://github.com/openedx/edx-platform/pull/30585
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/468036b3085adbe77a2dbb4a1c3bd88ab831f7b0.patch | git am
+# Fix LTI 1.3 Names & Roles and Grades conflict with DarkLangMiddleware
+# https://github.com/openedx/edx-platform/pull/30716
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/531bc54833dc97244b408f9f443d2b036f474f0d.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
The actual merge of this into open-release/nutmeg.master is here:
  https://github.com/openedx/edx-platform/pull/30716