### PR TITLE
olive fixes

### DIFF
--- a/changelog.d/20221213_083234_regis_dev.md
+++ b/changelog.d/20221213_083234_regis_dev.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgrade ipdb and ipython packages in the openedx development image. (by @regisb)

--- a/changelog.d/20221213_090356_regis_dev.md
+++ b/changelog.d/20221213_090356_regis_dev.md
@@ -1,0 +1,1 @@
+- [Improvement] Skip unnecessary image building in development. This should make `tutor dev launch` slightly faster. (by @regisb)

--- a/changelog.d/20221213_102202_regis_dev.md
+++ b/changelog.d/20221213_102202_regis_dev.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix Authn MFE login in development by disabling enterprise integration. (by @regisb)

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -98,9 +98,6 @@ Tutor may not work if Docker is configured with < 4 GB RAM. Please follow instru
         click.echo(fmt.title("Docker image updates"))
         context.invoke(compose.dc_command, command="pull")
 
-    click.echo(fmt.title("Building Docker image for LMS and CMS development"))
-    context.invoke(compose.dc_command, command="build", args=["lms"])
-
     click.echo(fmt.title("Starting the platform in detached mode"))
     context.invoke(compose.start, detach=True)
 

--- a/tutor/templates/apps/openedx/settings/lms/development.py
+++ b/tutor/templates/apps/openedx/settings/lms/development.py
@@ -24,7 +24,11 @@ SESSION_COOKIE_SAMESITE = "Lax"
 # CMS authentication
 IDA_LOGOUT_URI_LIST.append("http://{{ CMS_HOST }}:8001/logout/")
 
-FEATURES['ENABLE_COURSEWARE_MICROFRONTEND'] = False
+FEATURES["ENABLE_COURSEWARE_MICROFRONTEND"] = False
+
+# Disable enterprise integration
+FEATURES["ENABLE_ENTERPRISE_INTEGRATION"] = False
+SYSTEM_WIDE_ROLE_CLASSES.remove("enterprise.SystemWideEnterpriseUserRoleAssignment")
 
 LOGGING["loggers"]["oauth2_provider"] = {
     "handlers": ["console"],

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -223,7 +223,9 @@ USER app
 
 # Install dev python requirements
 RUN pip install -r requirements/edx/development.txt
-RUN pip install ipdb==0.13.4 ipython==7.27.0
+# https://pypi.org/project/ipdb/
+# https://pypi.org/project/ipython
+RUN pip install ipdb==0.13.9 ipython==8.7.0
 
 # Add ipdb as default PYTHONBREAKPOINT
 ENV PYTHONBREAKPOINT=ipdb.set_trace


### PR DESCRIPTION
- Upgrade openedx dev dependencies
- Skip separate openedx-dev building in `tutor dev launch`.
- Fix authn login in development (see [this conversation](https://discuss.overhang.io/t/tutor-login-fail-in-new-version/3083))