### PR TITLE
fix: race condition could cause mkdirs() to fail with "file exists"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every user-facing change should have an entry in this changelog. Please respect 
 
 ## Unreleased
 - [Improvement] Make it possible to override k8s resources in plugins using `k8s-override` patch. (by @foadlind)
+- [Bugfix] Fix a race condition that could prevent a newly provisioned Studio container from starting due to a FileExistsError when creating logs directory.
 
 ## v14.0.2 (2022-06-27)
 

--- a/tutor/templates/apps/openedx/settings/partials/common_cms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_cms.py
@@ -18,7 +18,7 @@ FRONTEND_REGISTER_URL = LMS_ROOT_URL + '/register'
 # Create folders if necessary
 for folder in [LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE]:
     if not os.path.exists(folder):
-        os.makedirs(folder)
+        os.makedirs(folder, exist_ok=True)
 
 {{ patch("openedx-cms-common-settings") }}
 


### PR DESCRIPTION
Exactly the same issue as https://github.com/overhangio/tutor/pull/649, but with Studio:

```python
*** Operational MODE: preforking ***
spawned uWSGI worker 1 (pid: 7, cores: 1)
spawned uWSGI worker 2 (pid: 9, cores: 1)
Traceback (most recent call last):
  File "cms/wsgi.py", line 21, in <module>
    import cms.startup as startup  # lint-amnesty, pylint: disable=wrong-import-position
  File "/openedx/edx-platform/./cms/startup.py", line 10, in <module>
    settings.INSTALLED_APPS  # pylint: disable=pointless-statement
  File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/opt/pyenv/versions/3.8.12/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/openedx/edx-platform/./cms/envs/tutor/production.py", line 260, in <module>
    os.makedirs(folder)
  File "/opt/pyenv/versions/3.8.12/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/openedx/data/logs'
unable to load app 0 (mountpoint='') (callable not found or import error)
*** no app loaded. going in full dynamic mode ***
```

Also, this doesn't happen when `OPENEDX_CMS_UWSGI_WORKERS` is set to `1`.