### PR TITLE
docs: Tweak upgrade instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -87,7 +87,9 @@ Tutor can be launched on Amazon Web Services very quickly with the `official Tut
 Upgrading
 ---------
 
-To upgrade Open edX or benefit from the latest features and bug fixes, you should simply upgrade Tutor. Start by upgrading the "tutor" package and its dependencies::
+To upgrade your Open edX site or benefit from the latest features and bug fixes, you should simply upgrade Tutor. Start by backing up your data and reading the `release notes <https://docs.openedx.org/en/latest/community/release_notes/>`_ for the current release.
+
+Next, upgrade the "tutor" package and its dependencies::
 
     pip install --upgrade "tutor[full]"
 


### PR DESCRIPTION
@regisb 
  [3 minutes ago](https://openedx.slack.com/archives/C049JQZFR5E/p1686164471558869?thread_ts=1686154946.792849&cid=C049JQZFR5E)
https://docs.tutor.overhang.io/install.html#upgrading I guess? Missing from these instructions are the usual "backup your stuff" and "read the changelog"...