### PR TITLE
feat: simplify nightly management

### DIFF
--- a/changelog.d/20231120_160115_regis_nightly_common_version.md
+++ b/changelog.d/20231120_160115_regis_nightly_common_version.md
@@ -1,0 +1,1 @@
+- [Improvement] Do not hardcode `OPENEDX_COMMON_VERSION = master` in the nightly branch. This removes git conflicts whenever we bump the common version in the master branch. (by @regisb)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -136,7 +136,7 @@ Open edX customisation
 
 This defines the git repository from which you install Open edX platform code. If you run an Open edX fork with custom patches, set this to your own git repository. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
 
-- ``OPENEDX_COMMON_VERSION`` (default: ``"open-release/palm.4"``)
+- ``OPENEDX_COMMON_VERSION`` (default: ``"open-release/palm.4"``, or ``master`` in :ref:`nightly <nightly>`)
 
 This defines the default version that will be pulled from all Open edX git repositories.
 

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from copy import deepcopy
+import typing as t
 
 import os
 
@@ -138,11 +139,30 @@ def get_defaults() -> Config:
 
     Entries in this configuration are unrendered.
     """
-    defaults = get_template("defaults.yml")
-    for name, value in hooks.Filters.CONFIG_DEFAULTS.iterate():
-        defaults[name] = value
+    defaults = dict(hooks.Filters.CONFIG_DEFAULTS.iterate())
     update_with_env(defaults)
     return defaults
+
+
+@hooks.Filters.CONFIG_DEFAULTS.add(priority=hooks.priorities.HIGH)
+def _load_config_defaults_yml(
+    items: list[tuple[str, t.Any]]
+) -> list[tuple[str, t.Any]]:
+    defaults = get_template("defaults.yml")
+    items += list(defaults.items())
+    return items
+
+
+@hooks.Filters.CONFIG_DEFAULTS.add()
+def _set_openedx_common_version_in_nightly(
+    items: list[tuple[str, t.Any]]
+) -> list[tuple[str, t.Any]]:
+    # REMOVE-AFTER-v16 move this callback to the dedicated openedx/plugin.py module
+    from tutor.__about__ import __version_suffix__
+
+    if __version_suffix__ == "nightly":
+        items.append(("OPENEDX_COMMON_VERSION", "master"))
+    return items
 
 
 def get_template(filename: str) -> Config:

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -52,6 +52,7 @@ OPENEDX_CMS_UWSGI_WORKERS: 2
 OPENEDX_LMS_UWSGI_WORKERS: 2
 OPENEDX_MYSQL_DATABASE: "openedx"
 OPENEDX_MYSQL_USERNAME: "openedx"
+# the common version will be automatically set to "master" in the nightly branch
 OPENEDX_COMMON_VERSION: "open-release/palm.4"
 OPENEDX_EXTRA_PIP_REQUIREMENTS:
   - "openedx-scorm-xblock>=16.0.0,<17.0.0"


### PR DESCRIPTION
Bumping the `OPENEDX_COMMON_VERSION` in the master branch usually creates a conflict when we merge the change in the nightly branch. To avoid this conflict, we add some logic to the `OPENEDX_COMMON_VERSION`.

This change should be invisible for most users.

This partially addresses issue #936.