### PR TITLE
sec: fix LTI consumer xblock grading

### DIFF
--- a/changelog.d/20230209_092607_regis_sec_lti.md
+++ b/changelog.d/20230209_092607_regis_sec_lti.md
@@ -1,0 +1,1 @@
+- [Security] Fix grading issue in LTI consumer XBlock. See [security advisory](https://github.com/openedx/xblock-lti-consumer/security/advisories/GHSA-7j9p-67mm-5g87). (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -53,6 +53,9 @@ RUN curl -fsSL https://github.com/openedx/edx-platform/commit/20b93b8b01276edadd
 # Fix TinyMCE editor for html components
 # https://github.com/openedx/edx-platform/pull/31500
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/5af42f8ba3.patch | git am
+# Fix security issue in lti-consumer-xblock
+# https://github.com/openedx/edx-platform/pull/31724
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/5f901a35d2.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
See advisory:
https://github.com/openedx/xblock-lti-consumer/security/advisories/GHSA-7j9p-67mm-5g87 Discussion:
https://discuss.openedx.org/t/upcoming-security-release-xblock-lti-consumer/9165 Pull requests:
https://github.com/openedx/xblock-lti-consumer/pull/331 https://github.com/openedx/edx-platform/pull/31724