### PR TITLE
fix: RsaKey.dq attribute error

### DIFF
--- a/changelog.d/20231214_110904_regis_rsa_error.md
+++ b/changelog.d/20231214_110904_regis_rsa_error.md
@@ -1,0 +1,1 @@
+- [Bugfix] Error "'Crypto.PublicKey.RSA.RsaKey object' has no attribute 'dq'" during `tutor config save` was caused by outdated minimum version of the pycryptodome package. To resolve this issue, run `pip install --upgrade pycryptodome`. (by @regisb)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,6 @@ click>=8.0
 jinja2>=2.10
 kubernetes
 mypy
-pycryptodome
+pycryptodome>=3.17.0
 pyyaml>=6.0
 typing-extensions>=4.4.0


### PR DESCRIPTION
Running `tutor config save` with an outdated version of pycryptodome was failing with the following error:

    Error: Missing configuration value: 'Crypto.PublicKey.RSA.RsaKey object' has no attribute 'dq'

This is because the "dq" attribute was only introduced in pycryptodome 3.17.0: https://www.pycryptodome.org/src/changelog#january-2023

To resolve this issue we bump the minimum requirements.

Close #962