### PR TITLE
feat: add surveyreport questions

### DIFF
--- a/changelog.d/20231214_141533_alecar.main_survey_report_plugin.md
+++ b/changelog.d/20231214_141533_alecar.main_survey_report_plugin.md
@@ -1,0 +1,1 @@
+- [Feature] add `CONFIG_INTERACTIVE` action that allows tutor plugins to interact with the configuration at the time of the interactive questionnaire that happens during tutor local launch. (by @Alec4r).

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -57,6 +57,12 @@ class Actions:
     #: :parameter str name: docker-compose project name.
     COMPOSE_PROJECT_STARTED: Action[[str, Config, str]] = Action()
 
+    #: Triggered after all interactive questions have been asked.
+    #: You should use this action if you want to add new questions.
+    #:
+    #: :parameter dict config: project configuration.
+    CONFIG_INTERACTIVE: Action[[Config]] = Action()
+
     #: This action is called at the end of the tutor.config.load_full function.
     #: Modifying this object will not trigger changes in the configuration.
     #: For all purposes, it should be considered read-only.

--- a/tutor/interactive.py
+++ b/tutor/interactive.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import click
 
 from . import config as tutor_config
-from . import env, exceptions, fmt
+from . import env, exceptions, fmt, hooks
 from .types import Config, get_typed
 
 
@@ -145,6 +145,8 @@ def ask_questions(config: Config, run_for_prod: Optional[bool] = None) -> None:
             config,
             defaults,
         )
+
+    hooks.Actions.CONFIG_INTERACTIVE.do(config)
 
 
 def ask(question: str, key: str, config: Config, defaults: Config) -> None:


### PR DESCRIPTION
## DESCRIPTION
This PR creates a new hook Action that allows tutor plugins to interact with the configuration at the time of the interactive questionnaire that happens during `tutor local launch`.


## REQUIRED PLUGINS
None. The creation of the Action does not require anything from new or existing plugins. Current plugins that do not use this action will see absolutely no changes to the functionality of `tutor local launch`.


## MORE INFO
This Action was first needed when trying to create a plugin to send automatic and anonymized reports of usage.
For more context on that see:
- https://github.com/eduNEXT/tutor-contrib-surveyreport
- https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3872948238/Problem+Very+few+are+going+to+generate+and+send+the+Survey+Report.

## EXAMPLE:

A plugin using this Action to add a new question can be seen at:
https://github.com/eduNEXT/tutor-contrib-surveyreport/pull/1