### PR TITLE
feat: use encode gzip for caddy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Improvement] use caddy `encode gzip` directive to optimize transfer size (by @ghassanmas)
+
 ## v14.1.0 (2022-10-10)
 
 - [Improvement] Upgrade Scorm XBlock to v14.0.0. (by @regisb)

--- a/tutor/templates/apps/caddy/Caddyfile
+++ b/tutor/templates/apps/caddy/Caddyfile
@@ -20,6 +20,11 @@
         }
     }
 
+    # This will compress requests that matches the default criteria set by Caddy.
+    # see https://caddyserver.com/docs/caddyfile/directives/encode
+    # for information about the defaults; i.e. how/when this will be applied.
+    encode gzip
+
     reverse_proxy {args.0} {
         header_up X-Forwarded-Port {{ 443 if ENABLE_HTTPS else 80 }}
     }


### PR DESCRIPTION
  Compressing assests would lead to readuce transfer size.
  As testing with frontend-app-learning/Olive, the network traffic
  before was about ~4MB, after this it became ~1MB.

  This change was suggested by Google Lighthouse[1], there are of
  course more suggestion but this was one the easiest and one of most
  impactful.

  Also check orignal PR overhangio/tutor-mfe/pull/64 for more
  info.
  [1]: https://web.dev/uses-text-compression
