### PR TITLE
fix: backport fix for html component editing in studio

### DIFF
--- a/changelog.d/20230109_134927_regis_fix_tinymce_formatting.md
+++ b/changelog.d/20230109_134927_regis_fix_tinymce_formatting.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix HTML component editing in studio by cherry-picking [upstream fix](https://github.com/openedx/edx-platform/pull/31500). (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -50,6 +50,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Fix broken Circuit Schematic Builder problem template
 # https://github.com/openedx/edx-platform/pull/31365
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/20b93b8b01276edadddfbbb67f15714fddd81c31.patch | git am
+# Fix TinyMCE editor for html components
+# https://github.com/openedx/edx-platform/pull/31500
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/5af42f8ba3.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
See: https://discuss.openedx.org/t/text-component-does-not-remove-text-with-link-or-insert-a-link-to-text/9029