### PR TITLE
fix: get rid of `CORS_ORIGIN_WHITELIST` from lms/cms logs

### DIFF
--- a/changelog.d/20230117_165024_regis_cors_whitelist.md
+++ b/changelog.d/20230117_165024_regis_cors_whitelist.md
@@ -1,0 +1,1 @@
+- [Improvement] Resolve `CORS_ORIGIN_WHITELIST` warnings that pollute the LMS and CMS logs. As far as we know they were not causing any issue, apart from being a nuisance. (by @regisb)

--- a/tutor/templates/apps/openedx/settings/cms/production.py
+++ b/tutor/templates/apps/openedx/settings/cms/production.py
@@ -8,6 +8,7 @@ ALLOWED_HOSTS = [
     ENV_TOKENS.get("CMS_BASE"),
     "cms",
 ]
+CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}")
 
 # Authentication
 SOCIAL_AUTH_EDX_OAUTH2_KEY = "{{ CMS_OAUTH2_KEY_SSO }}"

--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -9,6 +9,7 @@ ALLOWED_HOSTS = [
     FEATURES["PREVIEW_LMS_BASE"],
     "lms",
 ]
+CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}")
 
 {% if ENABLE_HTTPS %}
 # Properly set the "secure" attribute on session/csrf cookies. This is required in


### PR DESCRIPTION
The LMS and CMS were producing lots of logs similar to:

    cms_1                        | 2023-01-17 15:30:11,359 INFO 7 [openedx.core.djangoapps.cors_csrf.helpers] [user 7] [ip 31.223.46.44] helpers.py:64 - Origin 'https://studio.demo.openedx.overhang.io' was not in `CORS_ORIGIN_WHITELIST`; full referer was 'https://studio.demo.openedx.overhang.io/learning/course/course-v1:edX+DemoX+Demo_Course/home' and requested host was 'studio.demo.openedx.overhang.io'; CORS_ORIGIN_ALLOW_ALL=False

These warnings are produced by openedx.core.djangoapps.cors_csrf.helpers. I don't think they indicate any problem, but they pollute the logs. They are resolved by adding the "http(s)://<lms/cms host>" to CORS_ORIGIN_WHITELIST in production, so we did just that.