### PR TITLE
depr: get rid of `quickstart` command

### DIFF
--- a/changelog.d/20221213_131305_regis_no_quickstart.md
+++ b/changelog.d/20221213_131305_regis_no_quickstart.md
@@ -1,0 +1,1 @@
+- 💥[Deprecation] Get rid of the `quickstart` command. v15.0.0 introduced a deprecation warning, but we actually want users to stop using this command. Instead, use `launch` (by @regisb).

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -120,28 +120,6 @@ Your Open edX platform is ready and can be accessed at the following urls:
     )
 
 
-@click.command(help="Deprecated alias to 'launch'")
-@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
-@click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
-@compose.mount_option
-@click.pass_context
-def quickstart(
-    context: click.Context,
-    non_interactive: bool,
-    pullimages: bool,
-    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
-) -> None:
-    """
-    This command has been renamed to 'launch'.
-    """
-    fmt.echo_alert(
-        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
-    )
-    context.invoke(
-        launch, non_interactive=non_interactive, pullimages=pullimages, mounts=mounts
-    )
-
-
 @hooks.Actions.COMPOSE_PROJECT_STARTED.add()
 def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
     """
@@ -154,5 +132,4 @@ def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
 
 
 dev.add_command(launch)
-dev.add_command(quickstart)
 compose.add_commands(dev)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -236,19 +236,6 @@ Press enter when you are ready to continue"""
     )
 
 
-@click.command(help="Configure and run Open edX from scratch")
-@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
-@click.pass_context
-def quickstart(context: click.Context, non_interactive: bool) -> None:
-    """
-    This command has been renamed to 'launch'.
-    """
-    fmt.echo_alert(
-        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
-    )
-    context.invoke(launch, non_interactive=non_interactive)
-
-
 @click.command(
     short_help="Run all configured Open edX resources",
     help=(
@@ -564,7 +551,6 @@ def k8s_namespace(config: Config) -> str:
 
 
 k8s.add_command(launch)
-k8s.add_command(quickstart)
 k8s.add_command(start)
 k8s.add_command(stop)
 k8s.add_command(reboot)

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -160,28 +160,6 @@ Your Open edX platform is ready and can be accessed at the following urls:
     )
 
 
-@click.command(help="Deprecated alias to 'launch'")
-@compose.mount_option
-@click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
-@click.option("-p", "--pullimages", is_flag=True, help="Update docker images")
-@click.pass_context
-def quickstart(
-    context: click.Context,
-    mounts: t.Tuple[t.List[compose.MountParam.MountType]],
-    non_interactive: bool,
-    pullimages: bool,
-) -> None:
-    """
-    This command has been renamed to 'launch'.
-    """
-    fmt.echo_alert(
-        "The 'quickstart' command is deprecated and will be removed in a later release. Use 'launch' instead."
-    )
-    context.invoke(
-        launch, non_interactive=non_interactive, pullimages=pullimages, mounts=mounts
-    )
-
-
 @click.command(
     short_help="Perform release-specific upgrade tasks",
     help="Perform release-specific upgrade tasks. To perform a full upgrade remember to run `launch`.",
@@ -219,6 +197,5 @@ def _stop_on_dev_start(root: str, config: Config, project_name: str) -> None:
 
 
 local.add_command(launch)
-local.add_command(quickstart)
 local.add_command(upgrade)
 compose.add_commands(local)


### PR DESCRIPTION
We meant to get rid of `quickstart` in Olive, but somehow we forgot to delete the command.