### PR TITLE
fix: parse strings prefixed with "#" in `config save --set ...`

### DIFF
--- a/changelog.d/20230906_105044_regis_parse_pound_keys_in_settings.md
+++ b/changelog.d/20230906_105044_regis_parse_pound_keys_in_settings.md
@@ -1,0 +1,1 @@
+- [Bugfix] Correctly parse strings prefixed with pound "#" key in `tutor config save --set KEY=#value` commands. (by @regisb)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -41,6 +41,10 @@ class SerializeTests(unittest.TestCase):
                 "x=key1:\n  subkey: value\nkey2:\n  subkey: value"
             ),
         )
+        self.assertEqual(
+            ("INDIGO_PRIMARY_COLOR", "#225522"),
+            serialize.parse_key_value("INDIGO_PRIMARY_COLOR=#225522"),
+        )
 
     def test_str_format(self) -> None:
         self.assertEqual("true", serialize.str_format(True))

--- a/tutor/serialize.py
+++ b/tutor/serialize.py
@@ -73,4 +73,8 @@ def parse_key_value(text: str) -> t.Optional[tuple[str, t.Any]]:
     if not value:
         # Empty strings are interpreted as null values, which is incorrect.
         value = "''"
+    elif "\n" not in value and value.startswith("#"):
+        # Single-line string that starts with a pound # key
+        # We need to escape the string, otherwise pound will be interpreted as a comment.
+        value = f'"{value}"'
     return key, parse(value)


### PR DESCRIPTION
Pound keys were interpreted as comments. This is annoying when we want to parse html color codes, such as in:

    $ tutor config save --set "INDIGO_PRIMARY_COLOR=#225522"
    $ tutor config printvalue INDIGO_PRIMARY_COLOR
    null

Close #866.