### PR TITLE
fix: use correct case for authsource mongo

### DIFF
--- a/changelog.d/20230526_151849_johan.castiblanco_update_authsource_mongo.md
+++ b/changelog.d/20230526_151849_johan.castiblanco_update_authsource_mongo.md
@@ -1,0 +1,1 @@
+- [Bugfix] Change `authSource` to `authsource`(LOWERCASE) in mongo db parameters. This allow to authenticate with credentials in openedx code.(by @johanv26)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -13,7 +13,7 @@ mongodb_parameters = {
     "password": {% if MONGODB_PASSWORD %}"{{ MONGODB_PASSWORD }}"{% else %}None{% endif %},
     # Connection/Authentication
     "ssl": {{ MONGODB_USE_SSL }},
-    "authSource": "{{ MONGODB_AUTH_SOURCE }}",
+    "authsource": "{{ MONGODB_AUTH_SOURCE }}",
     "replicaSet": {% if MONGODB_REPLICA_SET %}"{{ MONGODB_REPLICA_SET }}"{% else %}None{% endif %},
     {% if MONGODB_AUTH_MECHANISM %}"authMechanism": "{{ MONGODB_AUTH_MECHANISM }}",{% endif %}
 }


### PR DESCRIPTION
# Description
Update `authSource`  keyword argument to  `authsource`

Authsource was configurated in camelcase.
https://github.com/overhangio/tutor/blob/master/tutor/templates/apps/openedx/settings/partials/common_all.py#L16 Something I think is ok because pymongo uses it in camelcase. ![2023-04-03_10-52](https://user-images.githubusercontent.com/51926076/229563381-68a9430e-a3ec-42cd-bc8b-910f01be7f1e.png)

However, the error was presented because edx-platform use another variable when credentials are provided **(LOWERCASE)**. https://github.com/openedx/edx-platform/blob/master/xmodule/mongo_utils.py#L72

Looking more ,  the `auth_source `is configured with another key name:  `authsource` **(LOWERCASE)** from the kwargs. https://github.com/openedx/edx-platform/blob/master/xmodule/mongo_utils.py#L34

This won't change the **kwargs behavior of the camelCase in pymongo `MongoClient` because pymongo has a caseInsentive method. https://github.com/mongodb/mongo-python-driver/blob/3.12.3/pymongo/mongo_client.py#L651
 it's probably OK to pass `authsource` instead of authSource as a keyword argument.

## issues related
https://github.com/overhangio/tutor/issues/823