### PR TITLE
fix: use dev image for `tutor dev do`, not prod image

### DIFF
--- a/changelog.d/20230313_163654_kdmc_dev_image_for_dev_do.md
+++ b/changelog.d/20230313_163654_kdmc_dev_image_for_dev_do.md
@@ -1,0 +1,1 @@
+- [Bugfix] Running jobs in development mode with ``tutor dev do ...`` will now correctly use the development image. Previously, it used the production image, just like ``tutor local do ...``. (by @kdmccormick)

--- a/tutor/templates/dev/docker-compose.jobs.yml
+++ b/tutor/templates/dev/docker-compose.jobs.yml
@@ -1,3 +1,21 @@
 version: "{{ DOCKER_COMPOSE_VERSION }}"
-services: {% if not patch("dev-docker-compose-jobs-services") %}{}{% endif %}
-    {{ patch("dev-docker-compose-jobs-services")|indent(4) }}
+
+x-openedx-job-service:
+  &openedx-job-service
+  image: {{ DOCKER_IMAGE_OPENEDX_DEV }}
+  build:
+    context: ../build/openedx/
+    target: development
+    args:
+      # Note that we never build the openedx-dev image with root user ID, as it would simply fail.
+      APP_USER_ID: "{{ HOST_USER_ID or 1000 }}"
+
+services:
+
+  lms-job:
+    <<: *openedx-job-service
+
+  cms-job:
+    <<: *openedx-job-service
+
+  {{ patch("dev-docker-compose-jobs-services")|indent(2) }}


### PR DESCRIPTION
## Description

The lms-job and cms-job services were configured to use {{ DOCKER_IMAGE_OPENEDX }} rather than {{ DOCKER_IMAGE_OPENEDX_DEV }}.

This means that when running jobs in dev mode, a la:

    tutor dev do init

a production image would be used, to the user's surprise.

FYI @bmtcril

## Testing

Replace tutor/templates/jobs/init/lms.sh with:
```
echo '****************************'
pip freeze | grep debug-toolbar
echo '****************************'
```

Run `tutor config save` and `tutor dev do init -l lms`.

Without the fix, you would see no output between the asterisks.
With the fix, you should see `django-debug-toolbar==...`, because the dev image contains the django-debug-toolbar package.

## Related

* https://github.com/openedx/wg-developer-experience/issues/165