### PR TITLE
feat: upgrade i18n openedx strings to nutmeg.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Feature] Upgrade edx-platform i18n strings to nutmeg.2 (by @regisb).
+
 ## v14.0.5 (2022-08-29)
 
-- [Bugfix] Fix MongoDB replica set connection error resulting from edx-platform's pymongo (3.10.1 -> 3.12.3) upgrade ([edx-platform#30569](https://github.com/openedx/edx-platform/pull/30569)). (by @ormsbee)
+- [Bugfix] Fix MongoDB replica set connection error resulting from edx-platform's pymongo (3.10.1 -> 3.12.3) upgrade ([edx-platform#30569](https://github.com/openedx/edx-platform/pull/30569)) (by @ormsbee).
 - [Feature] Upgrade all applications to open-release/nutmeg.2 (@BbrSofiane).
 
 ## v14.0.4 (2022-07-29)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -57,11 +57,7 @@ RUN curl -fsSL https://github.com/open-craft/edx-platform/commit/3d54f284f82b61e
 
 ###### Download extra locales to /openedx/locale/contrib/locale
 FROM minimal as locales
-# TODO Due to a bug in the transifex generation process, we cannot pull the translation
-# strings from nutmeg.1. We'll be able to pull them once they have been pushed to
-# Transifex.
-# ARG OPENEDX_I18N_VERSION={{ OPENEDX_COMMON_VERSION }}
-ARG OPENEDX_I18N_VERSION=open-release/nutmeg.master
+ARG OPENEDX_I18N_VERSION={{ OPENEDX_COMMON_VERSION }}
 RUN cd /tmp \
     && curl -L -o openedx-i18n.tar.gz https://github.com/openedx/openedx-i18n/archive/$OPENEDX_I18N_VERSION.tar.gz \
     && tar xzf /tmp/openedx-i18n.tar.gz \


### PR DESCRIPTION
Strings could not be pulled from transifex because the file names were
incorrect. This is now fixed and we are now able to pull the i18n strings from
the nutmeg.2 tag.