### PR TITLE
fix: file upload in open response assessments (ora2)

### DIFF
--- a/changelog.d/20231002_110754_regis_fix_ora2_uploads.md
+++ b/changelog.d/20231002_110754_regis_fix_ora2_uploads.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix file upload in open response assessments. (by @regisb)

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -36,6 +36,11 @@ CACHES["staticfiles"] = {
     "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     "LOCATION": "staticfiles_lms",
 }
+CACHES["ora2-storage"] = {
+    "KEY_PREFIX": "ora2-storage",
+    "BACKEND": "django_redis.cache.RedisCache",
+    "LOCATION": "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}",
+}
 
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:


### PR DESCRIPTION
For some reason, the ora2 cache configuration had disappeared in the upgrade to Palm.

This issue was initially raised here:
https://discuss.openedx.org/t/palm-2-ora-file-upload-failure/11332

Close #907.