### PR TITLE
chore: Add .webp and .otf file extensions to list of binary file extensions

### DIFF
--- a/changelog.d/20240118_155012_r.khetani.md
+++ b/changelog.d/20240118_155012_r.khetani.md
@@ -1,0 +1,1 @@
+[Improvement] Add `.webp` and. `.otf` extensions to list of binary extensions to ignore when rendering templates.

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -15,7 +15,7 @@ from tutor.types import Config, ConfigValue
 
 TEMPLATES_ROOT = pkg_resources.resource_filename("tutor", "templates")
 VERSION_FILENAME = "version"
-BIN_FILE_EXTENSIONS = [".ico", ".jpg", ".patch", ".png", ".ttf", ".woff", ".woff2"]
+BIN_FILE_EXTENSIONS = [".ico", ".jpg", ".otf", ".patch", ".png", ".ttf", ".webp", ".woff", ".woff2"]
 JinjaFilter = t.Callable[..., t.Any]
 
 

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -15,7 +15,17 @@ from tutor.types import Config, ConfigValue
 
 TEMPLATES_ROOT = pkg_resources.resource_filename("tutor", "templates")
 VERSION_FILENAME = "version"
-BIN_FILE_EXTENSIONS = [".ico", ".jpg", ".otf", ".patch", ".png", ".ttf", ".webp", ".woff", ".woff2"]
+BIN_FILE_EXTENSIONS = [
+    ".ico",
+    ".jpg",
+    ".otf",
+    ".patch",
+    ".png",
+    ".ttf",
+    ".webp",
+    ".woff",
+    ".woff2",
+]
 JinjaFilter = t.Callable[..., t.Any]
 
 


### PR DESCRIPTION
Short term solution to address issue raised in #975, which was causing tutor to throw exceptions when enabling theming plugins, which included file extensions not specified by `BIN_FILE_EXTENSIONS` in `env.py`