### PR TITLE
chore: Bump MongoDB default to version 4.2.24

### DIFF
--- a/changelog.d/20230613_091959_fghaas_mongodb_4_2_24.md
+++ b/changelog.d/20230613_091959_fghaas_mongodb_4_2_24.md
@@ -1,0 +1,1 @@
+- [Improvement] Bump the default MongoDB Docker image reference from version 4.2.17 to 4.2.24. (by @fghaas) -->

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -75,7 +75,7 @@ This configuration paramater defines which Caddy Docker image to use.
 
 This configuration parameter defines which Elasticsearch Docker image to use.
 
-- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:4.2.17"``)
+- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:4.2.24"``)
 
 This configuration parameter defines which MongoDB Docker image to use.
 

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -14,7 +14,7 @@ DOCKER_IMAGE_OPENEDX: "{{ DOCKER_REGISTRY }}overhangio/openedx:{{ TUTOR_VERSION 
 DOCKER_IMAGE_OPENEDX_DEV: "openedx-dev:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_CADDY: "docker.io/caddy:2.6.3"
 DOCKER_IMAGE_ELASTICSEARCH: "docker.io/elasticsearch:7.10.1"
-DOCKER_IMAGE_MONGODB: "docker.io/mongo:4.2.17"
+DOCKER_IMAGE_MONGODB: "docker.io/mongo:4.2.24"
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:5.7.35"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_REDIS: "docker.io/redis:6.2.6"


### PR DESCRIPTION
Bump the default image reference for MongoDB from 4.2.17 to 4.2.24, to address a critical issue present in versions 4.2.0 through 4.2.23.

References:
https://www.mongodb.com/docs/manual/release-notes/4.2/#patch-releases
https://jira.mongodb.org/browse/WT-10461

Fixes #854.