### PR TITLE
fix: fix `ulimits` error for elasticsearch in Docker rootless mode

### DIFF
--- a/changelog.d/20231116_081945_i_rootless_docker.md
+++ b/changelog.d/20231116_081945_i_rootless_docker.md
@@ -1,0 +1,2 @@
+- [Improvement] Fix `ulimits` error for elasticsearch in Docker rootless mode (by @OmarIthawi)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from io import StringIO
+import subprocess
 from typing import List, Tuple
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -240,6 +241,25 @@ class UtilsTests(unittest.TestCase):
         self.assertFalse(utils.is_http("/home/user/"))
         self.assertFalse(utils.is_http("home/user/"))
         self.assertFalse(utils.is_http("http-home/user/"))
+
+    @patch("subprocess.run")
+    def test_is_docker_rootless(self, mock_run: MagicMock) -> None:
+        # Mock rootless `docker info` output
+        utils.is_docker_rootless.cache_clear()
+        mock_run.return_value.stdout = "some prefix\n rootless foo bar".encode("utf-8")
+        self.assertTrue(utils.is_docker_rootless())
+
+        # Mock regular `docker info` output
+        utils.is_docker_rootless.cache_clear()
+        mock_run.return_value.stdout = "some prefix, regular docker".encode("utf-8")
+        self.assertFalse(utils.is_docker_rootless())
+
+    @patch("subprocess.run")
+    def test_is_docker_rootless_podman(self, mock_run: MagicMock) -> None:
+        """Test the `is_docker_rootless` when podman is used or any other error with `docker info`"""
+        utils.is_docker_rootless.cache_clear()
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker info")
+        self.assertFalse(utils.is_docker_rootless())
 
     def test_format_table(self) -> None:
         rows: List[Tuple[str, ...]] = [

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -55,6 +55,7 @@ def _prepare_environment() -> None:
             ("TUTOR_APP", __app__.replace("-", "_")),
             ("TUTOR_VERSION", __version__),
             ("is_buildkit_enabled", utils.is_buildkit_enabled),
+            ("is_docker_rootless", utils.is_docker_rootless),
         ],
     )
 

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -52,4 +52,13 @@ services:
     command: openedx-assets watch-themes --env dev
     restart: unless-stopped
 
+  {% if RUN_ELASTICSEARCH and is_docker_rootless() %}
+  elasticsearch:
+    ulimits:
+      memlock:
+        # Fixes error setting rlimits for ready process in rootless docker
+        soft: 0  # zero means "unset" in the memlock context
+        hard: 0
+  {% endif %}
+
   {{ patch("local-docker-compose-dev-services")|indent(2) }}

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -192,6 +192,20 @@ def is_buildkit_enabled() -> bool:
         return False
 
 
+@lru_cache(maxsize=None)
+def is_docker_rootless() -> bool:
+    """
+    A helper function to determine if Docker is running in rootless mode.
+
+     - https://docs.docker.com/engine/security/rootless/
+    """
+    try:
+        results = subprocess.run(["docker", "info"], capture_output=True, check=True)
+        return "rootless" in results.stdout.decode()
+    except subprocess.CalledProcessError:
+        return False
+
+
 def docker_compose(*command: str) -> int:
     return execute("docker", "compose", *command)
 


### PR DESCRIPTION
### Description

Unset `ulimits.memlock` for elasticsearch for Docker rootless devstacks.

Related issue:

 - Fixes #876 

### Error

When running `tutor dev launch` in rootless docker, everything works except for elasticsearch. 

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting rlimits for ready process: error setting rlimit type 8: operation not permitted: unknown
```

### TODO

 - [x] Test locally
 - [x] Rebase and open against `master`