### PR TITLE
feat: add support for http/3

### DIFF
--- a/changelog.d/20230623_170336_regis_http3.md
+++ b/changelog.d/20230623_170336_regis_http3.md
@@ -1,0 +1,1 @@
+- [Feature] Add support for HTTP/3, which considerably improves performance for Open edX. (by @regisb and @ghassanmas)

--- a/docs/tutorials/proxy.rst
+++ b/docs/tutorials/proxy.rst
@@ -26,6 +26,7 @@ It is then your responsibility to configure the web proxy on the host. There are
     - Forward http traffic to https.
 - Set the following headers appropriately: ``X-Forwarded-Proto``, ``X-Forwarded-Port``.
 - Forward all traffic to ``localhost:81`` (or whatever port indicated by CADDY_HTTP_PORT, see above).
+- If possible, add support for `HTTP/3 <https://en.wikipedia.org/wiki/HTTP/3>`__, which considerably improves performance for Open edX (see `this comment <https://github.com/overhangio/tutor/issues/845#issuecomment-1566964289>`__).
 
 .. note::
     If you want to run Open edX at ``https://...`` urls (as you probably do in production) it is *crucial* that the ``ENABLE_HTTPS`` flag is set to ``true``. If not, the web services will be configured to run at ``http://...`` URLs, and all sorts of trouble will happen. Therefore, make sure to continue answering ``y`` ("yes") to the quickstart dialogue question "Activate SSL/TLS certificates for HTTPS access?".

--- a/tutor/templates/k8s/services.yml
+++ b/tutor/templates/k8s/services.yml
@@ -14,7 +14,12 @@ spec:
       name: http
     {%- if ENABLE_HTTPS %}
     - port: 443
+      protocol: TCP
       name: https
+    # include support for http/3
+    - port: 443
+      protocol: UDP
+      name: http3
     {%- endif %}
   selector:
     app.kubernetes.io/name: caddy

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -6,7 +6,11 @@ services:
     restart: unless-stopped
     ports:
       - "{{ CADDY_HTTP_PORT }}:80"
-      {% if ENABLE_HTTPS and ENABLE_WEB_PROXY %}- "443:443"{% endif %}
+      {% if ENABLE_HTTPS and ENABLE_WEB_PROXY %}
+      - "443:443"
+      # include support for http/3
+      - "443:443/udp"
+      {% endif %}
     environment:
       default_site_port: "{% if not ENABLE_HTTPS or not ENABLE_WEB_PROXY %}:80{% endif %}"
     volumes:


### PR DESCRIPTION
It was observed that waiting time was cut in half after http/3 was enabled. Plus, supporting http/3 is super easy :)

Close #845