### PR TITLE
fix: accurately log shell commands when running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Bugfix] Log the shell commands that Tutor executes more accurately. (by @kdmccormick)
 - [Fix] `tutor dev quickstart` would fail under certain versions of docker-compose due to a bug in the logic that handled volume mounting. (by @kdmccormick)
 - [Bugfix] The `tutor k8s start` command will succeed even when `k8s-override` and `kustomization-patches-strategic-merge` are not specified. (by @edazzocaisser)
 

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -202,7 +202,7 @@ def is_a_tty() -> bool:
 
 
 def execute(*command: str) -> int:
-    click.echo(fmt.command(shlex.join(command)))
+    click.echo(fmt.command(_shlex_join(*command)))
     with subprocess.Popen(command) as p:
         try:
             result = p.wait(timeout=None)
@@ -219,6 +219,19 @@ def execute(*command: str) -> int:
                 f"Command failed with status {result}: {' '.join(command)}"
             )
     return result
+
+
+def _shlex_join(*split_command: str) -> str:
+    """
+    Return a shell-escaped string from *split_command.
+
+    TODO: REMOVE THIS FUNCTION AFTER 2023-06-27.
+      This function is a shim for the ``shlex.join`` standard library function,
+      which becomes available in Python 3.8  The end-of-life date for Python 3.7
+      is in Jan 2023 (https://endoflife.date/python). After that point, it
+      would be good to delete this function and just use Py3.8's ``shlex.join``.
+    """
+    return " ".join(shlex.quote(arg) for arg in split_command)
 
 
 def check_output(*command: str) -> bytes:

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 import json
 import os
 import random
+import shlex
 import shutil
 import string
 import struct
@@ -201,7 +202,7 @@ def is_a_tty() -> bool:
 
 
 def execute(*command: str) -> int:
-    click.echo(fmt.command(" ".join(command)))
+    click.echo(fmt.command(shlex.join(command)))
     with subprocess.Popen(command) as p:
         try:
             result = p.wait(timeout=None)


### PR DESCRIPTION
Whenever Tutor executes a shell command, it logs out said
command in order to aid in end user understanding/debugging.

In some cases (notably, when running jobs in containers)
the logged command was not accurately quoted. The command
was run correctly, because it was passed in pieces to
``subprocess.Popen``, which correctly joins the pieces together
into a valid POSIX shell command; however, the logged version
of the command was constructed by simply joining the pieces
with spaces. This usually works, but breaks down when running
complex shell commands with nested quoting.

This commit changes the logging to use ``shlex.join``, which
joins command pieces together in a POSIX-compliant way,
presumably the same way as ``subprocess.Popen``.

Example:

    tutor local importdemocourse

runs the shell command:

    docker-compose -f /home/kyle/.local/share/tutor/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.prod.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.tmp.yml --project-name tutor_local -f /home/kyle/.local/share/tutor/env/local/docker-compose.jobs.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.jobs.tmp.yml run --rm cms-job sh -e -c 'echo "Loading settings $DJANGO_SE... (several more script lines) ...eindex_course --all --setup'

but the logged shell command was:

    docker-compose -f /home/kyle/.local/share/tutor/env/local/docker-compose.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.prod.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.tmp.yml --project-name tutor_local -f /home/kyle/.local/share/tutor/env/local/docker-compose.jobs.yml -f /home/kyle/.local/share/tutor/env/local/docker-compose.jobs.tmp.yml run --rm cms-job sh -e -c echo "Loading settings $DJANGO_SE... (several more script lines) ...eindex_course --all --setup

which will not run if copied and pasted back into the
user's terminal, as the importdemocourse shell script is unquoted.