### PR TITLE
docs: tutor uses `docker compose` now, not `docker-compose`

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 
 * Supported OS: Tutor runs on any 64-bit, UNIX-based OS. It was also reported to work on Windows (with `WSL 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`__).
-* Architecture: support for ARM64 is a work-in-progress. See `this issue <https://github.com/overhangio/tutor/issues/510>`__.
+* Architecture: Both AMD64 and ARM64 are supported.
 * Required software:
 
     - `Docker <https://docs.docker.com/engine/installation/>`__: v20.10.15+
@@ -17,7 +17,6 @@ Requirements
 
 .. warning::
     Do not attempt to simply run ``apt-get install docker docker-compose`` on older Ubuntu platforms, such as 16.04 (Xenial), as you will get older versions of these utilities.
-
 * Ports 80 and 443 should be open. If other web services run on these ports, check the tutorial on :ref:`how to setup a web proxy <web_proxy>`.
 * Hardware:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -51,7 +51,7 @@ Tutor simplifies the deployment of Open edX by:
   :width: 500px
   :align: center
 
-Because Docker containers are becoming an industry-wide standard, that means that with Tutor it becomes possible to run Open edX anywhere: for now, Tutor supports deploying on a local server, with `docker-compose <https://docs.docker.com/compose/overview/>`_, and in a large cluster, with `Kubernetes <http://kubernetes.io/>`_. But in the future, Tutor may support other deployment platforms.
+Because Docker containers are becoming an industry-wide standard, that means that with Tutor it becomes possible to run Open edX anywhere: for now, Tutor supports deploying on a local server, with `docker compose <https://docs.docker.com/compose/overview/>`_, and in a large cluster, with `Kubernetes <http://kubernetes.io/>`_. But in the future, Tutor may support other deployment platforms.
 
 Where can I try Open edX and Tutor?
 -----------------------------------
@@ -101,7 +101,7 @@ You can now take advantage of the Tutor-powered CLI (item #3) to bootstrap your 
 
     tutor local launch
 
-Under the hood, Tutor simply runs ``docker-compose`` and ``docker`` commands to launch your platform. These commands are printed in the standard output, such that you are free to replicate the same behaviour by simply copying/pasting the same commands.
+Under the hood, Tutor simply runs ``docker compose`` and ``docker`` commands to launch your platform. These commands are printed in the standard output, such that you are free to replicate the same behaviour by simply copying/pasting the same commands.
 
 How do I navigate Tutor's command-line interface?
 -------------------------------------------------

--- a/docs/k8s.rst
+++ b/docs/k8s.rst
@@ -119,7 +119,7 @@ Common tasks
 Executing commands inside service pods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Tutor and plugin documentation usually often instructions to execute some ``tutor local run ...`` commands. These commands are only valid when running Tutor locally with docker-compose, and will not work on Kubernetes. Instead, you should run ``tutor k8s exec ...`` commands. Arguments and options should be identical.
+The Tutor and plugin documentation usually often instructions to execute some ``tutor local run ...`` commands. These commands are only valid when running Tutor locally with docker compose, and will not work on Kubernetes. Instead, you should run ``tutor k8s exec ...`` commands. Arguments and options should be identical.
 
 For instance, to run a Python shell in the lms container, run::
 

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -6,7 +6,7 @@ Local deployment
 This method is for deploying Open edX locally on a single server, where docker images are orchestrated with `docker-compose <https://docs.docker.com/compose/overview/>`_.
 
 .. note::
-    Tutor is compatible with the ``docker compose`` subcommand. However, this support is still in beta and we're not sure it will behave the same as the previous ``docker-compose`` command. So ``docker-compose`` will be preferred, unless you set an environment variable ``TUTOR_USE_COMPOSE_SUBCOMMAND`` to enforce using ``docker compose``.
+    As of v16.0.0, Tutor now uses the ``docker compose`` subcommand instead of the separate ``docker-compose`` command.
 
 .. _tutor_root:
 

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -272,7 +272,7 @@ def reboot(context: click.Context, detach: bool, services: list[str]) -> None:
 @click.command(
     short_help="Restart some components from a running platform.",
     help="""Specify 'openedx' to restart the lms, cms and workers, or 'all' to
-restart all services. Note that this performs a 'docker-compose restart', so new images
+restart all services. Note that this performs a 'docker compose restart', so new images
 may not be taken into account. It is useful for reloading settings, for instance. To
 fully stop the platform, use the 'reboot' command.""",
 )
@@ -302,8 +302,8 @@ def do() -> None:
 @click.command(
     short_help="Run a command in a new container",
     help=(
-        "Run a command in a new container. This is a wrapper around `docker-compose run`. Any option or argument passed"
-        " to this command will be forwarded to docker-compose. Thus, you may use `-v` or `-p` to mount volumes and"
+        "Run a command in a new container. This is a wrapper around `docker compose run`. Any option or argument passed"
+        " to this command will be forwarded to docker compose. Thus, you may use `-v` or `-p` to mount volumes and"
         " expose ports."
     ),
     context_settings={"ignore_unknown_options": True},
@@ -368,7 +368,7 @@ def copyfrom(
 @click.command(
     short_help="Run a command in a running container",
     help=(
-        "Run a command in a running container. This is a wrapper around `docker-compose exec`. Any option or argument"
+        "Run a command in a running container. This is a wrapper around `docker compose exec`. Any option or argument"
         " passed to this command will be forwarded to docker-compose. Thus, you may use `-e` to manually define"
         " environment variables."
     ),
@@ -383,7 +383,7 @@ def execute(context: click.Context, args: list[str]) -> None:
 
 @click.command(
     short_help="View output from containers",
-    help="View output from containers. This is a wrapper around `docker-compose logs`.",
+    help="View output from containers. This is a wrapper around `docker compose logs`.",
 )
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
 @click.option("--tail", type=int, help="Number of lines to show from each container")
@@ -406,10 +406,10 @@ def status(context: click.Context) -> None:
 
 
 @click.command(
-    short_help="Direct interface to docker-compose.",
+    short_help="Direct interface to docker compose.",
     help=(
-        "Direct interface to docker-compose. This is a wrapper around `docker-compose`. Most commands, options and"
-        " arguments passed to this command will be forwarded as-is to docker-compose."
+        "Direct interface to docker compose. This is a wrapper around `docker compose`. Most commands, options and"
+        " arguments passed to this command will be forwarded as-is to docker compose."
     ),
     context_settings={"ignore_unknown_options": True},
     name="dc",

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -50,7 +50,7 @@ class Actions:
     For more information about how actions work, check out the :py:class:`tutor.core.hooks.Action` API.
     """
 
-    #: Triggered whenever a "docker-compose start", "up" or "restart" command is executed.
+    #: Triggered whenever a "docker compose start", "up" or "restart" command is executed.
     #:
     #: :parameter str root: project root.
     #: :parameter dict config: project configuration.

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -1,8 +1,8 @@
 # Tutor provides the `tutor MODE do JOB ...` CLI as a consistent way to execute jobs
-# across the dev, local, and k8s modes. To support jobs in the docker-compose modes
+# across the dev, local, and k8s modes. To support jobs in the docker compose modes
 # (dev and local), we must define a `-job` variant service in which jobs could be run.
 
-# When `tutor local do JOB ...` is invoked, we `docker-compose run` each of JOB's
+# When `tutor local do JOB ...` is invoked, we `docker compose run` each of JOB's
 # tasks against the appropriate `-job` services, as defined here.
 # When `tutor dev do JOB ...` is invoked, we do the same, but also include any
 # compose overrides in ../dev/docker-compose.jobs.yml.


### PR DESCRIPTION
Per v16 changelog: https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1600-2023-06-14

@regisb , a couple related questions:

* Is v20.10.15+ still the right Docker version to require?
* Do we count on BuildKit now? If so, it's not [default in Docker Engine until v23](https://docs.docker.com/build/buildkit/).
* I didn't update the [podman tutorial](https://docs.tutor.overhang.io/tutorials/podman.html). Do you if the podman shim still works now that we're using builtin `docker compose`?