### PR TITLE
fix: v0 plugin patch ordering

### DIFF
--- a/changelog.d/20230316_113639_regis_fix_yaml_patch_ordering.md
+++ b/changelog.d/20230316_113639_regis_fix_yaml_patch_ordering.md
@@ -1,0 +1,1 @@
+- [Bugfix] Make sure that v0 plugin patches are applied in the same order as plugins are listed. (by @regisb)

--- a/tests/test_plugins_v0.py
+++ b/tests/test_plugins_v0.py
@@ -86,7 +86,7 @@ class PluginsTests(PluginsTestCase):
         plugins_v0.DictPlugin(
             {"name": "plugin1", "patches": {"patch1": "Hello {{ ID }}"}}
         )
-        plugins.load("plugin1")
+        plugins.load_all(["plugin1"])
         patches = list(plugins.iter_patches("patch1"))
         self.assertEqual(["Hello {{ ID }}"], patches)
 

--- a/tutor/plugins/v0.py
+++ b/tutor/plugins/v0.py
@@ -146,7 +146,7 @@ class BasePlugin:
                 raise exceptions.TutorError(
                     f"Invalid patch '{patch_name}' in plugin {self.name}. Expected str, got {content.__class__}."
                 )
-            hooks.Filters.ENV_PATCH(patch_name).add_item(content)
+            hooks.Filters.ENV_PATCHES.add_item((patch_name, content))
 
     def _load_tasks(self) -> None:
         """


### PR DESCRIPTION
v0 plugin patches were directly added to ENV_PATCH, while v1 patches were added to ENV_PATCHES. ENV_PATCHES items are forwarded to ENV_PATCH later at runtime, which means that yaml plugin patches were always loaded before v1 patches.

This was causing weird ordering issues, as discussed here: https://discuss.openedx.org/t/using-mfe-config-to-set-logo-trademark-url-for-the-footer-component-in-olive/9578