### PR TITLE
fix: override CMS_BASE setting in Studio for dev

### DIFF
--- a/changelog.d/20231004_114528_dave_fix_cms_base_settings.md
+++ b/changelog.d/20231004_114528_dave_fix_cms_base_settings.md
@@ -1,0 +1,1 @@
+- [Bugfix] Override CMS_BASE setting in Studio for the development environment. Without this, parts of Studio will try to use the devstack default of localhost:8010 instead. (by @ormsbee)

--- a/tutor/templates/apps/openedx/settings/cms/development.py
+++ b/tutor/templates/apps/openedx/settings/cms/development.py
@@ -5,6 +5,9 @@ from cms.envs.devstack import *
 LMS_BASE = "{{ LMS_HOST }}:8000"
 LMS_ROOT_URL = "http://" + LMS_BASE
 
+CMS_BASE = "{{ CMS_HOST }}:8001"
+CMS_ROOT_URL = "http://" + CMS_BASE
+
 # Authentication
 SOCIAL_AUTH_EDX_OAUTH2_KEY = "{{ CMS_OAUTH2_KEY_SSO_DEV }}"
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = LMS_ROOT_URL


### PR DESCRIPTION
The LMS was overriding CMS_BASE properly, but Studio (CMS) configuration was not. That meant that Studio's CMS_BASE in dev mode was using the devstack default of localhost:18010 (because this is what's defined in edx-platform). This in turn broke parts of Studio that use this value, such as the XBlock v2 API (/api/xblock/v2).

This commit derives the value of the CMS_BASE Django setting from Tutor's CMS_HOST config value, in the same way that the LMS does it.