### PR TITLE
fix: use supported YouTube API for transcripts imports

### DIFF
--- a/changelog.d/20230307_132140_maria.grimaldi_fix_transcripts.md
+++ b/changelog.d/20230307_132140_maria.grimaldi_fix_transcripts.md
@@ -1,0 +1,12 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+[Bugfix] Use supported YouTube API for transcripts imports (by @mariajgrimaldi)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -50,6 +50,10 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Fix broken Circuit Schematic Builder problem template
 # https://github.com/openedx/edx-platform/pull/31365
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/20b93b8b01276edadddfbbb67f15714fddd81c31.patch | git am
+
+# Use supported YouTube API for transcripts imports
+# https://github.com/openedx/edx-platform/pull/31862
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/210dd1d7c211e531b9bc4376d1692a0bb0e6b651.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1> | git am #}


### PR DESCRIPTION
## Description
This PR adds the following fix: https://github.com/openedx/wg-build-test-release/issues/247. This cherry-pick can be removed after olive.3 since a backport was already merged.