### PR TITLE
fix: build error caused by removed py2neo package

### DIFF
--- a/changelog.d/20231010_111112_regis_fix_py2neo.md
+++ b/changelog.d/20231010_111112_regis_fix_py2neo.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix build error caused by py2neo package that was abruptly pulled from pypi and GitHub. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -88,6 +88,9 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/openedx/.cache/pip,
     # https://pypi.org/project/wheel/
     setuptools==67.6.1 pip==23.0.1. wheel==0.40.0
 
+# Install missing py2neo package that was abruptly trimmed from pypi
+RUN pip install https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+
 # Install base requirements
 {% if not is_buildkit_enabled() %}
 COPY --from=edx-platform /requirements/edx/base.txt /openedx/edx-platform/requirements/edx/base.txt


### PR DESCRIPTION
On Oct. 10, py2neo package was abruptly removed from pypi, GitHub, and the py2neo website now displays just a super funny meme: https://py2neo.org/

Yes, we should get rid of that dependency, but we are still supposed to support existing users. So we install py2neo from our fork.