### PR TITLE
Improve Proxy Tutorial Documentation

### DIFF
--- a/docs/tutorials/proxy.rst
+++ b/docs/tutorials/proxy.rst
@@ -13,3 +13,8 @@ In this example, the caddy container port would be mapped to 81 instead of 80. Y
     In this setup, the Caddy HTTP port will be exposed to the world. Make sure to configure your server firewall to block unwanted connections to your server's ``CADDY_HTTP_PORT``. Alternatively, you can configure the Caddy container to accept only local connections::
 
         tutor config save --set CADDY_HTTP_PORT=127.0.0.1:81
+
+If your external proxy will handle TLS/SSL, appropriate headers (namely ``X-Forwarded-Proto`` and ``X-Forwarded-Port``) must be set by the proxy and forwarded by Caddy.
+
+.. note::
+    The ``ENABLE_HTTPS`` flag (which is controlled by the last question of the quickstart dialogue) must be set to true, otherwise Caddy will overwrite ``X-Forwarded-Port`` to 80. Therefore, make sure to continue answering ``y`` to the quickstart dialogue question "Activate SSL/TLS certificates for HTTPS access?".


### PR DESCRIPTION
The proxy tutorial documentation provides the necessary basics. It however doesn't explain which headers need to be set in order for Django to pick up the correct port and protocol information.

Also, based on the built-in template, Caddy doesn't honour the `X-Forwarded-Port` header, it simply overrides it, either to 80 or 443 depending on the `ENABLE_HTTPS` flag.

As this flag is controlled by the Quickstart dialogue with a slightly misleading question ("Activate SSL/TLS certificates for HTTPS access?"), I felt it makes sense to add a hint to the docs, as it took me quite some time to figure this out.

The question imho is misleading, as in this case (external proxy handling SSL/TLS) I don't want Caddy to generate certificates for me, but I also don't want it to overwrite the existing header.

Would it be another option to introduce a flag that controls whether Caddy trusts an upstream header?