### PR TITLE
depr: richie plugin is no longer official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- 💥[Improvement] The Richie plugin was transferred to the Openfun organization; thus, it is no longer officially supported and it is removed from the default set of plugins that ships with `pip install tutor[full]` or the Tutor pre-compiled binary. Users are encouraged to uninstall the `tutor-richie` Python package and install the `tutor-contrib-richie` package instead.
 - [Feature] Upgrade edx-platform i18n strings to nutmeg.2 (by @regisb).
 
 ## v14.0.5 (2022-08-29)

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ci-test-bundle: ## Run basic tests on bundle
 	yes "" | ./dist/tutor config save --interactive
 	./dist/tutor config save
 	./dist/tutor plugins list
-	./dist/tutor plugins enable android discovery ecommerce forum license mfe minio notes richie webui xqueue
+	./dist/tutor plugins enable android discovery ecommerce forum license mfe minio notes webui xqueue
 	./dist/tutor plugins list
 	./dist/tutor license --help
 

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -7,6 +7,5 @@ tutor-license>=14.0.0,<15.0.0
 tutor-mfe>=14.0.0,<15.0.0
 tutor-minio>=14.0.0,<15.0.0
 tutor-notes>=14.0.0,<15.0.0
-tutor-richie>=14.0.0,<15.0.0
 tutor-webui>=14.0.0,<15.0.0
 tutor-xqueue>=14.0.0,<15.0.0

--- a/tutor/plugins/v0.py
+++ b/tutor/plugins/v0.py
@@ -281,7 +281,6 @@ class OfficialPlugin(BasePlugin):
         "mfe",
         "minio",
         "notes",
-        "richie",
         "webui",
         "xqueue",
     ]


### PR DESCRIPTION
The richie plugin was transferred to the openfun GitHub org. As a consequence, it is no longer part of the list of official plugins.

See: https://github.com/overhangio/tutor-contrib-richie/pull/5