### PR TITLE
fix: adds `connect=False` to MongoDB connection configuration

### DIFF
--- a/changelog.d/20231003_144841_paulo_mongodb_connect.md
+++ b/changelog.d/20231003_144841_paulo_mongodb_connect.md
@@ -1,0 +1,1 @@
+[Improvement] Adds `connect=False` to the LMS and CMS' MongoDB connection to prevent `ServerSelectionError` after a cluster failover. (by @open-craft)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -12,6 +12,7 @@ mongodb_parameters = {
     "user": {% if MONGODB_USERNAME %}"{{ MONGODB_USERNAME }}"{% else %}None{% endif %},
     "password": {% if MONGODB_PASSWORD %}"{{ MONGODB_PASSWORD }}"{% else %}None{% endif %},
     # Connection/Authentication
+    "connect": False,
     "ssl": {{ MONGODB_USE_SSL }},
     "authsource": "{{ MONGODB_AUTH_SOURCE }}",
     "replicaSet": {% if MONGODB_REPLICA_SET %}"{{ MONGODB_REPLICA_SET }}"{% else %}None{% endif %},


### PR DESCRIPTION
## Description

This adds `connect=False` to the LMS and CMS' MongoDB connection configuration to prevent `ServerSelectionError` after a failover.

Related issue: https://github.com/overhangio/tutor/issues/865