### PR TITLE
feat: full edx-platform setup with `tutor dev launch -m ...`

### DIFF
--- a/changelog.d/20230313_110919_kdmc_mounted_init.md
+++ b/changelog.d/20230313_110919_kdmc_mounted_init.md
@@ -1,0 +1,1 @@
+- [Improvement] Running ``tutor dev launch --mount=edx-platform`` now performs all necessary setup for a local edx-platform development. This includes running setup.py, installing node modules, and building assets; previously, those steps had to be run explicitly after bind-mounting a local copy of edx-platform (by @kdmccormick).

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -10,24 +10,24 @@ In addition to running Open edX in production, Tutor can be used for local devel
 First-time setup
 ----------------
 
-First, ensure you have already :ref:`installed Tutor <install>` (for development against the named releases of Open edX) or :ref:`Tutor Nightly <nightly>` (for development against Open edX's master branches).
+Firstly, either :ref:`install Tutor <install>` (for development against the named releases of Open edX) or :ref:`install Tutor Nightly <nightly>` (for development against Open edX's master branches).
 
 Then, run one of the following in order to launch the developer platform setup process::
 
-    # To use the edx-platform repository that is built into the image:
+    # To use the edx-platform repository that is built into the image, run:
     tutor dev launch
 
-    # To bind-mount and run your local clone of edx-platform,
-    # where './edx-platform' should be replaced with your local edx-platform's path:
+    # To bind-mount and run a local clone of edx-platform, replace
+    # './edx-platform' with the path to the local clone and run:
     tutor dev launch --mount=./edx-platform
 
-This will perform several tasks for you. It will:
+This will perform several tasks. It will:
 
 * stop any existing locally-running Tutor containers,
 
 * disable HTTPS,
 
-* set your ``LMS_HOST`` to `local.overhang.io <http://local.overhang.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.overhang.io>`_),
+* set ``LMS_HOST`` to `local.overhang.io <http://local.overhang.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.overhang.io>`_),
 
 * prompt for a platform details (with suitable defaults),
 
@@ -39,12 +39,10 @@ This will perform several tasks for you. It will:
 
 * run service initialization scripts, such as service user creation and Waffle configuration.
 
-Additionally, if you chose to bind-mount your local clone of edx-platform, it will:
+Additionally, when a local clone of edx-platform is bind-mounted, it will:
 
 * re-run setup.py,
-
 * clean-reinstall Node modules, and
-
 * regenerate static assets.
 
 Once setup is complete, the platform will be running in the background:
@@ -53,45 +51,45 @@ Once setup is complete, the platform will be running in the background:
 * CMS will be accessible at `http://studio.local.overhang.io:8001 <http://studio.local.overhang.io:8001>`_.
 * Plugged-in services should be accessible at their documented URLs.
 
-Now, you can use the ``tutor dev ...`` command-line interface to manage your development environment. Some common commands are described below.
+Now, use the ``tutor dev ...`` command-line interface to manage the development environment. Some common commands are described below.
 
 .. note::
 
-  Wherever you see ``[--mount=./edx-platform]``, either:
+  Wherever the ``[--mount=./edx-platform]`` option is present, either:
 
-  * omit it, if you are using the edx-platform repository built into the image, or
-  * substitute it with ``--mount=<path/to/your/edx-platform>``.
+  * omit it when running of the edx-platform repository built into the image, or
+  * substitute it with ``--mount=<path/to/edx-platform>``.
 
-  You can :ref:`read more about bind-mounts below <bind_mounts>`.
+  Read more about bind-mounts :ref:`below <bind_mounts>`.
 
 Stopping the platform
 ---------------------
 
-To bring down your platform's containers, simply run::
+To bring down the platform's containers, simply run::
 
   tutor dev stop
 
 Starting the platform back up
 -----------------------------
 
-Once you have used ``launch`` once, you can start the platform in the future with the lighter-weight ``start -d`` command, which brings up containers *detached* (that is: in the background), but does not perform any initialization tasks::
+Once first-time setup has been performed with ``launch``, the platform can be started going forward with the lighter-weight ``start -d`` command, which brings up containers *detached* (that is: in the background), but does not perform any initialization tasks::
 
   tutor dev start -d [--mount=./edx-platform]
 
-If you prefer to run containers *attached* (that is: in the foreground, your current terminal), you can omit the ``-d`` flag::
+Or, to start with platform with containers *attached* (that is: in the foreground, the current terminal), omit the ``-d`` flag::
 
   tutor dev start [--mount=./edx-platform]
 
-When running containers attached, you can stop the platform with ``Ctrl+c``, or switch to detached mode using ``Ctrl+z``.
+When running containers attached, stop the platform with ``Ctrl+c``, or switch to detached mode using ``Ctrl+z``.
 
-Finally, you can always start your platform with ``launch``, even if you have already run it in the past. It will take longer, but it will ensure that your config is applied, your database is provisioned, your plugins are fully initialized, and (if mounted) your local edx-platform is set up. If you include the ``--pullimages`` flag it will also ensure that your container images are up-to-date as well::
+Finally, the platform can also be started back up with ``launch``. It will take longer than ``start``, but it will ensure that config is applied, databases are provisioned & migrated, plugins are fully initialized, and (if applicable) the bind-mounted edx-platform is set up. Notably, ``launch`` is idempotent, so it is always safe to run it again without risk to data. Including the ``--pullimages`` flag will also ensure that container images are up-to-date::
 
   tutor dev launch [--mount=./edx-platform] --pullimages
 
 Debugging with breakpoints
 --------------------------
 
-To debug a local edx-platform repository, you can add a `python breakpoint <https://docs.python.org/3/library/functions.html#breakpoint>`__ with ``breakpoint()`` anywhere in your code. Then, attach to the applicable service's container by running ``start`` (without ``-d``) followed by the service's name:
+To debug a local edx-platform repository, add a `python breakpoint <https://docs.python.org/3/library/functions.html#breakpoint>`__ with ``breakpoint()`` anywhere in the code. Then, attach to the applicable service's container by running ``start`` (without ``-d``) followed by the service's name::
 
   # Debugging LMS:
   tutor dev start [--mount=./edx-platform] lms

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -11,6 +11,7 @@ from typing_extensions import ParamSpec
 
 from tutor import config as tutor_config
 from tutor import env, fmt, hooks
+from tutor.hooks import priorities
 
 
 class DoGroup(click.Group):
@@ -40,6 +41,15 @@ def _add_core_init_tasks() -> None:
             ("mysql", env.read_core_template_file("jobs", "init", "mysql.sh"))
         )
     with hooks.Contexts.APP("lms").enter():
+        hooks.Filters.CLI_DO_INIT_TASKS.add_item(
+            (
+                "lms",
+                env.read_core_template_file("jobs", "init", "mounted-edx-platform.sh"),
+            ),
+            # If edx-platform is mounted, then we may need to perform some setup
+            # before other initialization scripts can be run.
+            priority=priorities.HIGH,
+        )
         hooks.Filters.CLI_DO_INIT_TASKS.add_item(
             ("lms", env.read_core_template_file("jobs", "init", "lms.sh"))
         )

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -207,6 +207,13 @@ RUN openedx-assets themes \
 # Create a data directory, which might be used (or not)
 RUN mkdir /openedx/data
 
+# If this "canary" file is missing from a container, then that indicates that a
+# local edx-platform was bind-mounted into that container, thus overwriting the
+# canary. This information is useful during edx-platform initialisation.
+RUN echo \
+  "This copy of edx-platform was built into a Docker image." \
+  > bindmount-canary
+
 # service variant is "lms" or "cms"
 ENV SERVICE_VARIANT lms
 ENV DJANGO_SETTINGS_MODULE lms.envs.tutor.production

--- a/tutor/templates/dev/docker-compose.jobs.yml
+++ b/tutor/templates/dev/docker-compose.jobs.yml
@@ -9,6 +9,15 @@ x-openedx-job-service:
     args:
       # Note that we never build the openedx-dev image with root user ID, as it would simply fail.
       APP_USER_ID: "{{ HOST_USER_ID or 1000 }}"
+  volumes:
+    # Settings & config
+    - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
+    - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
+    - ../apps/openedx/config:/openedx/config:ro
+    # theme files
+    - ../build/openedx/themes:/openedx/themes
+    # editable requirements
+    - ../build/openedx/requirements:/openedx/requirements
 
 services:
 

--- a/tutor/templates/jobs/init/mounted-edx-platform.sh
+++ b/tutor/templates/jobs/init/mounted-edx-platform.sh
@@ -1,0 +1,26 @@
+# When a new local copy of edx-platform is bind-mounted, certain build
+# artifacts from the openedx image's edx-platform directory are lost.
+# We regenerate them here.
+
+if [ -f /openedx/edx-platform/bindmount-canary ] ; then
+	# If this file exists, then edx-platform has not been bind-mounted,
+	# so no build artifacts need to be regenerated.
+	echo "Using edx-platform from image (not bind-mount)."
+	echo "No extra setup is required."
+	exit
+fi
+
+echo "Performing additional setup for bind-mounted edx-platform."
+set -x # Echo out executed lines
+
+# Regenerate Open_edX.egg-info
+pip install -e .
+
+# Regenerate node_modules
+npm clean-install
+
+# Regenerate static assets.
+openedx-assets build --env=dev
+
+set -x
+echo "Done setting up bind-mounted edx-platform."


### PR DESCRIPTION
## Preface

This is the part of [effort to make it easier to work with mounted repositories](https://github.com/openedx/wg-developer-experience/issues/146).

@regisb , previously we had agreed that it'd be good to [generate the .egg-info folder automatically using an init task](https://github.com/openedx/wg-developer-experience/issues/152#issuecomment-1379465966). I realized the other day, though, that we may as well do the same thing for installing node_modules and regenerating static assets too! With this change, **we can setup a dev env with a bind-mounted edx-platform in one command**.

In the future, I am still interesting in removing the need to reinstall node_modules and regenerate static assets; for now, though, I think that this is an improvement, and its user interface is compatible with the long-term vision.

I did my best to rework the Open edX development docs around the simplified setup. Hopefully they feel simpler now.... very open to feedback here, though.

Finally, I expect that `bindmount-canary` might be controversial, but I'm not sure of a better solution--open to other suggestions 😄 

## Description

Before this commit, setting up an edx-platform development environment took multiple steps:

      tutor dev launch
      tutor dev run --mount=/path/to/edx-platform lms bash
      >> pip install -e .
      >> npm clean-install
      >> openedx-assets build --env=dev

This commit moves the steps under ``run`` into an init task, which is automatically run by ``launch``. Thus, setup is now one command:

      tutor dev launch --mount=edx-platform

These extra init steps are only applicable when bind-mounting edx-platform (because bind-mounting the repository overrides some important artifacts that exist on the image, which must be re-generated). Thus, the new init tasks exists early if it detects that it is *not* operating on a bind-mounted repository.

Finally, we try to simplify the Open edX development docs so that it is clearer how bind-mounting fits into the development process.

Part of:
* https://github.com/openedx/wg-developer-experience/issues/146
Closes:
* https://github.com/openedx/wg-developer-experience/issues/152

This works around (but does not close) these related issues:
* https://github.com/openedx/wg-developer-experience/issues/150
* https://github.com/openedx/wg-developer-experience/issues/151

## Changed docs
![image](https://user-images.githubusercontent.com/3628148/225128599-82ac04f5-633d-4ba4-99bc-1a3e556e17bd.png)
