### PR TITLE
fix: start and wait for mysql if RUN_MYSQL was true

### DIFF
--- a/tutor/commands/upgrade/k8s.py
+++ b/tutor/commands/upgrade/k8s.py
@@ -120,13 +120,14 @@ def upgrade_from_maple(context: Context, config: Config) -> None:
     # The environment needs to be updated because the backpopulate/backfill commands are from Nutmeg
     tutor_env.save(context.root, config)
 
-    # Start mysql
-    k8s.kubectl_apply(
-        context.root,
-        "--selector",
-        "app.kubernetes.io/name=mysql",
-    )
-    k8s.wait_for_deployment_ready(config, "mysql")
+    if config["RUN_MYSQL"]:
+        # Start mysql
+        k8s.kubectl_apply(
+            context.root,
+            "--selector",
+            "app.kubernetes.io/name=mysql",
+        )
+        k8s.wait_for_deployment_ready(config, "mysql")
 
     # lms upgrade
     k8s.kubectl_apply(


### PR DESCRIPTION
this will fix https://github.com/overhangio/tutor/issues/777
if you want to upgrade from maple to nutmeg and you were hosting your MySQL somewhere like RDS, and RUN_MYSQL is set to false.

running `tutor k8s upgrade --from=maple` will fail since there's no MySQL deployment.
this will check `RUN_MYSQL` value and make sure it's not `false`.

p.s: this is the 777th PR of Tutor which fix the 777th issue. 😄

