### PR TITLE
build: add Github action to auto-add new issues and PRs to project

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,20 @@
+name: Auto Add Issues and Pull Requests to Project
+
+on:
+  pull_request:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+
+
+jobs:
+  add-to-project:
+    name: Add issue and bugs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/overhangio/projects/4
+          github-token: ${{ secrets.ADD_TO_PROJECT_SECRET_TOKEN }}

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -14,7 +14,7 @@ jobs:
     name: Add issue and bugs to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@RELEASE_VERSION
+      - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/overhangio/projects/4
           github-token: ${{ secrets.ADD_TO_PROJECT_SECRET_TOKEN }}


### PR DESCRIPTION
### Description
Adds a Github action to auto-add new PRs and issues to Overhang.io project https://github.com/orgs/overhangio/projects/4.

Requires a token with repo and project scopes in env variable ADD_TO_PROJECT_SECRET_TOKEN

- https://github.com/actions/add-to-project?tab=readme-ov-file#inputs
- https://stackoverflow.com/questions/62530078/github-auto-assign-issue-to-project