### PR TITLE
fix: update problem templates according newer python versions

### DIFF
--- a/changelog.d/20221207_071139_maria.grimaldi_fix_problem_templates.md
+++ b/changelog.d/20221207_071139_maria.grimaldi_fix_problem_templates.md
@@ -1,0 +1,1 @@
+- [Bugfix] Update problem templates according newer python versions. (by @mariajgrimaldi)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -47,6 +47,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 {{ patch("openedx-dockerfile-git-patches-default") }}
 {%- else %}
 # Patch edx-platform
+# Fix broken Circuit Schematic Builder problem template
+# https://github.com/openedx/edx-platform/pull/31365
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/20b93b8b01276edadddfbbb67f15714fddd81c31.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
### Description
This PR adds a patch that fixes a syntax error in the Circuit Schematic Builder problem template reported [here](https://github.com/openedx/build-test-release-wg/issues/209) during the olive testing plan.

Please, let me know if this is the right place to add this fix.