### PR TITLE
fix: set default theme by simply deleting SiteTheme objects

### DIFF
--- a/changelog.d/20230714_100627_kyle.md
+++ b/changelog.d/20230714_100627_kyle.md
@@ -1,0 +1,1 @@
+- [Bugfix] Improve `tutor ... do settheme default` so that it reverts to the default theme rather than trying to switch to a nonexistent theme named "default". This will clear up some error noise from LMS/CMS logs. (by @kdmccormick)

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -216,7 +216,8 @@ def assign_theme(name, domain):
         site.name = domain[:name_max_length]
         site.save()
     site.themes.all().delete()
-    site.themes.create(theme_dir_name=name)
+    if name != 'default':
+        site.themes.create(theme_dir_name=name)
 """
     domain_names = domain_names or [
         "{{ LMS_HOST }}",


### PR DESCRIPTION
`tutor ... do settheme default` is meant to revert to the default theme.  However, in its current implementation, it creates SiteTheme objects pointing to a theme named "default", which doesn't exist, resulting in errors like:

    Theme dirs:
    [Path('/openedx/themes')]]
    Traceback (most recent call last):
      File "/openedx/edx-platform/openedx/core/djangoapps/theming/helpers.py", line 204, in get_current_theme
	themes_base_dir=get_theme_base_dir(site_theme.theme_dir_name),
      File "/openedx/edx-platform/openedx/core/djangoapps/theming/helpers.py", line 242, in get_theme_base_dir
	raise ValueError(
    ValueError: Theme 'default' not found in any of the following themes dirs,

This works from the perspective of the user, because a missing theme is treated as the default theme. However, the errors are unneccesary & confusing.

By simply deleting & not recreating SiteTheme objects instead, we are able to revert to the default theme while keeping the logs clear of theming errors.