### PR TITLE
feat: dev added to extras_require

### DIFF
--- a/changelog.d/20231106_202213_codewithemad.md
+++ b/changelog.d/20231106_202213_codewithemad.md
@@ -1,0 +1,1 @@
+- [Improvement] Install tutor development tools with `pip install tutor[dev]`. (by @CodeWithEmad)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     python_requires=">=3.6",
     install_requires=load_requirements("base.in"),
     extras_require={
+        "dev": load_requirements("dev.txt"),
         "full": load_requirements("plugins.txt"),
     },
     entry_points={"console_scripts": ["tutor=tutor.commands.cli:main"]},


### PR DESCRIPTION
We can use this to install tutor development packages inside ci jobs, with one line. it can be helpful for [this](https://github.com/overhangio/tutor-mfe/pull/155) 