### PR TITLE
chore: upgrade requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,7 @@ rst_prolog = f"""
 .. |tutor_version| replace:: {about["__version__"]}
 """
 
+
 # Custom directives
 def youtube(
     _name: Any,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,17 +6,17 @@
 #
 appdirs==1.4.4
     # via -r requirements/base.in
-cachetools==5.2.0
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
     #   kubernetes
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via -r requirements/base.in
-google-auth==2.15.0
+google-auth==2.16.0
     # via kubernetes
 idna==3.4
     # via requests
@@ -24,11 +24,11 @@ jinja2==3.1.2
     # via -r requirements/base.in
 kubernetes==25.3.0
     # via -r requirements/base.in
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mypy==1.0.0
     # via -r requirements/base.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via mypy
 oauthlib==3.2.2
     # via requests-oauthlib
@@ -38,7 +38,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycryptodome==3.16.0
+pycryptodome==3.17
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via kubernetes
@@ -46,7 +46,7 @@ pyyaml==6.0
     # via
     #   -r requirements/base.in
     #   kubernetes
-requests==2.28.1
+requests==2.28.2
     # via
     #   kubernetes
     #   requests-oauthlib
@@ -65,11 +65,11 @@ typing-extensions==4.4.0
     # via
     #   -r requirements/base.in
     #   mypy
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   kubernetes
     #   requests
-websocket-client==1.4.2
+websocket-client==1.5.1
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,17 +8,17 @@ altgraph==0.17.3
     # via pyinstaller
 appdirs==1.4.4
     # via -r requirements/base.txt
-astroid==2.12.13
+astroid==2.14.1
     # via pylint
-attrs==22.1.0
+attrs==22.2.0
     # via scriv
-black==22.10.0
+black==23.1.0
     # via -r requirements/dev.in
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-build==0.9.0
+build==0.10.0
     # via pip-tools
-cachetools==5.2.0
+cachetools==5.3.0
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -29,7 +29,7 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -42,11 +42,9 @@ click==8.1.3
     #   scriv
 click-log==0.4.0
     # via scriv
-commonmark==0.9.1
-    # via rich
-coverage==6.5.0
+coverage==7.1.0
     # via -r requirements/dev.in
-cryptography==38.0.4
+cryptography==39.0.1
     # via secretstorage
 dill==0.3.6
     # via pylint
@@ -54,7 +52,7 @@ docutils==0.17.1
     # via
     #   -r requirements/dev.in
     #   readme-renderer
-google-auth==2.15.0
+google-auth==2.16.0
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -66,7 +64,7 @@ importlib-metadata==6.0.0
     # via
     #   keyring
     #   twine
-isort==5.10.1
+isort==5.12.0
     # via pylint
 jaraco-classes==3.2.3
     # via keyring
@@ -78,23 +76,27 @@ jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   scriv
-keyring==23.11.0
+keyring==23.13.1
     # via twine
 kubernetes==25.3.0
     # via -r requirements/base.txt
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markdown-it-py==2.1.0
+    # via rich
+markupsafe==2.1.2
     # via
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.7.0
     # via pylint
+mdurl==0.1.2
+    # via markdown-it-py
 more-itertools==9.0.0
     # via jaraco-classes
 mypy==1.0.0
     # via -r requirements/base.txt
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   -r requirements/base.txt
     #   black
@@ -103,17 +105,17 @@ oauthlib==3.2.2
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
-packaging==22.0
-    # via build
-pathspec==0.10.2
+packaging==23.0
+    # via
+    #   black
+    #   build
+pathspec==0.11.0
     # via black
-pep517==0.13.0
-    # via build
-pip-tools==6.11.0
+pip-tools==6.12.2
     # via -r requirements/dev.in
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   black
     #   pylint
@@ -128,18 +130,20 @@ pyasn1-modules==0.2.8
     #   google-auth
 pycparser==2.21
     # via cffi
-pycryptodome==3.16.0
+pycryptodome==3.17
     # via -r requirements/base.txt
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   rich
 pyinstaller==5.7.0
     # via -r requirements/dev.in
-pyinstaller-hooks-contrib==2022.14
+pyinstaller-hooks-contrib==2022.15
     # via pyinstaller
-pylint==2.15.8
+pylint==2.16.1
     # via -r requirements/dev.in
+pyproject-hooks==1.0.0
+    # via build
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
@@ -150,7 +154,7 @@ pyyaml==6.0
     #   kubernetes
 readme-renderer==37.3
     # via twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -166,13 +170,13 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.3.1
     # via twine
 rsa==4.9
     # via
     #   -r requirements/base.txt
     #   google-auth
-scriv==1.1.0
+scriv==1.2.0
     # via -r requirements/dev.in
 secretstorage==3.3.3
     # via keyring
@@ -189,23 +193,26 @@ tomli==2.0.1
     #   black
     #   build
     #   mypy
-    #   pep517
     #   pylint
+    #   pyproject-hooks
 tomlkit==0.11.6
     # via pylint
 twine==4.0.2
     # via -r requirements/dev.in
-types-docutils==0.19.1.1
+types-docutils==0.19.1.3
+    # via
+    #   -r requirements/dev.in
+    #   types-setuptools
+types-pyyaml==6.0.12.4
     # via -r requirements/dev.in
-types-pyyaml==6.0.12.2
-    # via -r requirements/dev.in
-types-setuptools==65.6.0.2
+types-setuptools==67.2.0.1
     # via -r requirements/dev.in
 typing-extensions==4.4.0
     # via
     #   -r requirements/base.txt
+    #   astroid
     #   mypy
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -213,7 +220,7 @@ urllib3==1.26.13
     #   twine
 webencodings==0.5.1
     # via bleach
-websocket-client==1.4.2
+websocket-client==1.5.1
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -221,7 +228,7 @@ wheel==0.38.4
     # via pip-tools
 wrapt==1.14.1
     # via astroid
-zipp==3.11.0
+zipp==3.12.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements/docs.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 appdirs==1.4.4
     # via -r requirements/base.txt
 babel==2.11.0
     # via sphinx
-cachetools==5.2.0
+cachetools==5.3.0
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -19,7 +19,7 @@ certifi==2022.12.7
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -27,12 +27,12 @@ click==8.1.3
     # via
     #   -r requirements/base.txt
     #   sphinx-click
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   sphinx
     #   sphinx-click
     #   sphinx-rtd-theme
-google-auth==2.15.0
+google-auth==2.16.0
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -48,13 +48,13 @@ jinja2==3.1.2
     #   sphinx
 kubernetes==25.3.0
     # via -r requirements/base.txt
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/base.txt
     #   jinja2
 mypy==1.0.0
     # via -r requirements/base.txt
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   -r requirements/base.txt
     #   mypy
@@ -62,7 +62,7 @@ oauthlib==3.2.2
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
-packaging==22.0
+packaging==23.0
     # via sphinx
 pyasn1==0.4.8
     # via
@@ -73,21 +73,21 @@ pyasn1-modules==0.2.8
     # via
     #   -r requirements/base.txt
     #   google-auth
-pycryptodome==3.16.0
+pycryptodome==3.17
     # via -r requirements/base.txt
-pygments==2.13.0
+pygments==2.14.0
     # via sphinx
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   kubernetes
-pytz==2022.6
+pytz==2022.7.1
     # via babel
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   kubernetes
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -109,21 +109,23 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r requirements/docs.in
     #   sphinx-click
     #   sphinx-rtd-theme
 sphinx-click==4.4.0
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -138,12 +140,12 @@ typing-extensions==4.4.0
     # via
     #   -r requirements/base.txt
     #   mypy
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-websocket-client==1.4.2
+websocket-client==1.5.1
     # via
     #   -r requirements/base.txt
     #   kubernetes

--- a/tests/commands/test_compose.py
+++ b/tests/commands/test_compose.py
@@ -13,7 +13,6 @@ from tutor.commands.local import LocalContext
 
 
 class ComposeTests(unittest.TestCase):
-
     maxDiff = None  # Ensure we can see long diffs of YAML files.
 
     def test_mount_option_parsing(self) -> None:

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -24,7 +24,6 @@ def config_command() -> None:
 
 
 class ConfigKeyParamType(click.ParamType):
-
     name = "configkey"
 
     def shell_complete(

--- a/tutor/core/hooks/filters.py
+++ b/tutor/core/hooks/filters.py
@@ -149,7 +149,6 @@ class Filter(t.Generic[T1, T2]):
         for callback in self.callbacks:
             if callback.is_in_context(context):
                 try:
-
                     value = callback.apply(
                         value,
                         *args,
@@ -225,6 +224,7 @@ class Filter(t.Generic[T1, T2]):
             my_filter.add_item("item1")
             my_filter.add_item("item2")
         """
+
         # Unfortunately we have to type-ignore this line. If not, mypy complains with:
         #
         #   Argument 1 has incompatible type "Callable[[Arg(List[E], 'values'), **T2], List[E]]"; expected "Callable[[List[E], **T2], List[E]]"


### PR DESCRIPTION
Cryptography in particular needs to be upgraded to 39.0.1: https://github.com/overhangio/tutor/security/dependabot/7 https://github.com/overhangio/tutor/security/dependabot/8