### PR TITLE
docs: Update troubleshooting.rst with notes about docker buildkit

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -168,3 +168,29 @@ This issue should only happen in development mode. Long story short, it can be s
     tutor dev run lms ./manage.py lms waffle_switch block_structure.invalidate_cache_on_publish on --create
 
 If you'd like to learn more, please take a look at `this Github issue <https://github.com/overhangio/tutor/issues/302>`__.
+
+High resource consumption on ``tutor images build`` by docker 
+-------------------------------------------------------------
+
+This issue can occur when building multiple images simultaneously by Docker, issue specifically related to BuildKit.
+
+Troubleshooting Steps:
+
+Create a buildkit.toml configuration file with the following contents::
+
+    [worker.oci]
+    max-parallelism = 2
+
+This configuration file limits the number of layers built concurrently to 2, which can significantly reduce resource consumption.
+
+Create a builder that uses this configuration::
+
+    docker buildx create --use --name=<name> --driver=docker-container --config=/path/to/buildkit.toml
+
+Replace <name> with a suitable name for your builder, and ensure that you specify the correct path to the buildkit.toml configuration file.
+
+Now build again::
+
+    tutor images build
+
+By following these steps, you should be able to mitigate the problem.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -192,4 +192,4 @@ Now build again::
 
     tutor images build
 
-By following these steps, you should be able to mitigate the problem.
+All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker buildx use default``. 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -174,7 +174,6 @@ High resource consumption on ``tutor images build`` by docker
 
 This issue can occur when building multiple images simultaneously by Docker, issue specifically related to BuildKit.
 
-Troubleshooting Steps:
 
 Create a buildkit.toml configuration file with the following contents::
 


### PR DESCRIPTION
It adds a note in the troubleshooting guide, offering solution for mitigating resource consumption issues related to BuildKit when building multiple images using Tutor.