### PR TITLE
fix: intermittent connection errors to mongodb because of eager uwsgi

### DIFF
--- a/tutor/templates/build/openedx/settings/uwsgi.ini
+++ b/tutor/templates/build/openedx/settings/uwsgi.ini
@@ -8,3 +8,4 @@ processes = $(UWSGI_WORKERS)
 thunder-lock = true
 single-interpreter = true
 enable-threads = true
+lazy-apps = true


### PR DESCRIPTION
This prevents `pymongo.errors.ServerSelectionTimeoutError: No servers found yet`

https://discuss.openedx.org/t/mongodb-intermittent-connection-timeout-errors-in-pymongo-topology-py/7278/4