### PR TITLE
fix: add a temporary patch for the fix of cache programs command error

### DIFF
--- a/changelog.d/20230620_163516_faraz.maqsood_faraz_add_temporary_patch_for_cache_program_command_issue_for_discovery.md
+++ b/changelog.d/20230620_163516_faraz.maqsood_faraz_add_temporary_patch_for_cache_program_command_issue_for_discovery.md
@@ -1,2 +1,1 @@
-- 💥[Improvement] Add a patch for this commit (https://github.com/openedx/edx-platform/pull/32506/commits/b3e9f0cbd5e44f25a42a7cbf4929b71ef122b697)
-which is fix for this issue (https://github.com/overhangio/tutor-discovery/issues/40). (by @Faraz32123)
+- [Bugfix] Make it possible to cache programs for a single site, instead of crashing when running `manage.py lms cache_programs` for all sites. (by @Faraz32123)

--- a/changelog.d/20230620_163516_faraz.maqsood_faraz_add_temporary_patch_for_cache_program_command_issue_for_discovery.md
+++ b/changelog.d/20230620_163516_faraz.maqsood_faraz_add_temporary_patch_for_cache_program_command_issue_for_discovery.md
@@ -1,0 +1,2 @@
+- 💥[Improvement] Add a patch for this commit (https://github.com/openedx/edx-platform/pull/32506/commits/b3e9f0cbd5e44f25a42a7cbf4929b71ef122b697)
+which is fix for this issue (https://github.com/overhangio/tutor-discovery/issues/40). (by @Faraz32123)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -45,6 +45,10 @@ WORKDIR /openedx/edx-platform
 RUN git config --global user.email "tutor@overhang.io" \
   && git config --global user.name "Tutor"
 
+# added a patch for this commit (https://github.com/openedx/edx-platform/pull/32506/commits/b3e9f0cbd5e44f25a42a7cbf4929b71ef122b697)
+# which is fix for this issue (https://github.com/overhangio/tutor-discovery/issues/40)
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/b3e9f0cbd5e44f25a42a7cbf4929b71ef122b697.patch | git am
+
 {%- if patch("openedx-dockerfile-git-patches-default") %}
 # Custom edx-platform patches
 {{ patch("openedx-dockerfile-git-patches-default") }}


### PR DESCRIPTION
This PR is created as temporary fix for cache programs command that is used in tutor-discovery plugin to cache programs.
The issue link is [here](https://github.com/overhangio/tutor-discovery/issues/40).