### PR TITLE
fix: ora2 file upload directory

### DIFF
--- a/changelog.d/20230320_213439_regis_fix_ora2_directory.md
+++ b/changelog.d/20230320_213439_regis_fix_ora2_directory.md
@@ -1,0 +1,1 @@
+- [Bugfix] Rename ORA2 file upload folder from "SET-ME-PLEASE (ex. bucket-name)" to "openedxuploads". This has the effect of moving the corresponding folder from the `<tutor root>/data/lms/ora2` directory. MinIO users were not affected by this bug.

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -120,7 +120,19 @@ GRADES_DOWNLOAD = {
 
 ORA2_FILEUPLOAD_BACKEND = "filesystem"
 ORA2_FILEUPLOAD_ROOT = "/openedx/data/ora2"
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "openedxuploads"
 ORA2_FILEUPLOAD_CACHE_NAME = "ora2-storage"
+# For a long while, we were storing ora2 uploads this directory.
+ora2_folder = os.path.join(ORA2_FILEUPLOAD_ROOT, FILE_UPLOAD_STORAGE_BUCKET_NAME)
+deprecated_ora2_folder = os.path.join(ORA2_FILEUPLOAD_ROOT, "SET-ME-PLEASE (ex. bucket-name)")
+if deprecated_ora2_folder != ora2_folder and os.path.exists(deprecated_ora2_folder):
+    if os.path.exists(ora2_folder):
+        # We are really not supposed to fall in this scenario, so print a warning
+        sys.stderr.write(f"⚠️ Deprecated ORA2 folder '{deprecated_ora2_folder}' exists. Its content should be moved to '{ora2_folder}'.\n")
+    else:
+        # This folder is a relic, let's rename it
+        print(f"Moving deprecated ORA2 folder from '{deprecated_ora2_folder}' to '{ora2_folder}'...")
+        os.rename(deprecated_ora2_folder, ora2_folder)
 
 # Change syslog-based loggers which don't work inside docker containers
 LOGGING["handlers"]["local"] = {

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -110,7 +110,7 @@ ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 COPY --from=code /openedx/edx-platform/package.json /openedx/edx-platform/package.json
 COPY --from=code /openedx/edx-platform/package-lock.json /openedx/edx-platform/package-lock.json
 WORKDIR /openedx/edx-platform
-RUN npm clean-install --verbose --registry=$NPM_REGISTRY
+RUN npm clean-install --registry=$NPM_REGISTRY
 
 ###### Production image with system and python requirements
 FROM minimal as production


### PR DESCRIPTION
ORA2 file uploads were stored in a folder named "SET-ME-PLEASE (ex.
bucket-name)" (sigh). With this change, the folder should be
automatically renamed to "openedxuploads".

This issue has been occuring since June 2019... (sigh²)

Close #707
