### PR TITLE
Fix: Large DEV Image

### DIFF
--- a/changelog.d/20231011_005657_codewithemad_large_dev_image.md
+++ b/changelog.d/20231011_005657_codewithemad_large_dev_image.md
@@ -1,0 +1,1 @@
+- [Improvement] No more large dev images. This was fixed by adding --no-log-init option to useradd command and reducing space usage of /var/log/faillog.  (by @CodeWithEmad)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -149,7 +149,7 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/var/cache/apt,shari
 # Note that this must always be different from root (APP_USER_ID=0)
 ARG APP_USER_ID=1000
 RUN if [ "$APP_USER_ID" = 0 ]; then echo "app user may not be root" && false; fi
-RUN useradd --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER_ID} app
+RUN useradd --no-log-init --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 
 # https://hub.docker.com/r/powerman/dockerize/tags


### PR DESCRIPTION
This will fix large dev images caused by the large user ID ([this docker bug](https://github.com/moby/moby/issues/5419)).
Closes https://github.com/openedx/wg-developer-experience/issues/178