### PR TITLE
feat: local.overhang.io -> local.edly.io

### DIFF
--- a/changelog.d/20231205_113430_regis_local_edly_io.md
+++ b/changelog.d/20231205_113430_regis_local_edly_io.md
@@ -1,0 +1,1 @@
+- 💥[Feature] Replace "*.local.overhang.io" hostnames by "*.local.edly.io". (by @regisb)

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -26,7 +26,7 @@ This will perform several tasks. It will:
 * build the "openedx-dev" Docker image, which is based on the "openedx" production image but is `specialized for developer usage`_ (eventually with your fork),
 * stop any existing locally-running Tutor containers,
 * disable HTTPS,
-* set ``LMS_HOST`` to `local.overhang.io <http://local.overhang.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.overhang.io>`_),
+* set ``LMS_HOST`` to `local.edly.io <http://local.edly.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.edly.io>`_),
 * prompt for a platform details (with suitable defaults),
 * build an ``openedx-dev`` image,
 * start LMS, CMS, supporting services, and any plugged-in services,
@@ -41,8 +41,8 @@ Additionally, when a local clone of edx-platform is bind-mounted, it will:
 
 Once setup is complete, the platform will be running in the background:
 
-* LMS will be accessible at `http://local.overhang.io:8000 <http://local.overhang.io:8000>`_.
-* CMS will be accessible at `http://studio.local.overhang.io:8001 <http://studio.local.overhang.io:8001>`_.
+* LMS will be accessible at `http://local.edly.io:8000 <http://local.edly.io:8000>`_.
+* CMS will be accessible at `http://studio.local.edly.io:8001 <http://studio.local.edly.io:8001>`_.
 * Plugged-in services should be accessible at their documented URLs.
 
 Now, use the ``tutor dev ...`` command-line interface to manage the development environment. Some common commands are described below.

--- a/docs/tutorials/theming.rst
+++ b/docs/tutorials/theming.rst
@@ -46,7 +46,7 @@ Then, run a local webserver::
 
     tutor dev start lms
 
-The LMS can then be accessed at http://local.overhang.io:8000. You will then have to :ref:`enable that theme <settheme>`::
+The LMS can then be accessed at http://local.edly.io:8000. You will then have to :ref:`enable that theme <settheme>`::
 
     tutor dev do settheme mythemename
 
@@ -54,4 +54,4 @@ Watch the themes folders for changes (in a different terminal)::
 
     tutor dev run watchthemes
 
-Make changes to some of the files inside the theme directory: the theme assets should be automatically recompiled and visible at http://local.overhang.io:8000.
+Make changes to some of the files inside the theme directory: the theme assets should be automatically recompiled and visible at http://local.edly.io:8000.

--- a/tutor/interactive.py
+++ b/tutor/interactive.py
@@ -18,7 +18,10 @@ def ask_questions(config: Config, run_for_prod: Optional[bool] = None) -> None:
     """
     defaults = tutor_config.get_defaults()
     if run_for_prod is None:
-        run_for_prod = config.get("LMS_HOST") != "local.overhang.io"
+        run_for_prod = not config.get("LMS_HOST") in [
+            "local.edly.io",
+            "local.overhang.io",
+        ]
         run_for_prod = click.confirm(
             fmt.question(
                 "Are you configuring a production platform? "
@@ -29,8 +32,8 @@ def ask_questions(config: Config, run_for_prod: Optional[bool] = None) -> None:
         )
     if not run_for_prod:
         dev_values: Config = {
-            "LMS_HOST": "local.overhang.io",
-            "CMS_HOST": "studio.local.overhang.io",
+            "LMS_HOST": "local.edly.io",
+            "CMS_HOST": "studio.local.edly.io",
             "ENABLE_HTTPS": False,
         }
         fmt.echo_info(

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
     networks:
       default:
         # These aliases are for internal communication between containers when running locally
-        # with *.local.overhang.io hostnames.
+        # with *.local.edly.io hostnames.
         aliases:
           - "{{ LMS_HOST }}"
           {{ patch("local-docker-compose-caddy-aliases")|indent(10) }}


### PR DESCRIPTION
The new domain name points to 127.0.0.1, just like the previous one. We keep the local.overhang.io domain names for backward compatibility. In the future, we hope to migrate to "*.openedx.io" but that will not happen before Redwood.

Close #945