### PR TITLE
feat: configure uwsgi through an ini file

### DIFF
--- a/changelog.d/20230310_021412_moises.gonzalez_configurable_uwsgi.md
+++ b/changelog.d/20230310_021412_moises.gonzalez_configurable_uwsgi.md
@@ -1,0 +1,12 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+- [Improvement] Make it possible to extend or override the configuration of the uWSGI server. (by @MoisesGSalas)

--- a/docs/reference/patches.rst
+++ b/docs/reference/patches.rst
@@ -356,3 +356,14 @@ Python-formatted LMS settings in development. Values defined here override the v
 File: ``apps/openedx/settings/lms/production.py``
 
 Python-formatted LMS settings in production. Values defined here override the values from :patch:`openedx-lms-common-settings`.
+
+``uwsgi-config``
+================
+
+File: ``apps/openedx/settings/uwsgi.ini``
+
+A .INI formatted file used to extend or override the uWSGI configuration.
+
+Check the uWSGI documentation for more details about the `.INI format <https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#ini-files>`__ and the `list of available options <https://uwsgi-docs.readthedocs.io/en/latest/Options.html>`__.
+
+.. patch:: uwsgi-config

--- a/tutor/templates/apps/openedx/uwsgi.ini
+++ b/tutor/templates/apps/openedx/uwsgi.ini
@@ -1,0 +1,3 @@
+{% include "build/openedx/settings/uwsgi.ini" %}
+{{ patch("uwsgi-config") }}
+

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -251,17 +251,14 @@ CMD ./manage.py $SERVICE_VARIANT runserver 0.0.0.0:8000
 ###### Final image with production cmd
 FROM production as final
 
+# Default amount of uWSGI processes
+ENV UWSGI_WORKERS=2
+
+# Copy the default uWSGI configuration
+COPY --chown=app:app settings/uwsgi.ini .
+
 # Run server
-CMD uwsgi \
-    --static-map /static=/openedx/staticfiles/ \
-    --static-map /media=/openedx/media/ \
-    --http 0.0.0.0:8000 \
-    --thunder-lock \
-    --single-interpreter \
-    --enable-threads \
-    --processes=${UWSGI_WORKERS:-2} \
-    --buffer-size=8192 \
-    --wsgi-file $SERVICE_VARIANT/wsgi.py
+CMD uwsgi uwsgi.ini
 
 {{ patch("openedx-dockerfile-final") }}
 

--- a/tutor/templates/build/openedx/settings/uwsgi.ini
+++ b/tutor/templates/build/openedx/settings/uwsgi.ini
@@ -1,0 +1,10 @@
+[uwsgi]
+static-map = /static=/openedx/staticfiles/
+static-map = /media=/openedx/media/
+http = 0.0.0.0:8000
+buffer-size = 8192
+wsgi-file = $(SERVICE_VARIANT)/wsgi.py
+processes = $(UWSGI_WORKERS)
+thunder-lock = true
+single-interpreter = true
+enable-threads = true

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -94,6 +94,9 @@ spec:
               name: settings-cms
             - mountPath: /openedx/config
               name: config
+            - mountPath: /openedx/edx-platform/uwsgi.ini
+              name: uwsgi-config
+              subPath: uwsgi.ini
           resources:
             requests:
               memory: 2Gi
@@ -109,6 +112,12 @@ spec:
         - name: config
           configMap:
             name: openedx-config
+        - name: uwsgi-config
+          configMap:
+            name: openedx-uwsgi-config
+            items:
+              - key: uwsgi.ini
+                path: uwsgi.ini
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -194,6 +203,9 @@ spec:
               name: settings-cms
             - mountPath: /openedx/config
               name: config
+            - mountPath: /openedx/edx-platform/uwsgi.ini
+              name: uwsgi-config
+              subPath: uwsgi.ini
           resources:
             requests:
               memory: 2Gi
@@ -209,6 +221,12 @@ spec:
         - name: config
           configMap:
             name: openedx-config
+        - name: uwsgi-config
+          configMap:
+            name: openedx-uwsgi-config
+            items:
+            - key: uwsgi.ini
+              path: uwsgi.ini
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -51,6 +51,12 @@ configMapGenerator:
   options:
     labels:
         app.kubernetes.io/name: openedx
+- name: openedx-uwsgi-config
+  files:
+  - apps/openedx/uwsgi.ini
+  options:
+    labels:
+        app.kubernetes.io/name: openedx
 - name: redis-config
   files:
   - apps/redis/redis.conf

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
       - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
       - ../apps/openedx/config:/openedx/config:ro
+      - ../apps/openedx/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
       - ../../data/lms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:
@@ -142,6 +143,7 @@ services:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
       - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
       - ../apps/openedx/config:/openedx/config:ro
+      - ../apps/openedx/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
       - ../../data/cms:/openedx/data
       - ../../data/openedx-media:/openedx/media
     depends_on:


### PR DESCRIPTION
## Description
The current invocation of uwsgi doesn't allow to modify any configuration value besides the amount of workers.

This changes introduces a new patch `uwsgi-config` and a `uwsgi.ini` file to be mounted on the container. This allows us to add additional configuration values or override the existing ones.

I've tested it by manually creating a cookie with a size big enough to exceed the maximum buffer size of 8192. This caused a crash when accessing the base lms page. Afterwards I added a small plugin:

```yaml
name: uwsgi
version: 0.1.0
patches:

  uwsgi-config: |
    buffer-size = 16384
```

And was able to access the page again. I duplicated the cookie a few times and was able to crash it again and the LMS logs reported the increased buffer size:

```
invalid request block size: 20564 (max 16384)...skip
```

## Additional notes

The `if-env` block is particularly ugly but [seems to be](https://github.com/unbit/uwsgi/issues/1604#issuecomment-321320233) the only way use fallback values for env variables. This is to keep changes at a minimum and replicate the previous behaviour.

Interestingly enough, the `UWSGI_WORKERS` variable is not present in the kubernetes deployments, only on the local/docker-compose.yml file. Adding the variable to de K8S deployments and relying on the `OPENEDX_LMS_UWSGI_WORKERS` and `OPENEDX_CMS_UWSGI_WORKERS` values should allow us to remove the `if-env` block while keeping compatibility with people using the variables (note that you can redefine the value of the workers using the patch).

