### PR TITLE
fix: mysql deployment on k8s

### DIFF
--- a/changelog.d/20230622_123257_regis_k8s_fix_mysql8_start.md
+++ b/changelog.d/20230622_123257_regis_k8s_fix_mysql8_start.md
@@ -1,0 +1,1 @@
+- [Bugfix] On Kubernetes, fix mysql deployment by removing the `-ignore-db-dir` option, which no longer exists on MySQL 8. (by @regisb)

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -392,9 +392,7 @@ spec:
       containers:
         - name: mysql
           image: {{ DOCKER_IMAGE_MYSQL }}
-          # Note the ignore-db-dir: this is because ext4 volumes are created with a lost+found directory in them, which causes mysql
-          # initialisation to fail
-          args: ["mysqld", "--character-set-server=utf8", "--collation-server=utf8_general_ci", "--ignore-db-dir=lost+found"]
+          args: ["mysqld", "--character-set-server=utf8", "--collation-server=utf8_general_ci"]
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: "{{ MYSQL_ROOT_PASSWORD }}"


### PR DESCRIPTION
The `--ignore-db-dir` option is no longer supported on MySQL 8. See: https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html

This option was causing the mysql container to fail.