### PR TITLE
feat: rename quickstart to launch

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -8,7 +8,7 @@ will be backported to the master branch at every major release.
 When backporting changes to master, we should keep only the entries that correspond to user-
 facing changes.
 -->
-
+- 💥[Improvement] Rename the implementation of tutor <mode> quickstart to tutor <mode> launch. (by @Carlos-Muniz)
 - 💥[Improvement] Remove the implementation of tutor dev runserver. (by @Carlos-Muniz)
 - [Bugfix] Fix MongoDB replica set connection error resulting from edx-platform's pymongo (3.10.1 -> 3.12.3) upgrade ([edx-platform#30569](https://github.com/openedx/edx-platform/pull/30569)). (by @ormsbee)
 - [Improvement] For Tutor Nightly (and only Nightly), official plugins are now installed from their nightly branches on GitHub instead of a version range on PyPI. This will allow Nightly users to install all official plugins by running ``pip install -e ".[full]"``.

--- a/README.rst
+++ b/README.rst
@@ -55,16 +55,17 @@ Features
 * No technical skill required with the `zero-click Tutor AWS image <https://docs.tutor.overhang.io/install.html#zero-click-aws-installation>`__
 
 .. _readme_intro_end:
-
+..
+  TODO: replace image + alt with tutor local launch
 .. image:: ./docs/img/quickstart.gif
     :alt: Tutor local quickstart
     :target: https://terminalizer.com/view/91b0bfdd557
 
-Quickstart
+Launch
 ----------
 
 1. Install the `latest stable release <https://github.com/overhangio/tutor/releases>`_ of Tutor
-2. Run ``tutor local quickstart``
+2. Run ``tutor local launch``
 3. You're done!
 
 Documentation

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,7 +15,7 @@ This section does not cover :ref:`plugin development <plugins>`. For simple chan
 Configuration
 -------------
 
-With Tutor, all Open edX deployment parameters are stored in a single ``config.yml`` file. This is the file that is generated when you run ``tutor local quickstart`` or ``tutor config save``. To view the content of this file, run::
+With Tutor, all Open edX deployment parameters are stored in a single ``config.yml`` file. This is the file that is generated when you run ``tutor local launch`` or ``tutor config save``. To view the content of this file, run::
 
     cat "$(tutor config printroot)/config.yml"
 
@@ -324,7 +324,7 @@ The following sections describe how to modify various aspects of the docker imag
 
     tutor local stop
 
-The custom image will be used the next time you run ``tutor local quickstart`` or ``tutor local start``. Do not attempt to run ``tutor local restart``! Restarting will not pick up the new image and will continue to use the old image.
+The custom image will be used the next time you run ``tutor local launch`` or ``tutor local start``. Do not attempt to run ``tutor local restart``! Restarting will not pick up the new image and will continue to use the old image.
 
 openedx Docker Image build arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -480,7 +480,7 @@ By default, Tutor runs the `overhangio/openedx <https://hub.docker.com/r/overhan
 
 (See the relevant :ref:`configuration parameters <docker_images>`.)
 
-The customised Docker image tag value will then be used by Tutor to run the platform, for instance when running ``tutor local quickstart``.
+The customised Docker image tag value will then be used by Tutor to run the platform, for instance when running ``tutor local launch``.
 
 
 Passing custom docker build options

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -13,7 +13,7 @@ First, ensure you have already :ref:`installed Tutor <install>` (for development
 
 Then, launch the developer platform setup process::
 
-    tutor dev quickstart
+    tutor dev launch
 
 This will perform several tasks for you. It will:
 
@@ -51,14 +51,14 @@ To bring down your platform's containers, simply run::
 Starting the platform back up
 -----------------------------
 
-Once you have used ``quickstart`` once, you can start the platform in the future with the lighter-weight ``start`` command, which brings up containers but does not perform any initialization tasks::
+Once you have used ``launch`` once, you can start the platform in the future with the lighter-weight ``start`` command, which brings up containers but does not perform any initialization tasks::
 
   tutor dev start     # Run platform in the same terminal ("attached")
   tutor dev start -d  # Or, run platform the in the background ("detached")
 
-Nonetheless, ``quickstart`` is idempotent, so it is always safe to run it again in the future without risk to your data. In fact, you may find it useful to use this command as a one-stop-shop for pulling images, running migrations, initializing new plugins you have enabled, and/or executing any new initialization steps that may have been introduced since you set up Tutor::
+Nonetheless, ``launch`` is idempotent, so it is always safe to run it again in the future without risk to your data. In fact, you may find it useful to use this command as a one-stop-shop for pulling images, running migrations, initializing new plugins you have enabled, and/or executing any new initialization steps that may have been introduced since you set up Tutor::
 
-  tutor dev quickstart --pullimages
+  tutor dev launch --pullimages
 
 
 Running arbitrary commands
@@ -112,7 +112,7 @@ It may sometimes be convenient to mount container directories on the host, for i
 Bind-mount volumes with ``--mount``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``quickstart``, ``run``, ``init`` and ``start`` subcommands of ``tutor dev`` and ``tutor local`` support the ``-m/--mount`` option (see :option:`tutor dev start -m`) which can take two different forms. The first is explicit::
+The ``launch``, ``run``, ``init`` and ``start`` subcommands of ``tutor dev`` and ``tutor local`` support the ``-m/--mount`` option (see :option:`tutor dev start -m`) which can take two different forms. The first is explicit::
 
     tutor dev start --mount=lms:/path/to/edx-platform:/openedx/edx-platform lms
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -8,5 +8,5 @@ Getting started
 
    install
    intro
-   quickstart
+   quickstart 
    whatnext

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,8 @@
 .. include:: ../README.rst
     :start-after: _readme_intro_start:
     :end-before: _readme_intro_end:
-
+..
+    TODO replace quickstart.gif + alt with 'launch'
 .. image:: ./img/quickstart.gif
     :alt: Tutor local quickstart
     :target: https://terminalizer.com/view/91b0bfdd557

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,20 +91,20 @@ To upgrade Open edX or benefit from the latest features and bug fixes, you shoul
 
     pip install --upgrade "tutor[full]"
 
-Then run the ``quickstart`` command again. Depending on your deployment target, run one of::
+Then run the ``launch`` command again. Depending on your deployment target, run one of::
 
-    tutor local quickstart # for local installations
-    tutor dev quickstart   # for local development installations
-    tutor k8s quickstart   # for Kubernetes installation
+    tutor local launch # for local installations
+    tutor dev launch   # for local development installations
+    tutor k8s launch   # for Kubernetes installation
 
 Upgrading with custom Docker images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you run :ref:`customised <configuration_customisation>` Docker images, you need to rebuild them before running ``quickstart``::
+If you run :ref:`customised <configuration_customisation>` Docker images, you need to rebuild them before running ``launch``::
 
     tutor config save
     tutor images build all # specify here the images that you need to build
-    tutor local quickstart
+    tutor local launch
 
 Upgrading to a new Open edX release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,12 +121,12 @@ Major Open edX releases are published twice a year, in June and December, by the
 4. Test the new release in a sandboxed environment.
 5. If you are running edx-platform, or some other repository from a custom branch, then you should rebase (and test) your changes on top of the latest release tag (see :ref:`edx_platform_fork`).
 
-The process for upgrading from one major release to the next works similarly to any other upgrade, with the ``quickstart`` command (see above). The single difference is that if the ``quickstart`` command detects that your tutor environment was generated with an older release, it will perform a few release-specific upgrade steps. These extra upgrade steps will be performed just once. But they will be ignored if you updated your local environment (for instance: with ``tutor config save``) before running ``quickstart``. This situation typically occurs if you need to re-build some Docker images (see above). In such a case, you should make use of the ``upgrade`` command. For instance, to upgrade a local installation from Maple to Nutmeg and rebuild some Docker images, run::
+The process for upgrading from one major release to the next works similarly to any other upgrade, with the ``launch`` command (see above). The single difference is that if the ``launch`` command detects that your tutor environment was generated with an older release, it will perform a few release-specific upgrade steps. These extra upgrade steps will be performed just once. But they will be ignored if you updated your local environment (for instance: with ``tutor config save``) before running ``launch``. This situation typically occurs if you need to re-build some Docker images (see above). In such a case, you should make use of the ``upgrade`` command. For instance, to upgrade a local installation from Maple to Nutmeg and rebuild some Docker images, run::
 
     tutor config save
     tutor images build all # list the images that should be rebuilt here
     tutor local upgrade --from=maple
-    tutor local quickstart
+    tutor local launch
 
 .. _autocomplete:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -99,7 +99,7 @@ Because the Tutor environment is generated entirely from the values in ``config.
 
 You can now take advantage of the Tutor-powered CLI (item #3) to bootstrap your Open edX platform::
 
-    tutor local quickstart
+    tutor local launch
 
 Under the hood, Tutor simply runs ``docker-compose`` and ``docker`` commands to launch your platform. These commands are printed in the standard output, such that you are free to replicate the same behaviour by simply copying/pasting the same commands.
 
@@ -117,7 +117,7 @@ as well as command trees for each mode in which Tutor can run::
     tutor k8s ...    # Commands for managing a Kubernetes Open edX deployment.
     tutor dev ...    # Commands for hacking on Open edX in development mode.
 
-Within each mode, Tutor has subcommands for managing that type of Open edX instance. Many of them are common between modes, such as ``quickstart``, ``start``, ``stop``, ``exec``, and ``logs``. For example::
+Within each mode, Tutor has subcommands for managing that type of Open edX instance. Many of them are common between modes, such as ``launch``, ``start``, ``stop``, ``exec``, and ``logs``. For example::
 
     tutor local logs  # View logs of a local deployment.
     tutor k8s logs    # View logs of a Kubernetes-managed deployment.

--- a/docs/k8s.rst
+++ b/docs/k8s.rst
@@ -85,19 +85,19 @@ The other benefit of ``kubectl apply`` is that it allows you to customise the Ku
 
 To learn more about "kustomizations", refer to the `official documentation <https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/>`__.
 
-Quickstart
+Launch
 ----------
 
 Launch the platform on Kubernetes in one command::
 
-    tutor k8s quickstart
+    tutor k8s launch
 
 All Kubernetes resources are associated with the "openedx" namespace. If you don't see anything in the Kubernetes dashboard, you are probably looking at the wrong namespace... 😉
 
 .. image:: img/k8s-dashboard.png
     :alt: Kubernetes dashboard ("openedx" namespace)
 
-The same ``tutor k8s quickstart`` command can be used to upgrade the cluster to the latest version.
+The same ``tutor k8s launch`` command can be used to upgrade the cluster to the latest version.
 
 Other commands
 --------------

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -18,7 +18,7 @@ In the following, environment and data files will be generated in a user-specifi
     tutor run ...
 
 .. note::
-    As of v10.0.0, a locally-running Open edX platform can no longer be accessed from http://localhost or http://studio.localhost. Instead, when running ``tutor local quickstart``, you must now decide whether you are running a platform that will be used in production. If not, the platform will be automatically be bound to http://local.overhang.io and http://studio.local.overhang.io, which are domain names that point to 127.0.0.1 (localhost). This change was made to facilitate internal communication between Docker containers.
+    As of v10.0.0, a locally-running Open edX platform can no longer be accessed from http://localhost or http://studio.localhost. Instead, when running ``tutor local launch``, you must now decide whether you are running a platform that will be used in production. If not, the platform will be automatically be bound to http://local.overhang.io and http://studio.local.overhang.io, which are domain names that point to 127.0.0.1 (localhost). This change was made to facilitate internal communication between Docker containers.
 
 Main commands
 -------------
@@ -32,9 +32,9 @@ All-in-one command
 
 A fully-functional platform can be configured and run in one command::
 
-    tutor local quickstart
+    tutor local launch
 
-But you may want to run commands one at a time: it's faster when you need to run only part of the local deployment process, and it helps you understand how your platform works. In the following, we decompose the ``quickstart`` command.
+But you may want to run commands one at a time: it's faster when you need to run only part of the local deployment process, and it helps you understand how your platform works. In the following, we decompose the ``launch`` command.
 
 Configuration
 ~~~~~~~~~~~~~

--- a/docs/plugins/intro.rst
+++ b/docs/plugins/intro.rst
@@ -11,7 +11,7 @@ Tutor comes with a plugin system that allows anyone to customise the deployment 
     # 2) Enable the plugin
     tutor plugins enable myapp
     # 3) Reconfigure and restart the platform
-    tutor local quickstart
+    tutor local launch
 
 For simple changes, it may be extremely easy to create a Tutor plugin: even non-technical users may get started with our :ref:`plugin_development_tutorial` tutorial. We also provide a list of :ref:`simple example plugins <plugins_examples>`.
 

--- a/docs/plugins/v0/gettingstarted.rst
+++ b/docs/plugins/v0/gettingstarted.rst
@@ -51,7 +51,7 @@ You should be able to view your changes in every LMS and CMS settings file::
 
 Now just restart your platform to start sending tracking events to Google Analytics::
 
-    tutor local quickstart
+    tutor local launch
 
 That's it! And it's very easy to share your plugins. Just upload them to your Github repo and share the url with other users. They will be able to install your plugin by running::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,4 @@
-.. _quickstart:
+.. _launch:
 
 Quickstart (1-click install)
 ----------------------------
@@ -11,12 +11,12 @@ Or `download <https://github.com/overhangio/tutor/releases>`_ the pre-compiled b
 
 .. include:: download/binary.rst
 
-2. Run ``tutor local quickstart``
+2. Run ``tutor local launch``
 3. You're done!
 
 **That's it?**
 
-Yes :) This is what happens when you run ``tutor local quickstart``:
+Yes :) This is what happens when you run ``tutor local launch``:
 
 1. You answer a few questions about the :ref:`configuration` of your Open edX platform.
 2. Configuration files are generated from templates.
@@ -26,4 +26,4 @@ Yes :) This is what happens when you run ``tutor local quickstart``:
 
 The whole procedure should require less than 10 minutes, on a server with good bandwidth. Note that your host environment will not be affected in any way, since everything runs inside docker containers. Root access is not even necessary.
 
-There's a lot more to Tutor than that! To learn more about what you can do with Tutor and Open edX, check out the :ref:`whatnext` section. If the quickstart installation method above somehow didn't work for you, check out the :ref:`troubleshooting` guide.
+There's a lot more to Tutor than that! To learn more about what you can do with Tutor and Open edX, check out the :ref:`whatnext` section. If the launch installation method above somehow didn't work for you, check out the :ref:`troubleshooting` guide.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -63,15 +63,15 @@ If the above command does not work, you should fix your Docker installation. Som
 "Running migrations... Killed!" / "Command failed with status 137: docker-compose"
 ----------------------------------------------------------------------------------
 
-Open edX requires at least 4 GB RAM, in particular, to run the SQL migrations. If the ``tutor local quickstart`` command dies after displaying "Running migrations", you most probably need to buy more memory or add swap to your machine.
+Open edX requires at least 4 GB RAM, in particular, to run the SQL migrations. If the ``tutor local launch`` command dies after displaying "Running migrations", you most probably need to buy more memory or add swap to your machine.
 
-On macOS, by default, Docker allocates at most 2 GB of RAM to containers. ``quickstart`` tries to check your current allocation and outputs a warning if it can't find a value of at least 4 GB. You should follow `these instructions from the official Docker documentation <https://docs.docker.com/docker-for-mac/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon.
+On macOS, by default, Docker allocates at most 2 GB of RAM to containers. ``launch`` tries to check your current allocation and outputs a warning if it can't find a value of at least 4 GB. You should follow `these instructions from the official Docker documentation <https://docs.docker.com/docker-for-mac/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon.
 
-If migrations were killed halfway, there is a good chance that the MySQL database is in a state that is hard to recover from. The easiest way to recover is simply to delete all the MySQL data and restart the quickstart process. After you have allocated more memory to the Docker daemon, run::
+If migrations were killed halfway, there is a good chance that the MySQL database is in a state that is hard to recover from. The easiest way to recover is simply to delete all the MySQL data and restart the launch process. After you have allocated more memory to the Docker daemon, run::
 
     tutor local stop
     sudo rm -rf "$(tutor config printroot)/data/mysql"
-    tutor local quickstart
+    tutor local launch
 
 .. warning::
     THIS WILL ERASE ALL YOUR DATA! Do not run this on a production instance. This solution is only viable for new Open edX installations.

--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -34,7 +34,7 @@ Don't forget to replace your email address and password in the prompt above. If 
 
 Then, restart your platform::
 
-    $ tutor local quickstart
+    $ tutor local launch
 
 That's it! You can send a test email with the following command::
 

--- a/docs/tutorials/nightly.rst
+++ b/docs/tutorials/nightly.rst
@@ -22,7 +22,7 @@ In addition to installing Tutor Nightly itself, this will install automatically 
 
 Once Tutor Nightly is installed, you can run the usual ``tutor`` commands::
 
-    tutor dev quickstart
+    tutor dev launch
     tutor dev run lms bash
     # ... and so on
 

--- a/docs/tutorials/oldreleases.rst
+++ b/docs/tutorials/oldreleases.rst
@@ -4,9 +4,9 @@ Upgrading from older releases
 Upgrading from v3+
 ~~~~~~~~~~~~~~~~~~
 
-Just upgrade Tutor using your :ref:`favorite installation method <install>` and run quickstart again::
+Just upgrade Tutor using your :ref:`favorite installation method <install>` and run launch again::
 
-    tutor local quickstart
+    tutor local launch
 
 Upgrading from v1 or v2
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,4 +22,4 @@ Then, install Tutor using one of the :ref:`installation methods <install>`. Then
 
 Finally, launch your platform with::
 
-    tutor local quickstart
+    tutor local launch

--- a/docs/tutorials/plugin.rst
+++ b/docs/tutorials/plugin.rst
@@ -218,7 +218,7 @@ You can now run the "myservice" container which will execute the ``CMD`` stateme
 Declaring initialisation tasks
 ------------------------------
 
-Services often need to run specific tasks before they can be started. For instance, the LMS and the CMS need to apply database migrations. These commands are written in shell scripts that are executed whenever we run ``quickstart``. We call these scripts "init tasks". To add a new local init task, we must first add the corresponding service to the ``docker-compose-jobs.yml`` file by implementing the :patch:`local-docker-compose-jobs-services` patch::
+Services often need to run specific tasks before they can be started. For instance, the LMS and the CMS need to apply database migrations. These commands are written in shell scripts that are executed whenever we run ``launch``. We call these scripts "init tasks". To add a new local init task, we must first add the corresponding service to the ``docker-compose-jobs.yml`` file by implementing the :patch:`local-docker-compose-jobs-services` patch::
 
     hooks.Filters.ENV_PATCHES.add_item(
         (

--- a/docs/whatnext.rst
+++ b/docs/whatnext.rst
@@ -3,7 +3,7 @@
 What next?
 ==========
 
-You have gone through the :ref:`Quickstart installation <quickstart>`: at this point, you should have a running Open edX platform. If you don't, please follow the instructions from the :ref:`Troubleshooting <troubleshooting>` section.
+You have gone through the :ref:`Launch installation <launch>`: at this point, you should have a running Open edX platform. If you don't, please follow the instructions from the :ref:`Troubleshooting <troubleshooting>` section.
 
 Logging-in as administrator
 ---------------------------

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -14,8 +14,8 @@ class LocalTests(unittest.TestCase, TestCommandMixin):
         self.assertIsNone(result.exception)
         self.assertEqual(0, result.exit_code)
 
-    def test_local_quickstart_help(self) -> None:
-        result = self.invoke(["local", "quickstart", "--help"])
+    def test_local_launch_help(self) -> None:
+        result = self.invoke(["local", "launch", "--help"])
         self.assertIsNone(result.exception)
         self.assertEqual(0, result.exit_code)
 

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -66,7 +66,7 @@ def dev(context: click.Context) -> None:
 @click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
 @compose.mount_option
 @click.pass_context
-def quickstart(
+def launch(
     context: click.Context,
     non_interactive: bool,
     pullimages: bool,
@@ -120,6 +120,28 @@ Your Open edX platform is ready and can be accessed at the following urls:
     )
 
 
+@click.command(help="Configure and run Open edX from scratch, for development")
+@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
+@click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
+@compose.mount_option
+@click.pass_context
+def quickstart(
+    context: click.Context,
+    non_interactive: bool,
+    pullimages: bool,
+    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
+) -> None:
+    """
+    This command has been renamed to 'launch'.
+    """
+    fmt.echo_alert(
+        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
+    )
+    context.invoke(
+        launch, non_interactive=non_interactive, pullimages=pullimages, mounts=mounts
+    )
+
+
 @hooks.Actions.COMPOSE_PROJECT_STARTED.add()
 def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
     """
@@ -131,5 +153,6 @@ def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
         runner.docker_compose("stop")
 
 
+dev.add_command(launch)
 dev.add_command(quickstart)
 compose.add_commands(dev)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -163,7 +163,7 @@ def k8s(context: click.Context) -> None:
 @click.command(help="Configure and run Open edX from scratch")
 @click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
 @click.pass_context
-def quickstart(context: click.Context, non_interactive: bool) -> None:
+def launch(context: click.Context, non_interactive: bool) -> None:
     run_upgrade_from_release = tutor_env.should_upgrade_from_release(context.obj.root)
     if run_upgrade_from_release is not None:
         click.echo(fmt.title("Upgrading from an older release"))
@@ -212,6 +212,19 @@ Press enter when you are ready to continue"""
             cms_host=config["CMS_HOST"],
         )
     )
+
+
+@click.command(help="Configure and run Open edX from scratch")
+@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
+@click.pass_context
+def quickstart(context: click.Context, non_interactive: bool) -> None:
+    """
+    This command has been renamed to 'launch'.
+    """
+    fmt.echo_alert(
+        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
+    )
+    context.invoke(launch, non_interactive=non_interactive)
 
 
 @click.command(
@@ -463,7 +476,7 @@ def wait(context: K8sContext, name: str) -> None:
 
 @click.command(
     short_help="Perform release-specific upgrade tasks",
-    help="Perform release-specific upgrade tasks. To perform a full upgrade remember to run `quickstart`.",
+    help="Perform release-specific upgrade tasks. To perform a full upgrade remember to run `launch`.",
 )
 @click.option(
     "--from",
@@ -479,7 +492,7 @@ def upgrade(context: click.Context, from_release: Optional[str]) -> None:
     else:
         fmt.echo_alert(
             "This command only performs a partial upgrade of your Open edX platform. "
-            "To perform a full upgrade, you should run `tutor k8s quickstart`."
+            "To perform a full upgrade, you should run `tutor k8s launch`."
         )
         upgrade_from(context.obj, from_release)
     # We update the environment to update the version
@@ -569,6 +582,7 @@ def k8s_namespace(config: Config) -> str:
     return get_typed(config, "K8S_NAMESPACE", str)
 
 
+k8s.add_command(launch)
 k8s.add_command(quickstart)
 k8s.add_command(start)
 k8s.add_command(stop)

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -67,7 +67,7 @@ def local(context: click.Context) -> None:
 @click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
 @click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
 @click.pass_context
-def quickstart(
+def launch(
     context: click.Context,
     mounts: t.Tuple[t.List[compose.MountParam.MountType]],
     non_interactive: bool,
@@ -159,9 +159,31 @@ Your Open edX platform is ready and can be accessed at the following urls:
     )
 
 
+@click.command(help="Configure and run Open edX from scratch")
+@compose.mount_option
+@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
+@click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
+@click.pass_context
+def quickstart(
+    context: click.Context,
+    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
+    non_interactive: bool,
+    pullimages: bool,
+) -> None:
+    """
+    This command has been renamed to 'launch'.
+    """
+    fmt.echo_alert(
+        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
+    )
+    context.invoke(
+        launch, non_interactive=non_interactive, pullimages=pullimages, mounts=mounts
+    )
+
+
 @click.command(
     short_help="Perform release-specific upgrade tasks",
-    help="Perform release-specific upgrade tasks. To perform a full upgrade remember to run `quickstart`.",
+    help="Perform release-specific upgrade tasks. To perform a full upgrade remember to run `launch`.",
 )
 @click.option(
     "--from",
@@ -172,7 +194,7 @@ Your Open edX platform is ready and can be accessed at the following urls:
 def upgrade(context: click.Context, from_release: t.Optional[str]) -> None:
     fmt.echo_alert(
         "This command only performs a partial upgrade of your Open edX platform. "
-        "To perform a full upgrade, you should run `tutor local quickstart`."
+        "To perform a full upgrade, you should run `tutor local launch`."
     )
     if from_release is None:
         from_release = tutor_env.get_env_release(context.obj.root)
@@ -195,6 +217,7 @@ def _stop_on_dev_start(root: str, config: Config, project_name: str) -> None:
         runner.docker_compose("stop")
 
 
+local.add_command(launch)
 local.add_command(quickstart)
 local.add_command(upgrade)
 compose.add_commands(local)

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -19,7 +19,7 @@ def load(root: str) -> Config:
         raise exceptions.TutorError(
             "Project root does not exist. Make sure to generate the initial "
             "configuration with `tutor config save --interactive` or `tutor local "
-            "quickstart` prior to running other commands."
+            "launch` prior to running other commands."
         )
     env.check_is_up_to_date(root)
     return load_full(root)


### PR DESCRIPTION
These changes renames all mentions of `quickstart` to `launch`
found in the code and documentation.

Acceptance Criteria:
- [X] Rename quickstart command to launch.
- [X] Update Tutor documentation.
- [X] Search for quickstart across the overhangio GH organization. If quickstart is referenced in any other Tutor repos, update them.
- [X] Temporarily alias quickstart to launch for backwards-compatibility. Mark quickstart as deprecated and warn users that launch should be used instead.
- [X] Create a new issue to remove quickstart in a following release (Palm, perhaps?) https://github.com/overhangio/2u-tutor-adoption/issues/119
- [ ] Announce the change in the forums and Slack.

This PR is related to the following PRs:

- https://github.com/overhangio/tutor-ecommerce/pull/33
- https://github.com/overhangio/tutor-forum/pull/9
- https://github.com/overhangio/tutor-android/pull/4
- https://github.com/overhangio/tutor-discovery/pull/35
- https://github.com/overhangio/tutor-mfe/pull/60
- https://github.com/overhangio/tutor-xqueue/pull/12

Closes https://github.com/overhangio/2u-tutor-adoption/issues/53