### PR TITLE
feat: backfill persistent grades during upgrade

### DIFF
--- a/changelog.d/20221213_163837_regis_backfill_persistent_grades.md
+++ b/changelog.d/20221213_163837_regis_backfill_persistent_grades.md
@@ -1,0 +1,1 @@
+- [Improvement] Backfill persistent grades during upgrade from Nutmeg. If you observe missing grades after the upgrade from Nutmeg, run `tutor local upgrade --from=nutmeg`. (by @regisb)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -475,7 +475,7 @@ def upgrade(context: click.Context, from_release: Optional[str]) -> None:
             "This command only performs a partial upgrade of your Open edX platform. "
             "To perform a full upgrade, you should run `tutor k8s launch`."
         )
-        upgrade_from(context.obj, from_release)
+        upgrade_from(context, from_release)
     # We update the environment to update the version
     context.invoke(config_save_command)
 

--- a/tutor/commands/upgrade/common.py
+++ b/tutor/commands/upgrade/common.py
@@ -1,3 +1,5 @@
+import click
+
 from tutor import config as tutor_config
 from tutor import fmt, plugins
 from tutor.types import Config
@@ -31,3 +33,9 @@ def upgrade_from_lilac(config: Config) -> None:
         )
         plugins.load("mfe")
         tutor_config.save_enabled_plugins(config)
+
+
+def upgrade_from_nutmeg(context: click.Context, config: Config) -> None:
+    context.obj.job_runner(config).run_task(
+        "lms", "./manage.py lms compute_grades -v1 --all_courses"
+    )

--- a/tutor/commands/upgrade/k8s.py
+++ b/tutor/commands/upgrade/k8s.py
@@ -1,3 +1,5 @@
+import click
+
 from tutor import config as tutor_config
 from tutor import env as tutor_env
 from tutor import fmt
@@ -8,8 +10,8 @@ from tutor.types import Config
 from . import common as common_upgrade
 
 
-def upgrade_from(context: Context, from_release: str) -> None:
-    config = tutor_config.load(context.root)
+def upgrade_from(context: click.Context, from_release: str) -> None:
+    config = tutor_config.load(context.obj.root)
 
     running_release = from_release
     if running_release == "ironwood":
@@ -29,11 +31,11 @@ def upgrade_from(context: Context, from_release: str) -> None:
         running_release = "maple"
 
     if running_release == "maple":
-        upgrade_from_maple(context, config)
+        upgrade_from_maple(context.obj, config)
         running_release = "nutmeg"
 
     if running_release == "nutmeg":
-        # Upgrade is a no-op
+        common_upgrade.upgrade_from_nutmeg(context, config)
         running_release = "olive"
 
 

--- a/tutor/commands/upgrade/local.py
+++ b/tutor/commands/upgrade/local.py
@@ -36,7 +36,7 @@ def upgrade_from(context: click.Context, from_release: str) -> None:
         running_release = "nutmeg"
 
     if running_release == "nutmeg":
-        # Upgrade is a no-op
+        common_upgrade.upgrade_from_nutmeg(context, config)
         running_release = "olive"
 
 


### PR DESCRIPTION
In Olive, persistent grades are now mandatory. This was already the case in Nutmeg, but it didn't mean that existing, non-persistent grades were migrated to be persistent. This introduces a job that is run whenever a user upgrades from Nutmeg. Alternatively, it can be run manually with:

    tutor local upgrade --from=nutmeg

See relevant documentation: https://openedx.atlassian.net/wiki/spaces/AC/pages/755171487/Migrating+to+Persistent+Grading#The-Persistent-Grades-Backfill
See discussion: https://app.slack.com/client/T02SNA1T6/C049JQZFR5E/thread/C02SNA1U4-1670937183.881709