### PR TITLE
fix: TemplateSyntaxError with old jinja2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,6 @@ appdirs
 click>=8.0
 mypy
 pycryptodome
-jinja2
+jinja2>=2.10
 kubernetes
 pyyaml>=4.2b1


### PR DESCRIPTION
The following syntax is only supported in jinja2>=2.10:

    {% set jwt_rsa_key | rsa_import_key %}{{ JWT_RSA_PRIVATE_KEY }}{% endset %}

Thus, we bump the minimal working version of jinja2 in the base requirements.

See discussion: https://discuss.openedx.org/t/error-while-tutor-local-quickstart/8796