### PR TITLE
fix: adds lazy-apps=true to uwsgi.ini

### DIFF
--- a/tutor/templates/build/openedx/settings/uwsgi.ini
+++ b/tutor/templates/build/openedx/settings/uwsgi.ini
@@ -8,3 +8,4 @@ processes = $(UWSGI_WORKERS)
 thunder-lock = true
 single-interpreter = true
 enable-threads = true
+lazy-apps = true


### PR DESCRIPTION
Port the change to fix ServerSelectionTimeoutError on MongoDB failover from the nutmeg branch.