### PR TITLE
feat: enable copy-paste of units by default

### DIFF
--- a/tutor/templates/jobs/init/cms.sh
+++ b/tutor/templates/jobs/init/cms.sh
@@ -12,3 +12,7 @@ if [ -d /openedx/data/uploads/ ]; then
     rm -rf /openedx/data/uploads/
   fi
 fi
+
+# Create waffle switches to enable some features, if they have not been explicitly defined before
+# Copy-paste of units in Studio (highly requested new feature, but defaults to off in Quince)
+(./manage.py cms waffle_flag --list | grep contentstore.enable_copy_paste_units) || ./manage.py lms waffle_flag --create contentstore.enable_copy_paste_units --everyone


### PR DESCRIPTION
This PR will enable the new-ish "copy & paste units" feature in Quince. Because it's a new feature and edx.org wants to roll it out later for their users, it's off by default in edx-platform. But Axim product is recommending it be on by default in Quince, because it's a useful, highly requested feature and there are no known issues with it. Operators can of course disable it easily via the django admin if for some reason they don't want it.

### Before

![Screenshot 2023-12-01 at 12 54 17 PM](https://github.com/overhangio/tutor/assets/945577/06950822-9c9f-4e1d-9058-a954e87e237b)

### After

![Screenshot 2023-12-01 at 12 58 04 PM](https://github.com/overhangio/tutor/assets/945577/d0f68825-5051-42ca-975f-abcd230b21ec)

![Screenshot 2023-12-01 at 12 58 27 PM](https://github.com/overhangio/tutor/assets/945577/ea447bdd-6f48-4154-b87e-08d00f3acfac)

### Dependencies

Most of the relevant code is already in Quince, but the features shown in the second "After" screenshot are waiting on a backport PR - https://github.com/openedx/edx-platform/pull/33866 . Whether or not that backport PR is merged, the flag enables new functionality and new UI on the course outline page.