### PR TITLE
fix: minimum click version is 8.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 appdirs
-click>=7.0
+click>=8.0
 mypy
 pycryptodome
 jinja2


### PR DESCRIPTION
An issue was reported here: https://app.slack.com/client/T02SNA1T6/CGE253B7V

CompletionItem was introduced in 8.0, so click needs to be upgraded when we `pip install tutor`.