### PR TITLE
docs: update test-running guide with new top-level xmodule package

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -283,6 +283,7 @@ Then, run unit tests with ``pytest`` commands::
     export EDXAPP_TEST_MONGO_HOST=mongodb
     pytest common
     pytest openedx
+    pytest xmodule
 
     # Run tests on LMS
     export DJANGO_SETTINGS_MODULE=lms.envs.tutor.test


### PR DESCRIPTION
edx-platform's ./common/lib/xmodule/xmodule folder has been moved to
./xmodule. The test-running instructions needed to be updated in order
to account for this new top-level folder.

For context on the edx-platform change, see:
https://discuss.openedx.org/t/breaking-apart-edx-platforms-common-lib-folder