### PR TITLE
fix: ora2 uploads in cms

### DIFF
--- a/changelog.d/20231007_153252_fateme.khodayari97.md
+++ b/changelog.d/20231007_153252_fateme.khodayari97.md
@@ -1,0 +1,2 @@
+- [Bugfix] Fix ORA2 file uploads in CMS. As the cache settings are shared between CMS and LMS, the settings are moved 
+from `common_lms.py` to `common_all.py`. (by @FatemeKhodayari)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -77,6 +77,11 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}",
     },
+    "ora2-storage": {
+        "KEY_PREFIX": "ora2-storage",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}",
+    }
 }
 
 # The default Django contrib site is the one associated to the LMS domain name. 1 is

--- a/tutor/templates/apps/openedx/settings/partials/common_lms.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_lms.py
@@ -36,11 +36,6 @@ CACHES["staticfiles"] = {
     "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     "LOCATION": "staticfiles_lms",
 }
-CACHES["ora2-storage"] = {
-    "KEY_PREFIX": "ora2-storage",
-    "BACKEND": "django_redis.cache.RedisCache",
-    "LOCATION": "redis://{% if REDIS_USERNAME and REDIS_PASSWORD %}{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}{% endif %}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CACHE_REDIS_DB }}",
-}
 
 # Create folders if necessary
 for folder in [DATA_DIR, LOG_DIR, MEDIA_ROOT, STATIC_ROOT_BASE, ORA2_FILEUPLOAD_ROOT]:


### PR DESCRIPTION
The ORA2 cache settings seem to never have existed in CMS, causing ORA2 file uploads fail on CMS side. As the cache settings are shared between both CMS and LMS, the settings are moved from `common_lms.py` to `common_all.py`. This issue was initially raised [here](https://discuss.openedx.org/t/palm-2-ora-file-upload-failure/11332).

Closes https://github.com/overhangio/tutor/issues/909.