### PR TITLE
feat: highlight enabled plugins with ✅

### DIFF
--- a/changelog.d/20230316_094112_regis_better_highlight_enabled_plugins.md
+++ b/changelog.d/20230316_094112_regis_better_highlight_enabled_plugins.md
@@ -1,0 +1,1 @@
+- [Improvement] Better highlight enabled plugins in `tutor plugins list`. (by @regisb)

--- a/tutor/commands/plugins.py
+++ b/tutor/commands/plugins.py
@@ -335,7 +335,7 @@ def plugin_status(name: str) -> str:
     Return the status of a plugin. Either: "enabled", "installed" or "not installed".
     """
     if plugins.is_loaded(name):
-        return "enabled"
+        return "✅ enabled"
     if plugins.is_installed(name):
         return "installed"
     return "not installed"


### PR DESCRIPTION
In the output of `plugins list` it's difficult to see which plugins are enabled at a glance. This change adds a more visible checkmark to the output.

Ex:

	$ tutor plugins list
	NAME            STATUS          VERSION
	cairn           ✅ enabled      15.0.3
	discovery       installed       15.0.0
	ecommerce       installed       15.0.1
	forum           installed       14.0.0
	mfe             ✅ enabled      15.0.5
	minio           installed       15.1.0