### PR TITLE
fix: ignore discussion units when forum is not enabled

### DIFF
--- a/changelog.d/20230731_155418_regis_fix_discussion_units.md
+++ b/changelog.d/20230731_155418_regis_fix_discussion_units.md
@@ -1,0 +1,1 @@
+- [Bugfix] Do not display discussion units when the forum is not enabled. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -53,6 +53,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Security advisory: https://github.com/openedx/edx-platform/security/advisories/GHSA-3q74-3rfh-g37j
 # https://github.com/openedx/edx-platform/pull/32838
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/163259779297a7dccb28e1f8c3dfa4d2cbdb9655.patch | git am
+# Fix discussion units when forum is not enabled
+# https://github.com/openedx/edx-platform/pull/32464
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/a9f66705503288c360055ab80c7c3bfb884f75fe.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}


### PR DESCRIPTION
This is a backport of a commit to the master branch: https://github.com/openedx/edx-platform/pull/32464

In particular, it will fix many issues that appear when the demo course is imported.