### PR TITLE
WIP strongly-typed hooks

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ kubernetes==18.20.0
     # via -r requirements/base.in
 markupsafe==2.0.1
     # via jinja2
-mypy==0.942
+mypy==0.982
     # via -r requirements/base.in
 mypy-extensions==0.4.3
     # via mypy
@@ -61,7 +61,7 @@ six==1.16.0
     #   python-dateutil
 tomli==2.0.1
     # via mypy
-typing-extensions==3.10.0.2
+typing-extensions==4.3.0
     # via mypy
 urllib3==1.26.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -76,7 +76,7 @@ markupsafe==2.0.1
     #   jinja2
 mccabe==0.6.1
     # via pylint
-mypy==0.942
+mypy==0.982
     # via -r requirements/base.txt
 mypy-extensions==0.4.3
     # via
@@ -183,7 +183,7 @@ types-pyyaml==6.0.0
     # via -r requirements/dev.in
 types-setuptools==57.4.2
     # via -r requirements/dev.in
-typing-extensions==3.10.0.2
+typing-extensions==4.3.0
     # via
     #   -r requirements/base.txt
     #   astroid

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -52,7 +52,7 @@ markupsafe==2.0.1
     # via
     #   -r requirements/base.txt
     #   jinja2
-mypy==0.942
+mypy==0.982
     # via -r requirements/base.txt
 mypy-extensions==0.4.3
     # via
@@ -136,7 +136,7 @@ tomli==2.0.1
     # via
     #   -r requirements/base.txt
     #   mypy
-typing-extensions==3.10.0.2
+typing-extensions==4.3.0
     # via
     #   -r requirements/base.txt
     #   mypy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import click
 
 from tests.helpers import PluginsTestCase, temporary_root
 from tutor import config as tutor_config
-from tutor import hooks, interactive
+from tutor import fmt, hooks, interactive, utils
 from tutor.types import Config, get_typed
 
 
@@ -25,13 +25,13 @@ class ConfigTests(unittest.TestCase):
     def test_merge_not_render(self) -> None:
         config: Config = {}
         base = tutor_config.get_base()
-        with patch.object(tutor_config.utils, "random_string", return_value="abcd"):
+        with patch.object(utils, "random_string", return_value="abcd"):
             tutor_config.merge(config, base)
 
         # Check that merge does not perform a rendering
         self.assertNotEqual("abcd", config["MYSQL_ROOT_PASSWORD"])
 
-    @patch.object(tutor_config.fmt, "echo")
+    @patch.object(fmt, "echo")
     def test_update_twice_should_return_same_config(self, _: Mock) -> None:
         with temporary_root() as root:
             config1 = tutor_config.load_minimal(root)
@@ -60,7 +60,7 @@ class ConfigTests(unittest.TestCase):
         self.assertTrue(tutor_config.is_service_activated(config, "service1"))
         self.assertFalse(tutor_config.is_service_activated(config, "service2"))
 
-    @patch.object(tutor_config.fmt, "echo")
+    @patch.object(fmt, "echo")
     def test_json_config_is_overwritten_by_yaml(self, _: Mock) -> None:
         with temporary_root() as root:
             # Create config from scratch
@@ -84,7 +84,7 @@ class ConfigTests(unittest.TestCase):
 
 
 class ConfigPluginTestCase(PluginsTestCase):
-    @patch.object(tutor_config.fmt, "echo")
+    @patch.object(fmt, "echo")
     def test_removed_entry_is_added_on_save(self, _: Mock) -> None:
         with temporary_root() as root:
             mock_random_string = Mock()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -86,7 +86,7 @@ class EnvTests(PluginsTestCase):
         rendered = env.render_file(config, "hooks", "mysql", "init")
         self.assertIn("testpassword", rendered)
 
-    @patch.object(tutor_config.fmt, "echo")
+    @patch.object(fmt, "echo")
     def test_render_file_missing_configuration(self, _: Mock) -> None:
         self.assertRaises(
             exceptions.TutorError, env.render_file, {}, "local", "docker-compose.yml"
@@ -118,7 +118,7 @@ class EnvTests(PluginsTestCase):
     def test_patch(self) -> None:
         patches = {"plugin1": "abcd", "plugin2": "efgh"}
         with patch.object(
-            env.plugins, "iter_patches", return_value=patches.values()
+            plugins, "iter_patches", return_value=patches.values()
         ) as mock_iter_patches:
             rendered = env.render_str({}, '{{ patch("location") }}')
             mock_iter_patches.assert_called_once_with("location")
@@ -126,7 +126,7 @@ class EnvTests(PluginsTestCase):
 
     def test_patch_separator_suffix(self) -> None:
         patches = {"plugin1": "abcd", "plugin2": "efgh"}
-        with patch.object(env.plugins, "iter_patches", return_value=patches.values()):
+        with patch.object(plugins, "iter_patches", return_value=patches.values()):
             rendered = env.render_str(
                 {}, '{{ patch("location", separator=",\n", suffix=",") }}'
             )

--- a/tutor/commands/cli.py
+++ b/tutor/commands/cli.py
@@ -60,7 +60,7 @@ class TutorCli(click.MultiCommand):
             # https://github.com/click-contrib/sphinx-click/issues/70
             return
         if not cls.IS_ROOT_READY:
-            hooks.Actions.PROJECT_ROOT_READY.do(root=ctx.params["root"])
+            hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
             cls.IS_ROOT_READY = True
 
     def list_commands(self, ctx: click.Context) -> t.List[str]:

--- a/tutor/hooks/actions.py
+++ b/tutor/hooks/actions.py
@@ -4,11 +4,14 @@ __license__ = "Apache 2.0"
 import sys
 import typing as t
 
+from typing_extensions import ParamSpec
+
 from .contexts import Contextualized
 
-# Similarly to CallableFilter, it should be possible to refine the definition of
-# CallableAction in the future.
-CallableAction = t.Callable[..., None]
+P = ParamSpec("P")
+# Similarly to CallableFilter, it should be possible to create a CallableAction alias in
+# the future.
+# CallableAction = t.Callable[P, None]
 
 DEFAULT_PRIORITY = 10
 
@@ -16,7 +19,7 @@ DEFAULT_PRIORITY = 10
 class ActionCallback(Contextualized):
     def __init__(
         self,
-        func: CallableAction,
+        func: t.Callable[P, None],
         priority: t.Optional[int] = None,
     ):
         super().__init__()
@@ -28,6 +31,7 @@ class ActionCallback(Contextualized):
     ) -> None:
         if self.is_in_context(context):
             self.func(*args, **kwargs)
+
 
 
 class Action:
@@ -54,8 +58,8 @@ class Action:
 
     def add(
         self, priority: t.Optional[int] = None
-    ) -> t.Callable[[CallableAction], CallableAction]:
-        def inner(func: CallableAction) -> CallableAction:
+    ) -> t.Callable[[t.Callable[P, None]], t.Callable[P, None]]:
+        def inner(func: t.Callable[P, None]) -> t.Callable[P, None]:
             callback = ActionCallback(func, priority=priority)
             # I wish we could use bisect.insort_right here but the `key=` parameter
             # is unsupported in Python 3.9
@@ -130,7 +134,7 @@ def get_template(name: str) -> ActionTemplate:
 def add(
     name: str,
     priority: t.Optional[int] = None,
-) -> t.Callable[[CallableAction], CallableAction]:
+) -> t.Callable[[t.Callable[P, None]], t.Callable[P, None]]:
     """
     Decorator to add a callback action associated to a name.
 

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -5,6 +5,9 @@ to generate part of the reference documentation.
 # The Tutor plugin system is licensed under the terms of the Apache 2.0 license.
 __license__ = "Apache 2.0"
 
+
+from tutor.types import Config
+
 from . import actions, contexts, filters
 
 __all__ = ["Actions", "Filters", "Contexts"]
@@ -30,7 +33,11 @@ class Actions:
     #: :parameter: str root: project root.
     #: :parameter: dict[str, ...] config: project configuration.
     #: :parameter: str name: docker-compose project name.
-    COMPOSE_PROJECT_STARTED = actions.get("compose:project:started")
+
+    # TODO Unfortunately, this fails at runtime on python 3.8/3.9:
+    # TypeError: Parameters to generic types must be types. Got [<class 'str'>, typing.Dict[str, typing.Union[str, float, NoneType, bool, typing.List[str], typing.L.
+    # See: https://stackoverflow.com/questions/73974069/generic-paramspec-on-python-3-9
+    COMPOSE_PROJECT_STARTED: actions.Action[[str, Config, str]] = actions.get("compose:project:started")
 
     #: Called whenever the core project is ready to run. This action is called as soon
     #: as possible. This is the right time to discover plugins, for instance. In
@@ -45,14 +52,12 @@ class Actions:
     #: developers probably don't have to implement this action themselves.
     #:
     #: This action does not have any parameter.
-    CORE_READY = actions.get("core:ready")
-
-    CORE_READY.do("pouac")
+    CORE_READY: actions.Action[[]] = actions.get("core:ready")
 
     #: Called as soon as we have access to the Tutor project root.
     #:
     #: :parameter str root: absolute path to the project root.
-    PROJECT_ROOT_READY: actions.Action = actions.create("project:root:ready")
+    PROJECT_ROOT_READY: actions.Action[[str]] = actions.get("project:root:ready")
 
     #: Triggered when a single plugin needs to be loaded. Only plugins that have previously been
     #: discovered can be loaded (see :py:data:`CORE_READY`).
@@ -65,13 +70,13 @@ class Actions:
     #: they want to perform a specific action at the moment the plugin is enabled.
     #:
     #: This action does not have any parameter.
-    PLUGIN_LOADED = actions.get_template("plugins:loaded:{0}")
+    PLUGIN_LOADED: actions.ActionTemplate[[]] = actions.get_template("plugins:loaded:{0}")
 
     #: Triggered after all plugins have been loaded. At this point the list of loaded
     #: plugins may be obtained from the :py:data:``Filters.PLUGINS_LOADED`` filter.
     #:
     #: This action does not have any parameter.
-    PLUGINS_LOADED = actions.get("plugins:loaded")
+    PLUGINS_LOADED: actions.Action[[]] = actions.get("plugins:loaded")
 
     #: Triggered when a single plugin is unloaded. Only plugins that have previously been
     #: loaded can be unloaded (see :py:data:`PLUGIN_LOADED`).
@@ -84,7 +89,7 @@ class Actions:
     #: :parameter str plugin: plugin name.
     #: :parameter str root: absolute path to the project root.
     #: :parameter dict config: full project configuration
-    PLUGIN_UNLOADED = actions.get("plugins:unloaded")
+    PLUGIN_UNLOADED: actions.Action[[str, str, Config]] = actions.get("plugins:unloaded")
 
 
 class Filters:

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -47,10 +47,12 @@ class Actions:
     #: This action does not have any parameter.
     CORE_READY = actions.get("core:ready")
 
+    CORE_READY.do("pouac")
+
     #: Called as soon as we have access to the Tutor project root.
     #:
     #: :parameter str root: absolute path to the project root.
-    PROJECT_ROOT_READY = actions.get("project:root:ready")
+    PROJECT_ROOT_READY: actions.Action = actions.create("project:root:ready")
 
     #: Triggered when a single plugin needs to be loaded. Only plugins that have previously been
     #: discovered can be loaded (see :py:data:`CORE_READY`).

--- a/tutor/hooks/filters.py
+++ b/tutor/hooks/filters.py
@@ -146,10 +146,10 @@ def get_template(name: str) -> FilterTemplate:
         named_filter = filter_template("name")
 
         @named_filter.add()
-        def my_callback():
+        def my_callback(x: int) -> int:
             ...
 
-        named_filter.do()
+        named_filter.apply(42)
     """
     return FilterTemplate(name)
 


### PR DESCRIPTION
This PR aims at achieving two things:

1. Refine the generic type of actions and filters. This is possible now that the upstream mypy bugs have been resolved.
2. Implement strongly-typed named actions and filters in consts.py, to make sure that they are always called with the right arguments. Unfortunately, this does not work, yet.

I'm opening this PR just for the sake of leaving a trace of my research. Unfortunately the proposed implementation does not work in Python < 3.10, so we'll have to wait until Python 3.9 EOL to get this to work... in [October 2025 ](https://endoflife.date/python) :crying_cat_face: 