### PR TITLE
feat: remove the implementation of dev runserver

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -9,6 +9,7 @@ When backporting changes to master, we should keep only the entries that corresp
 facing changes.
 -->
 
+- 💥[Improvement] Remove the implementation of tutor dev runserver. (by @Carlos-Muniz)
 - [Bugfix] Fix MongoDB replica set connection error resulting from edx-platform's pymongo (3.10.1 -> 3.12.3) upgrade ([edx-platform#30569](https://github.com/openedx/edx-platform/pull/30569)). (by @ormsbee)
 - [Improvement] For Tutor Nightly (and only Nightly), official plugins are now installed from their nightly branches on GitHub instead of a version range on PyPI. This will allow Nightly users to install all official plugins by running ``pip install -e ".[full]"``.
 - [Bugfix] Remove edX references from bulk emails ([issue](https://github.com/openedx/build-test-release-wg/issues/100)).

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -120,37 +120,6 @@ Your Open edX platform is ready and can be accessed at the following urls:
     )
 
 
-@click.command(
-    help="DEPRECATED: Use 'tutor dev start ...' instead!",
-    context_settings={"ignore_unknown_options": True},
-)
-@compose.mount_option
-@click.argument("options", nargs=-1, required=False)
-@click.argument("service")
-@click.pass_context
-def runserver(
-    context: click.Context,
-    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
-    options: t.List[str],
-    service: str,
-) -> None:
-    depr_warning = "'runserver' is deprecated and will be removed in a future release. Use 'start' instead."
-    for option in options:
-        if option.startswith("-v") or option.startswith("--volume"):
-            depr_warning += " Bind-mounts can be specified using '-m/--mount'."
-            break
-    fmt.echo_alert(depr_warning)
-    config = tutor_config.load(context.obj.root)
-    if service in ["lms", "cms"]:
-        port = 8000 if service == "lms" else 8001
-        host = config["LMS_HOST"] if service == "lms" else config["CMS_HOST"]
-        fmt.echo_info(
-            f"The {service} service will be available at http://{host}:{port}"
-        )
-    args = ["--service-ports", *options, service]
-    context.invoke(compose.run, mounts=mounts, args=args)
-
-
 @hooks.Actions.COMPOSE_PROJECT_STARTED.add()
 def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
     """
@@ -163,5 +132,4 @@ def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
 
 
 dev.add_command(quickstart)
-dev.add_command(runserver)
 compose.add_commands(dev)


### PR DESCRIPTION
This PR was [originally authored](https://github.com/overhangio/tutor/pull/710) by @Carlos-Muniz. I'm re-opening it against the nightly branch so that this breaking change goes out along with the Olive release.

___________________

This PR removes the implementation of `tutor dev runserve`r. It is being removed in favor of using `tutor dev start`.

This PR should be merged last after each of the following have been merged:

* https://github.com/overhangio/tutor-ecommerce/pull/31
* https://github.com/overhangio/tutor-forum/pull/8
* https://github.com/overhangio/tutor-notes/pull/13
* https://github.com/overhangio/tutor-xqueue/pull/9

Closes https://github.com/overhangio/2u-tutor-adoption/issues/26