### PR TITLE
fix: allow to setup redis maxmemory

### DIFF
--- a/tutor/templates/apps/redis/redis.conf
+++ b/tutor/templates/apps/redis/redis.conf
@@ -39,3 +39,9 @@ auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 aof-load-truncated yes
 aof-use-rdb-preamble yes
+
+################################ MEMORY - EVICTION ###############################
+
+# https://redis.io/docs/reference/eviction/
+maxmemory {{ REDIS_MAXMEMORY }}
+maxmemory-policy allkeys-lru


### PR DESCRIPTION
### Description

In some of our production environments, we have experienced an incremental use of Redis capacity. After some research we found that this [code](https://github.com/openedx/edx-platform/blob/open-release/nutmeg.3/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py#L248) (with no major changes since the nutmeg release) was storing course structure data in Redis without TTL as it the expected cache layer was `memcached` and it's configured by default to use the LRU eviction policy.

The above code stored the data in the following key format: `course_structure.{{db}}{{version_id}}` so there was a lot of outdated/unused data (due to changes in the courses) stored in Redis indefinitely.

**Note**: Although the majority of the keys stored in Redis were associated with sessions, those already had a TTL configured and didn't represent the majority of the data. It was estimated (using a sample) that every key in the `course_structure` namespace has 0.3 MB of data (for small courses) and there was around 54k keys there.

To configure an eviction policy in Redis we need to configure two params:
- `maxmemory`: Setups the Redis memory usage limit.
- `maxmemory-policy`: Setups the eviction policy used by Redis when the `maxmemory` limit is reached.

See [Key eviction](https://redis.io/docs/reference/eviction/) for more information.

The problem was discussed [here](https://discuss.openedx.org/t/course-structure-cache-never-expire-in-juniper-3/4336) in the Juniper release, but the problem is the same.

This PR solves that issue by configuring the above parameters.