### PR TITLE
Remove warning about building tutor-mfe on ARM systems

### DIFF
--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -54,8 +54,3 @@ Or for a development environment::
 
     tutor dev start -d
     tutor dev init
-
-Using with tutor-mfe
---------------------
-
-You may wish to use `tutor-mfe <https://github.com/overhangio/tutor-mfe>`_ to run the Open edX microfrontends. If so, be aware that there is a known issue with ``tutor-mfe`` on ARM systems. See `this GitHub issue <https://github.com/overhangio/tutor-mfe/issues/31>`_ for details and known workarounds.


### PR DESCRIPTION
It looks like this was resolved in https://github.com/overhangio/tutor-mfe/pull/42