### PR TITLE
Fix: Issue 702: tutor k8s start fails with no PatchStrategicMerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Bugfix] The `tutor k8s start` command will succeed even when `k8s-override` and `kustomization-patches-strategic-merge` are not specified. (by @edazzocaisser)
 
 ## v14.0.3 (2022-07-09)
 

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -59,7 +59,7 @@ configMapGenerator:
         app.kubernetes.io/name: redis
 {{ patch("kustomization-configmapgenerator") }}
 
-{%- if patch("k8s-override") || patch("kustomization-patches-strategic-merge") %}
+{%- if patch("k8s-override") or patch("kustomization-patches-strategic-merge") %}
 patchesStrategicMerge:
 {%- if patch("k8s-override") %}
 - k8s/override.yml

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -59,8 +59,12 @@ configMapGenerator:
         app.kubernetes.io/name: redis
 {{ patch("kustomization-configmapgenerator") }}
 
+{%- if patch("k8s-override") || patch("kustomization-patches-strategic-merge") %}
 patchesStrategicMerge:
+{%- if patch("k8s-override") %}
 - k8s/override.yml
+{%- endif %}
 {{ patch("kustomization-patches-strategic-merge") }}
+{%- endif %}
 
 {{ patch("kustomization") }}


### PR DESCRIPTION
Fix: tutor k8s start will succeed when `k8s-override` and `kustomization-patches-strategic-merge` aren't specified.

https://github.com/overhangio/tutor/issues/704

Starting with version 14.0.2, every time we tried to run `tutor k8s start`, we would receive the following error:

```
Run tutor k8s start
kubectl get namespaces openedx-prod
NAME           STATUS   AGE
openedx-prod   Active   49d
Namespace already exists: skipping creation.
kubectl apply --kustomize /home/runner/.local/share/tutor/env --wait --selector app.kubernetes.io/component=volume
error: trouble configuring builtin PatchStrategicMergeTransformer with config: `
paths:
- k8s/override.yml
`: patch appears to be empty; files=[k8s/override.yml], Patch=
Error: Command failed with status 1: kubectl apply --kustomize /home/runner/.local/share/tutor/env --wait --selector app.kubernetes.io/component=volume
Error: Process completed with exit code 1.
```

Since we don't specify a `k8s-override` resulting in an empty `k8s/override.yml`, which is unsupported by kustomize. No `kustomization-patches-strategic-merge` also results in an empty `patchesStrategicMerge`.

I opened an issue for this bug, but since it seemed like a straightforward fix, I just made the changes. 