### PR TITLE
fix: bind-mount in dev-specific services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Bugfix] Fix `tutor dev start -m /path/to/frontend-app-learning` by introducing dev-specific `COMPOSE_DEV_TMP` and `COMPOSE_DEV_JOBS_TMP` filters (by @regisb).
 - [Bugfix] Log the shell commands that Tutor executes more accurately. (by @kdmccormick)
-- [Fix] `tutor dev quickstart` would fail under certain versions of docker-compose due to a bug in the logic that handled volume mounting. (by @kdmccormick)
+- [Bugfix] `tutor dev quickstart` would fail under certain versions of docker-compose due to a bug in the logic that handled volume mounting. (by @kdmccormick)
 - [Bugfix] The `tutor k8s start` command will succeed even when `k8s-override` and `kustomization-patches-strategic-merge` are not specified. (by @edazzocaisser)
-- [Fix] `kubectl wait` checks deployments instead of pods as it could hang indefinitely if there are extra pods in a broken state. (by @keithgg)
+- [BugFix] `kubectl wait` checks deployments instead of pods as it could hang indefinitely if there are extra pods in a broken state. (by @keithgg)
 
 ## v14.0.3 (2022-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Feature] Add the `-m/--mount` option to `tutor dev quickstart`.
 - [Bugfix] Fix `tutor dev start -m /path/to/frontend-app-learning` by introducing dev-specific `COMPOSE_DEV_TMP` and `COMPOSE_DEV_JOBS_TMP` filters (by @regisb).
 - [Bugfix] Log the shell commands that Tutor executes more accurately. (by @kdmccormick)
 - [Bugfix] `tutor dev quickstart` would fail under certain versions of docker-compose due to a bug in the logic that handled volume mounting. (by @kdmccormick)

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -18,29 +18,39 @@ class DevJobRunner(compose.ComposeJobRunner):
         """
         super().__init__(root, config)
         self.project_name = get_typed(self.config, "DEV_PROJECT_NAME", str)
-        self.docker_compose_tmp_path = tutor_env.pathjoin(
+        docker_compose_tmp_path = tutor_env.pathjoin(
             self.root, "dev", "docker-compose.tmp.yml"
         )
-        self.docker_compose_jobs_tmp_path = tutor_env.pathjoin(
+        docker_compose_jobs_tmp_path = tutor_env.pathjoin(
             self.root, "dev", "docker-compose.jobs.tmp.yml"
         )
         self.docker_compose_files += [
             tutor_env.pathjoin(self.root, "local", "docker-compose.yml"),
             tutor_env.pathjoin(self.root, "dev", "docker-compose.yml"),
-            self.docker_compose_tmp_path,
+            docker_compose_tmp_path,
             tutor_env.pathjoin(self.root, "local", "docker-compose.override.yml"),
             tutor_env.pathjoin(self.root, "dev", "docker-compose.override.yml"),
         ]
         self.docker_compose_job_files += [
             tutor_env.pathjoin(self.root, "local", "docker-compose.jobs.yml"),
             tutor_env.pathjoin(self.root, "dev", "docker-compose.jobs.yml"),
-            self.docker_compose_jobs_tmp_path,
+            docker_compose_jobs_tmp_path,
             tutor_env.pathjoin(self.root, "local", "docker-compose.jobs.override.yml"),
             tutor_env.pathjoin(self.root, "dev", "docker-compose.jobs.override.yml"),
         ]
+        # Update docker-compose.tmp files
+        self.update_docker_compose_tmp(
+            hooks.Filters.COMPOSE_DEV_TMP,
+            hooks.Filters.COMPOSE_DEV_JOBS_TMP,
+            docker_compose_tmp_path,
+            docker_compose_jobs_tmp_path,
+        )
 
 
 class DevContext(compose.BaseComposeContext):
+    COMPOSE_TMP_FILTER = hooks.Filters.COMPOSE_DEV_TMP
+    COMPOSE_JOBS_TMP_FILTER = hooks.Filters.COMPOSE_DEV_JOBS_TMP
+
     def job_runner(self, config: Config) -> DevJobRunner:
         return DevJobRunner(self.root, config)
 

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -64,8 +64,15 @@ def dev(context: click.Context) -> None:
 @click.command(help="Configure and run Open edX from scratch, for development")
 @click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
 @click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
+@compose.mount_option
 @click.pass_context
-def quickstart(context: click.Context, non_interactive: bool, pullimages: bool) -> None:
+def quickstart(
+    context: click.Context,
+    non_interactive: bool,
+    pullimages: bool,
+    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
+) -> None:
+    compose.mount_tmp_volumes(mounts, context.obj)
     try:
         utils.check_macos_docker_memory()
     except exceptions.TutorError as e:

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -121,6 +121,12 @@ class Filters:
     #: :parameter list[tuple[str, tuple[str, ...]]] tasks: list of ``(service, path)`` tasks. (see :py:data:`COMMANDS_INIT`).
     COMMANDS_PRE_INIT = filters.get("commands:pre-init")
 
+    #: Same as :py:data:`COMPOSE_LOCAL_TMP` but for the development environment.
+    COMPOSE_DEV_TMP = filters.get("compose:dev:tmp")
+
+    #: Same as :py:data:`COMPOSE_LOCAL_JOBS_TMP` but for the development environment.
+    COMPOSE_DEV_JOBS_TMP = filters.get("compose:dev-jobs:tmp")
+
     #: List of folders to bind-mount in docker-compose containers, either in ``tutor local`` or ``tutor dev``.
     #:
     #: Many ``tutor local`` and ``tutor dev`` commands support ``--mounts`` options
@@ -359,7 +365,3 @@ class Contexts:
 
     #: Python entrypoint plugins will be installed within this context.
     PLUGINS_V0_ENTRYPOINT = contexts.Context("plugins:v0:entrypoint")
-
-    #: Docker Compose volumes added via the CLI's ``--mount`` option will
-    #: be installed within this context.
-    COMPOSE_CLI_MOUNTS = contexts.Context("compose:cli:mounts")

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -1,5 +1,4 @@
 import base64
-from functools import lru_cache
 import json
 import os
 import random
@@ -9,6 +8,7 @@ import string
 import struct
 import subprocess
 import sys
+from functools import lru_cache
 from typing import List, Tuple
 
 import click


### PR DESCRIPTION
The -m/--mount option makes it possible to bind-mount volumes at runtime. The
volumes are declared in a local/docker-compose.tmp.yml file. The problem with
this approach is when we want to bind-mount a volume to a service which is
specific to the dev context. For instance: the "learning" service when the MFE
plugin is enabled.

In such a case, starting the service triggers a call to `docker-compose stop`
in the local context. This call fails because the "learning" service does not
exist in the local context. Note that this issue only seems to occur with
docker-compose v1.

To resolve this issue, we create two additional filters for
the dev context, which emulate the behaviour of the local context. With this approach, we convert the -m/--mount arguments right after they are parsed. Because they are parsed just once, we can get rid of the de-duplication logic initially introduced with the COMPOSE_CLI_MOUNTS context.

Close #711. Close also https://github.com/overhangio/tutor-mfe/issues/57.