### PR TITLE
fix: `tutor local upgrade --from=nutmeg`

### DIFF
--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -13,6 +13,7 @@ from tutor.commands import jobs
 from tutor.commands.config import save as config_save_command
 from tutor.commands.context import BaseTaskContext
 from tutor.commands.upgrade.k8s import upgrade_from
+from tutor.commands.upgrade import OPENEDX_RELEASE_NAMES
 from tutor.tasks import BaseTaskRunner
 from tutor.types import Config, get_typed
 
@@ -461,7 +462,7 @@ def wait(context: K8sContext, name: str) -> None:
 @click.option(
     "--from",
     "from_release",
-    type=click.Choice(["ironwood", "juniper", "koa", "lilac", "maple"]),
+    type=click.Choice(OPENEDX_RELEASE_NAMES),
 )
 @click.pass_context
 def upgrade(context: click.Context, from_release: Optional[str]) -> None:

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -10,6 +10,7 @@ from tutor import utils
 from tutor.commands import compose
 from tutor.commands.config import save as config_save_command
 from tutor.commands.upgrade.local import upgrade_from
+from tutor.commands.upgrade import OPENEDX_RELEASE_NAMES
 from tutor.types import Config, get_typed
 
 
@@ -188,7 +189,7 @@ def quickstart(
 @click.option(
     "--from",
     "from_release",
-    type=click.Choice(["ironwood", "juniper", "koa", "lilac", "maple"]),
+    type=click.Choice(OPENEDX_RELEASE_NAMES),
 )
 @click.pass_context
 def upgrade(context: click.Context, from_release: t.Optional[str]) -> None:

--- a/tutor/commands/upgrade/__init__.py
+++ b/tutor/commands/upgrade/__init__.py
@@ -1,0 +1,2 @@
+# Note: don't forget to change this when we upgrade from olive
+OPENEDX_RELEASE_NAMES = ["ironwood", "juniper", "koa", "lilac", "maple", "nutmeg"]


### PR DESCRIPTION
There is nothing to do in the upgrade from nutmeg to olive, but it's not a reason to crash this command.

Close #756.