### PR TITLE
sec: fix XSS vulnerability in drag-n-drop v2 xblock

### DIFF
--- a/changelog.d/20221129_083631_regis_sec_drag_n_drop.md
+++ b/changelog.d/20221129_083631_regis_sec_drag_n_drop.md
@@ -1,0 +1,1 @@
+- [Security] Apply drag-n-drop v2 xblock [security patch](https://discuss.openedx.org/t/upcoming-security-release-xblock-drag-and-drop-v2/8768/7). (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -56,6 +56,9 @@ RUN curl -fsSL https://github.com/overhangio/edx-platform/commit/3f0f9eed42.patc
 # Fix XSS vulnerability on "next" parameter
 # https://github.com/overhangio/edx-platform/tree/overhangio/sec-redirect-xss
 RUN curl -fsSL https://github.com/overhangio/edx-platform/commit/e16f8c0986.patch | git am
+# Fix drag-n-drop v2 xblock vulnerability
+# https://github.com/openedx/edx-platform/pull/31354
+RUN curl -fsSL https://github.com/overhangio/edx-platform/commit/527b4993ae.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
Vulnerability is fixed by upgrading the xblock from v2.3.5 to v3.0.0. See announcement:
https://discuss.openedx.org/t/upcoming-security-release-xblock-drag-and-drop-v2/8768