### PR TITLE
nightly: fix: installation of local requirements

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -8,6 +8,7 @@ will be backported to the master branch at every major release.
 When backporting changes to master, we should keep only the entries that correspond to user-
 facing changes.
 -->
+- 💥[Bugfix] Fix local installation requirements. Plugins that implemented the "openedx-dockerfile-post-python-requirements" patch and that needed access to the edx-platform repo will no longer work. Instead, these plugins should implement the "openedx-dockerfile-pre-assets" patch. This scenario should be very rare, though. (by @regisb)
 - 💥[Improvement] Rename the implementation of tutor <mode> quickstart to tutor <mode> launch. (by @Carlos-Muniz)
 - 💥[Improvement] Remove the implementation of tutor dev runserver. (by @Carlos-Muniz)
 - [Bugfix] Fix MongoDB replica set connection error resulting from edx-platform's pymongo (3.10.1 -> 3.12.3) upgrade ([edx-platform#30569](https://github.com/openedx/edx-platform/pull/30569)). (by @ormsbee)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -69,13 +69,6 @@ ENV VIRTUAL_ENV /openedx/venv/
 
 RUN apt update && apt install -y software-properties-common libmysqlclient-dev libxmlsec1-dev libgeos-dev
 
-# Note that this means that we need to reinstall all requirements whenever there is a
-# change in edx-platform, which sucks. Yet, we must do it, because edx-platform installs some
-# Python projects from within the edx-platform repo itself. This is being fixed upstream.
-# TODO: https://github.com/overhangio/2u-tutor-adoption/issues/86
-COPY --from=code /openedx/edx-platform /openedx/edx-platform
-WORKDIR /openedx/edx-platform
-
 # Install the right version of pip/setuptools
 # https://pypi.org/project/setuptools/
 # https://pypi.org/project/pip/
@@ -83,8 +76,8 @@ WORKDIR /openedx/edx-platform
 RUN pip install setuptools==62.1.0 pip==22.0.4 wheel==0.37.1
 
 # Install base requirements
-RUN pip install -r ./requirements/edx/base.txt
-RUN pip install -e .
+COPY --from=code /openedx/edx-platform/requirements/edx/base.txt /tmp/base.txt
+RUN pip install -r /tmp/base.txt
 
 # Install django-redis for using redis as a django cache
 # https://pypi.org/project/django-redis/
@@ -147,6 +140,10 @@ COPY --chown=app:app --from=nodejs-requirements /openedx/edx-platform/node_modul
 ENV PATH /openedx/venv/bin:./node_modules/.bin:/openedx/nodeenv/bin:${PATH}
 ENV VIRTUAL_ENV /openedx/venv/
 WORKDIR /openedx/edx-platform
+
+# We install edx-platform here because it creates an egg-info folder in the current
+# repo. We need both the source code and the virtualenv to run this command.
+RUN pip install -e .
 
 # Create folder that will store lms/cms.env.yml files, as well as
 # the tutor-specific settings files.


### PR DESCRIPTION
The `compilejsi18n` command was failing during image building because the Open-edX package was not installed properly. The reason for that was an earlier change where we got rid of the `pip install -r requirements/edx/local.in` command. Installing the Open-edX package was part of this requirement file.

The local.in requirements file no longer exists, but we still need to `pip install -e .` the edx-platform repo. To run this command we need both the edx-platform repo and the virtualenv.

The good news is that there are no more local requirements in the base.txt requirements file. This means that we no longer have to COPY the edx-platform repo in the requirements installation step. Thus, changes in edx-platform will no longer trigger a rebuild of the pip requirements; this means that re-builds will be much faster when making changes to edx-platform.

Note that plugins that implemented the
"openedx-dockerfile-post-python-requirements" patch and that needed access to the edx-platform repo will no longer work. Instead, these plugins should implement the "openedx-dockerfile-pre-assets" patch. This scenario should be very rare, though.

Close #726