### PR TITLE
fix: patchStrategicMerge now works for kind:Job

### DIFF
--- a/changelog.d/20230214_105510_keith_fix_jobs_merge.md
+++ b/changelog.d/20230214_105510_keith_fix_jobs_merge.md
@@ -1,0 +1,12 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+[Bugfix] `patchStrategicMerge` can now be applied to jobs (by @keithgg)

--- a/tutor/serialize.py
+++ b/tutor/serialize.py
@@ -17,6 +17,10 @@ def load_all(stream: str) -> t.Iterator[t.Any]:
     return yaml.load_all(stream, Loader=yaml.SafeLoader)
 
 
+def dump_all(content: t.Any, fileobj: TextIOWrapper) -> None:
+    yaml.safe_dump_all(content, stream=fileobj, default_flow_style=False)
+
+
 def dump(content: t.Any, fileobj: TextIOWrapper) -> None:
     yaml.dump(content, stream=fileobj, default_flow_style=False)
 

--- a/tutor/serialize.py
+++ b/tutor/serialize.py
@@ -17,8 +17,8 @@ def load_all(stream: str) -> t.Iterator[t.Any]:
     return yaml.load_all(stream, Loader=yaml.SafeLoader)
 
 
-def dump_all(content: t.Any, fileobj: TextIOWrapper) -> None:
-    yaml.safe_dump_all(content, stream=fileobj, default_flow_style=False)
+def dump_all(documents: t.Sequence[t.Any], fileobj: TextIOWrapper) -> None:
+    yaml.safe_dump_all(documents, stream=fileobj, default_flow_style=False)
 
 
 def dump(content: t.Any, fileobj: TextIOWrapper) -> None:


### PR DESCRIPTION
## Description

When a job is invoked, we now replace the job in k8s/jobs.yml instead of rewriting jobs.yml to only contain the relevant job. This allows patchStrategicMerge to work for jobs.

Fixes #791.

## Testing instructions

```
pip install --upgrade tutor-forum tutor-mfe git+https://gitlab.com/opencraft/dev/tutor-contrib-grove@keith/tutor-override-test
tutor plugins enable forum grove mfe
tutor config save
tutor k8s launch
```

`tutor k8s launch` will fail without these changes.