### PR TITLE
fix: k8s wait for deployments instead of pods to determine readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 - [Fix] `tutor dev quickstart` would fail under certain versions of docker-compose due to a bug in the logic that handled volume mounting. (by @kdmccormick)
 - [Bugfix] The `tutor k8s start` command will succeed even when `k8s-override` and `kustomization-patches-strategic-merge` are not specified. (by @edazzocaisser)
+- [Fix] `kubectl wait` checks deployments instead of pods as it could hang indefinitely if there are extra pods in a broken state. (by @keithgg)
 
 ## v14.0.3 (2022-07-09)
 

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -332,10 +332,10 @@ def delete(context: K8sContext, yes: bool) -> None:
 def init(context: K8sContext, limit: Optional[str]) -> None:
     config = tutor_config.load(context.root)
     runner = context.job_runner(config)
-    wait_for_pod_ready(config, "caddy")
+    wait_for_deployment_ready(config, "caddy")
     for name in ["elasticsearch", "mysql", "mongodb"]:
         if tutor_config.is_service_activated(config, name):
-            wait_for_pod_ready(config, name)
+            wait_for_deployment_ready(config, name)
     jobs.initialise(runner, limit_to=limit)
 
 
@@ -458,7 +458,7 @@ def logs(
 @click.pass_obj
 def wait(context: K8sContext, name: str) -> None:
     config = tutor_config.load(context.root)
-    wait_for_pod_ready(config, name)
+    wait_for_deployment_ready(config, name)
 
 
 @click.command(
@@ -536,14 +536,14 @@ def kubectl_exec(config: Config, service: str, command: List[str]) -> int:
     )
 
 
-def wait_for_pod_ready(config: Config, service: str) -> None:
-    fmt.echo_info(f"Waiting for a {service} pod to be ready...")
+def wait_for_deployment_ready(config: Config, service: str) -> None:
+    fmt.echo_info(f"Waiting for a {service} deployment to be ready...")
     utils.kubectl(
         "wait",
         *resource_selector(config, f"app.kubernetes.io/name={service}"),
-        "--for=condition=ContainersReady",
+        "--for=condition=Available=True",
         "--timeout=600s",
-        "pod",
+        "deployment",
     )
 
 

--- a/tutor/commands/upgrade/k8s.py
+++ b/tutor/commands/upgrade/k8s.py
@@ -120,7 +120,7 @@ def upgrade_from_maple(context: Context, config: Config) -> None:
         "--selector",
         "app.kubernetes.io/name=mysql",
     )
-    k8s.wait_for_pod_ready(config, "mysql")
+    k8s.wait_for_deployment_ready(config, "mysql")
 
     # lms upgrade
     k8s.kubectl_apply(
@@ -128,7 +128,7 @@ def upgrade_from_maple(context: Context, config: Config) -> None:
         "--selector",
         "app.kubernetes.io/name=lms",
     )
-    k8s.wait_for_pod_ready(config, "lms")
+    k8s.wait_for_deployment_ready(config, "lms")
 
     # Command backpopulate_user_tours
     k8s.kubectl_exec(
@@ -144,7 +144,7 @@ def upgrade_from_maple(context: Context, config: Config) -> None:
         "--selector",
         "app.kubernetes.io/name=cms",
     )
-    k8s.wait_for_pod_ready(config, "cms")
+    k8s.wait_for_deployment_ready(config, "cms")
 
     # Command backfill_course_tabs
     k8s.kubectl_exec(


### PR DESCRIPTION
## Description

Currently tutor waits for k8s pods to be ready by running the `kubectl wait` command like this:

`kubectl wait --namespace openedx --selector=app.kubernetes.io/name=elasticsearch --for=condition=ContainersReady --timeout=600s pod`

This works for the most part, however it fails if there are existing pods not in the correct state.

For example, if a the Elastic Search pod is Evicted, you can end up with a pod list that looks list this if the nodes were experiencing memory pressure.

```
elasticsearch-78dcff9c9d-69lqp   0/1     Evicted     0          13h
elasticsearch-78dcff9c9d-clp66   0/1     OOMKilled   0          16h
elasticsearch-78dcff9c9d-g28bp   0/1     Evicted     0          13h
elasticsearch-78dcff9c9d-hngsd   1/1     Running     0          13h
elasticsearch-78dcff9c9d-jx2n7   0/1     Evicted     0          13h
elasticsearch-78dcff9c9d-nfc4f   0/1     Evicted     0          13h
elasticsearch-78dcff9c9d-pth9t   0/1     Evicted     0          13h
```

Even though there is still valid running pod, the `kubectl wait` condition will fail and time out, resulting in a failed deploy.

Instead of waiting for pods, I propose instead we should wait for `deployments` as they become `Available` as soon as the pods are ready. So far, I've found that it fixes the above issue with no downside.

## Testing instructions

### Verify that everything works normally

Run `tutor k8s quickstart`. The behaviour should be unchanged except `kubectl wait` command mentioning deployments instead of pods.

### Verify the fix

I haven't quite figured out the best way to create extra pods in a "broken" state so this is the best I can do.

We start 20 replicas of the elasticsearch pod and then almost immediately scale down to 1. If you get the pods list (`kubectl get pods -nopenedx`) it'll show a bunch of pods in the `Terminating` state.

- `kubectl scale deployment elasticsearch -nopenedx --replicas=20; sleep 1; kubectl scale deployment elasticsearch -nopenedx --replicas=1`: Create ElasticSearch pods where almost all will be in `Terminating` status
- `kubectl wait --namespace openedx --selector=app.kubernetes.io/name=elasticsearch --for=condition=Available=True --timeout=600s deployment` Will exit immediately as there will be 1 instance corresponding to the number required for the deployment.
- `kubectl wait --namespace openedx --selector=app.kubernetes.io/name=elasticsearch --for=condition=ContainersReady --timeout=600s pod` will not until the other pods are terminated.

## Other
- I've included the changes made in #705 in this PR for easier testing, I'll remove them if approved.