### PR TITLE
build: copy in copy-node-modules.sh for npm post-install hook

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -123,6 +123,7 @@ RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 WORKDIR /openedx/edx-platform
+COPY --from=edx-platform scripts/copy-node-modules.sh scripts
 RUN {% if is_buildkit_enabled() %}--mount=type=bind,from=edx-platform,source=/package.json,target=/openedx/edx-platform/package.json \
     --mount=type=bind,from=edx-platform,source=/package-lock.json,target=/openedx/edx-platform/package-lock.json \
     --mount=type=cache,target=/root/.npm,sharing=shared {% endif %}npm clean-install --no-audit --registry=$NPM_REGISTRY


### PR DESCRIPTION
scripts/copy-node-modules.sh replaces `openedx-assets npm`.
We run it automatically as a post-install NPM hook.
That means that the script must be available when running `npm clean-install`.

This should merge right after https://github.com/openedx/edx-platform/pull/32767 merges.

Part of: https://github.com/openedx/edx-platform/issues/31604