### PR TITLE
refactor: move format_table function to utils

### DIFF
--- a/tests/commands/test_plugins.py
+++ b/tests/commands/test_plugins.py
@@ -56,17 +56,3 @@ class PluginsTests(unittest.TestCase, TestCommandMixin):
         self.assertEqual(
             ["all", "alba"], plugins_commands.PluginName(allow_all=True).get_names("al")
         )
-
-    def test_format_table(self) -> None:
-        rows: t.List[t.Tuple[str, ...]] = [
-            ("a", "xyz", "value 1"),
-            ("abc", "x", "value 12345"),
-        ]
-        formatted = plugins_commands.format_table(rows, separator="  ")
-        self.assertEqual(
-            """
-a    xyz  value 1
-abc  x    value 12345
-""".strip(),
-            formatted,
-        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from io import StringIO
+from typing import List, Tuple
 from unittest.mock import MagicMock, mock_open, patch
 
 from tutor import exceptions, utils
@@ -239,3 +240,17 @@ class UtilsTests(unittest.TestCase):
         self.assertFalse(utils.is_http("/home/user/"))
         self.assertFalse(utils.is_http("home/user/"))
         self.assertFalse(utils.is_http("http-home/user/"))
+
+    def test_format_table(self) -> None:
+        rows: List[Tuple[str, ...]] = [
+            ("a", "xyz", "value 1"),
+            ("abc", "x", "value 12345"),
+        ]
+        formatted = utils.format_table(rows, separator="  ")
+        self.assertEqual(
+            """
+a    xyz  value 1
+abc  x    value 12345
+""".strip(),
+            formatted,
+        )

--- a/tutor/commands/plugins.py
+++ b/tutor/commands/plugins.py
@@ -128,7 +128,7 @@ def list_command(show_enabled_only: bool) -> None:
                     (plugin_info or "").replace("\n", " "),
                 )
             )
-    fmt.echo(format_table(plugins_table))
+    fmt.echo(utils.format_table(plugins_table))
 
 
 @click.command(help="Enable a plugin")
@@ -302,7 +302,7 @@ def search(pattern: str) -> None:
                     plugin.short_description,
                 )
             )
-    print(format_table(results))
+    print(utils.format_table(results))
 
 
 @click.command()
@@ -406,34 +406,6 @@ def index_remove(context: Context, url: str) -> None:
         update_indexes(config)
     else:
         fmt.echo_alert("Plugin index not present")
-
-
-def format_table(rows: t.List[t.Tuple[str, ...]], separator: str = "\t") -> str:
-    """
-    Format a list of values as a tab-separated table. Column sizes are determined such
-    that row values are vertically aligned.
-    """
-    formatted = ""
-    if not rows:
-        return formatted
-    columns_count = len(rows[0])
-    # Determine each column size
-    col_sizes = [1] * columns_count
-    for row in rows:
-        for c, value in enumerate(row):
-            col_sizes[c] = max(col_sizes[c], len(value))
-    # Print all values
-    for r, row in enumerate(rows):
-        for c, value in enumerate(row):
-            if c < len(col_sizes) - 1:
-                formatted += f"{value:{col_sizes[c]}}{separator}"
-            else:
-                # The last column is not left-justified
-                formatted += f"{value}"
-        if r < len(rows) - 1:
-            # Append EOL at all lines but the last one
-            formatted += "\n"
-    return formatted
 
 
 index_command.add_command(index_add)

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -345,3 +345,31 @@ def is_http(url: str) -> bool:
     Basic test to check whether a string is a web URL. Use only for basic use cases.
     """
     return re.match(r"^https?://", url) is not None
+
+
+def format_table(rows: List[Tuple[str, ...]], separator: str = "\t") -> str:
+    """
+    Format a list of values as a tab-separated table. Column sizes are determined such
+    that row values are vertically aligned.
+    """
+    formatted = ""
+    if not rows:
+        return formatted
+    columns_count = len(rows[0])
+    # Determine each column size
+    col_sizes = [1] * columns_count
+    for row in rows:
+        for c, value in enumerate(row):
+            col_sizes[c] = max(col_sizes[c], len(value))
+    # Print all values
+    for r, row in enumerate(rows):
+        for c, value in enumerate(row):
+            if c < len(col_sizes) - 1:
+                formatted += f"{value:{col_sizes[c]}}{separator}"
+            else:
+                # The last column is not left-justified
+                formatted += f"{value}"
+        if r < len(rows) - 1:
+            # Append EOL at all lines but the last one
+            formatted += "\n"
+    return formatted


### PR DESCRIPTION
## Description

This PR moves the format_table function to utils to reuse it.

## Additional info

When I try to reuse from plugins, for example, for PR #798, I have this error:
![Screenshot from 2023-02-22 22-26-12](https://user-images.githubusercontent.com/35668326/221383024-564c59f7-a866-47ba-badf-bac19cb52acd.png)

