### PR TITLE
fix: "TypeError: Parameters to Generic[...]" error

### DIFF
--- a/changelog.d/20221212_235220_regis_fix_parameters_to_generic.md
+++ b/changelog.d/20221212_235220_regis_fix_parameters_to_generic.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix "TypeError: Parameters to Generic[...] must all be type variables" error. This error may occur when upgrading from a very old installation of Tutor. It is due to an old version of the typing-extensions package.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,8 @@
 appdirs
 click>=8.0
-mypy
-pycryptodome
 jinja2>=2.10
 kubernetes
+mypy
+pycryptodome
 pyyaml>=6.0
+typing-extensions>=4.4.0


### PR DESCRIPTION
People running typing-extensions==3.10 faced this error for just any tutor command:

    $ tutor version
    ...
    Traceback (most recent call last):
      File "/usr/local/bin/tutor", line 5, in <module>
        from tutor.commands.cli import main
      File "/usr/local/lib/python3.8/dist-packages/tutor/commands/cli.py", line 7, in <module>
        from tutor import exceptions, fmt, hooks, utils
      File "/usr/local/lib/python3.8/dist-packages/tutor/hooks/__init__.py", line 7, in <module>
        from . import actions, contexts, filters, priorities
      File "/usr/local/lib/python3.8/dist-packages/tutor/hooks/actions.py", line 18, in <module>
        class ActionCallback(Contextualized, t.Generic[P]):
      File "/usr/lib/python3.8/typing.py", line 261, in inner
        return func(*args, **kwds)
      File "/usr/lib/python3.8/typing.py", line 890, in __class_getitem__
        raise TypeError(
    TypeError: Parameters to Generic[...] must all be type variables

We fix this error by requiring a more recent version of typing-extensions.

See: https://discuss.openedx.org/t/tutor-v15-python-error-when-running-on-quickstart/8910/2