### PR TITLE
build: run a subset of test suite under Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,25 @@ on:
     branches: [ master, nightly ]
 
 jobs:
-  tests:
+  # Run a subset of the test suite using the oldest-supported Python version.
+  tests-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip setuptools==44.0.0
+      - name: Install dependencies
+        run: pip install -r requirements/dev.txt
+      - name: Static code analysis
+        run: make test-lint
+      - name: Python unit tests
+        run: make test-unit
+  # Run the full test suite using the preferred version of Python.
+  tests-latest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

This PR changes the CI suite to run `make test-lint` and `make test-unit` for both the oldest-supported (3.7) and latest-supported (3.9) Python versions.

We still only run the remaining tests on the latest-supported version (3.9):

* `test-format`, `test-docs`, and `test-pythonpackage`, because end users will not care whether these work on 3.7.
* `test-types`, because type annotations in 3.7 are missing a lot helpful features.

## Example

With this change, [`shlex.join`'s incompatibility with 3.7](https://github.com/overhangio/tutor/pull/708#discussion_r928912499) would have been caught by CI:

![image](https://user-images.githubusercontent.com/3628148/180820473-5866bf0c-8bac-42e7-b20a-2a21aa4ee97c.png)
