### PR TITLE
docs: Update ARM64 tutorial

### DIFF
--- a/docs/tutorials/arm64.rst
+++ b/docs/tutorials/arm64.rst
@@ -3,14 +3,15 @@
 Running Tutor on ARM-based systems
 ==================================
 
-Tutor can be used on ARM64 systems, although support for that platform is currently experimental.
+Tutor can be used on ARM64 systems, although no official ARM64 docker images are available. If you want to get started quickly, there is `an unofficial  community-maintained ARM64 plugin <https://github.com/open-craft/tutor-contrib-arm64>`_ which will set the required settings for you and which includes unofficial docker images. If you prefer not to use an unofficial plugin, you can follow this tutorial.
 
-There are generally two ways to run Tutor on an ARM system - using qemu to run x86_64 images using emulation or running native ARM images. Since emulation can be quite slow, this Tutorial will focus on using native images where possible.
+.. note:: There are generally two ways to run Tutor on an ARM system - using emulation (via qemu or Rosetta 2) to run x86_64 images or running native ARM images. Since emulation can be noticeably slower (typically 20-100% slower depending on the emulation method), this tutorial aims to use native images where possible.
 
-There are currently no official ARM64 images provided for Tutor, but Tutor makes it easy to build them yourself.
 
 Building the images
 -------------------
+
+Although there are no official ARM64 images, Tutor makes it easy to build the images yourself.
 
 Start by :ref:`installing <install>` Tutor and its dependencies (e.g. Docker) onto your system.
 
@@ -33,14 +34,13 @@ If you want to use Tutor as an Open edX development environment, you should also
 Change the database server
 --------------------------
 
-The version of MySQL that Open edX uses by default does not support the ARM architecture. Our current recommendation is to use MariaDB instead, which should be largely compatible.
+The version of MySQL that Open edX uses by default (5.7) does not support the ARM architecture. You need to tell Tutor to use MySQL 8.0, which does support the ARM architecture and which has been supported by Open edX since the "Nutmeg" release.
 
-.. warning::
-    Note that using MariaDB is experimental and incompatibilities may exist, so this should only be used for local development - not for production instances.
+Configure Tutor to use MySQL 8::
 
-Configure Tutor to use MariaDB::
+    tutor config save --set DOCKER_IMAGE_MYSQL=docker.io/mysql:8.0
 
-    tutor config save --set DOCKER_IMAGE_MYSQL=mariadb:10.4
+(If you need to run an older release of Open edX on ARM64, you can try using `mariadb:10.4` although it's not officially supported nor recommended for production.)
 
 Finish setup and start Tutor
 ----------------------------


### PR DESCRIPTION
The ARM64 tutorial is a bit out of date. I have updated it to recommend MySQL 8 instead of MariaDB and remove the warnings about MariaDB, since MySQL 8 is officially supported by Open edX. Also, based on the discussion in https://github.com/open-craft/tutor-contrib-arm64/issues/1 and the new automated image builds for ARM64 in https://github.com/open-craft/tutor-contrib-arm64/pull/3 I have linked to the unofficial ARM64 plugin, for those who would like to use it.