### PR TITLE
fix: add the missing `UWSGI_WORKERS` env variable to the k8s deployments

### DIFF
--- a/changelog.d/20230310_045537_moises.gonzalez_fix_k8s_uwsgi_workers.md
+++ b/changelog.d/20230310_045537_moises.gonzalez_fix_k8s_uwsgi_workers.md
@@ -1,0 +1,12 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+- [Bugfix] Add the missing `UWSGI_WORKERS` env variables to the lms and cms k8s deployments. (by @MoisesGSalas)

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -85,6 +85,8 @@ spec:
             value: cms
           - name: DJANGO_SETTINGS_MODULE
             value: cms.envs.tutor.production
+          - name: UWSGI_WORKERS
+            value: "{{ OPENEDX_CMS_UWSGI_WORKERS }}"
           ports:
             - containerPort: 8000
           volumeMounts:
@@ -185,6 +187,8 @@ spec:
             value: lms
           - name: DJANGO_SETTINGS_MODULE
             value: lms.envs.tutor.production
+          - name: UWSGI_WORKERS
+            value: "{{ OPENEDX_LMS_UWSGI_WORKERS }}"
           ports:
             - containerPort: 8000
           volumeMounts:


### PR DESCRIPTION
## Description

The amount of workers processes that uWSGI spawns can be configured through the environment variable `UWSGI_WORKERS` which in turn can be adjusted with the `OPENEDX_LMS_UWSGI_WORKERS` and `OPENEDX_CMS_UWSGI_WORKERS` variables.

This env variable was missing from the k8s deployments.