### PR TITLE
chore: install compiled base dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include requirements/base.in
+include requirements/base.txt
 include requirements/plugins.txt
 include requirements/dev.txt
 recursive-include tutor/templates *

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=load_requirements("base.in"),
+    install_requires=load_requirements("base.txt"),
     extras_require={
         "dev": load_requirements("dev.txt"),
         "full": load_requirements("plugins.txt"),


### PR DESCRIPTION
If there's no weird reason behind it, this will fix the installation of the compiled base dependencies.