### PR TITLE
feat: auto-complete `--mount` args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 
+- [Improvement] Auto-complete implicit `local/dev --mount /path/to/...` options. (by @regisb)
 - 💥[Feature] Strong typing of action and filter hooks: this allows us to detect incorrect calls to `actions.add` or `filters.add` early. Strong typing forces us to break the `do` and `apply` API by removing the `context` named argument. Developers should replace `do(context=...)` by `do_from_context(..., )` (and similar for `apply`).
 
 ## v14.1.2 (2022-11-02)

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -4,6 +4,7 @@ import typing as t
 from copy import deepcopy
 
 import click
+from click.shell_completion import CompletionItem
 from typing_extensions import TypeAlias
 
 from tutor import bindmounts
@@ -170,6 +171,18 @@ class MountParam(click.ParamType):
         if not mounts:
             raise self.fail(f"no mount found for {value}")
         return mounts
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> t.List[CompletionItem]:
+        """
+        Mount argument completion works only for the single path (implicit) form. The
+        reason is that colons break words in bash completion:
+        http://tiswww.case.edu/php/chet/bash/FAQ (E13)
+        Thus, we do not even attempt to auto-complete mount arguments that include
+        colons: such arguments will not even reach this method.
+        """
+        return [CompletionItem(incomplete, type="file")]
 
 
 mount_option = click.option(

--- a/tutor/hooks/consts.py
+++ b/tutor/hooks/consts.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 __license__ = "Apache 2.0"
 
 from typing import Any, Callable
+
 import click
 
 from tutor.types import Config


### PR DESCRIPTION
When typing `tutor local run --mount /path/to/edx-pl<TAB>`, the mount option should be auto-completed to the full edx-platform repo path. That is, if shell completion is enabled:
https://docs.tutor.overhang.io/install.html#shell-autocompletion

Here, we make sure that the implicit form of the `--mount` argument is properly auto-completed. We are unable to get completion to work in the explicit form, because args that include colons do not even reach the `shell_completion` method.