### PR TITLE
fix: init template paths

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -42,8 +42,8 @@ class EnvTests(PluginsTestCase):
         self.assertTrue(env.is_binary_file("/home/somefile.ico"))
 
     def test_find_os_path(self) -> None:
-        renderer = env.Renderer()
-        path = renderer.find_os_path("local/docker-compose.yml")
+        environment = env.JinjaEnvironment()
+        path = environment.find_os_path("local/docker-compose.yml")
         self.assertTrue(os.path.exists(path))
 
     def test_pathjoin(self) -> None:

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -45,15 +45,15 @@ def _add_core_init_tasks() -> None:
     """
     with hooks.Contexts.APP("mysql").enter():
         hooks.Filters.CLI_DO_INIT_TASKS.add_item(
-            ("mysql", env.read_template_file("jobs", "init", "mysql.sh"))
+            ("mysql", env.read_core_template_file("jobs", "init", "mysql.sh"))
         )
     with hooks.Contexts.APP("lms").enter():
         hooks.Filters.CLI_DO_INIT_TASKS.add_item(
-            ("lms", env.read_template_file("jobs", "init", "lms.sh"))
+            ("lms", env.read_core_template_file("jobs", "init", "lms.sh"))
         )
     with hooks.Contexts.APP("cms").enter():
         hooks.Filters.CLI_DO_INIT_TASKS.add_item(
-            ("cms", env.read_template_file("jobs", "init", "cms.sh"))
+            ("cms", env.read_core_template_file("jobs", "init", "cms.sh"))
         )
 
 

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -139,7 +139,7 @@ def get_template(filename: str) -> Config:
 
     Entries in this configuration are unrendered.
     """
-    config = serialize.load(env.read_template_file("config", filename))
+    config = serialize.load(env.read_core_template_file("config", filename))
     return cast_config(config)
 
 


### PR DESCRIPTION
Plugin template paths of init jobs could not be found because they were searched for in the Tutor template root only.