### PR TITLE
fix: 'example.com' links in registration emails

### DIFF
--- a/changelog.d/20230106_163518_regis_fix_example_com_links.md
+++ b/changelog.d/20230106_163518_regis_fix_example_com_links.md
@@ -1,0 +1,1 @@
+- 💥[Bugfix] Fix "example.com" links in registration emails. This is a breaking change for platforms that have modified the "id" field of the LMS site object in the database. These platforms should set `SITE_ID=1` in the common settings via a plugin. (by @regisb)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -78,6 +78,10 @@ CACHES = {
     },
 }
 
+# The default Django contrib site is the one associated to the LMS domain name. 1 is
+# usually "example.com", so it's the next available integer.
+SITE_ID = 2
+
 # Contact addresses
 CONTACT_MAILING_ADDRESS = "{{ PLATFORM_NAME }} - {% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
 DEFAULT_FROM_EMAIL = ENV_TOKENS.get("DEFAULT_FROM_EMAIL", ENV_TOKENS["CONTACT_EMAIL"])


### PR DESCRIPTION
When a user registers, they receive a confirmation email. This email contained two links to "https://example.com/..." urls. This was caused by the fact that the default site, indicated by SITE_ID=1, was example.com. We resolve this issue by setting instead SITE_ID=2, which should point to the site with the LMS domain name.

This is a potentially breaking change for platforms that have manually set to 1 the id of the LMS site in the database. These platforms should now set SITE_ID=1 via a plugin.

Alternatives we have considered include modifying the id field of the LMS site in the database. Unfortunately such a change would have important consequences, as the site ID is used as a foreign key for other models.

Note that non-https sites still include https links in the registration emails. This is because the "https" scheme is hardcoded by the "ensure_url_is_absolute" utility function. So there is nothing we can do about this without making changes upstream.

Close #572.