### PR TITLE
chore: update deprecation warning for Django 4.2

### DIFF
--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -149,9 +149,16 @@ LOGGING["loggers"]["blockstore.apps.bundles.storage"] = {"handlers": ["console"]
 
 # These warnings are visible in simple commands and init tasks
 import warnings
-from django.utils.deprecation import RemovedInDjango40Warning, RemovedInDjango41Warning
-warnings.filterwarnings("ignore", category=RemovedInDjango40Warning)
-warnings.filterwarnings("ignore", category=RemovedInDjango41Warning)
+
+try:
+    from django.utils.deprecation import RemovedInDjango50Warning, RemovedInDjango51Warning
+    warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)
+    warnings.filterwarnings("ignore", category=RemovedInDjango51Warning)
+except ImportError:
+    from django.utils.deprecation import RemovedInDjango40Warning, RemovedInDjango41Warning
+    warnings.filterwarnings("ignore", category=RemovedInDjango40Warning)
+    warnings.filterwarnings("ignore", category=RemovedInDjango41Warning)
+
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="wiki.plugins.links.wiki_plugin")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="boto.plugin")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore.vendored.requests.packages.urllib3._collections")


### PR DESCRIPTION
We are going to upgrade to Django 4.2 for Quince.
Issue: https://github.com/openedx/wg-build-test-release/issues/315
PR to edx-platform: https://github.com/openedx/edx-platform/pull/33516 (will be merged only after Tutor preparation for Django4.2)

Here I'm just updating to the new `50`/`51` DeprecationWarnings.
Also to be able to smoothly move from Django 3.2 to 4.2 I propose to add try/except block (for now).