### PR TITLE
feat: atlas pull for plugins and xblocks | FC-0012

### DIFF
--- a/changelog.d/20240124_080753_i_plugins_xblocks.md
+++ b/changelog.d/20240124_080753_i_plugins_xblocks.md
@@ -1,0 +1,1 @@
+- [Feature] `atlas pull` translations for XBlocks and Plugins (by @OmarIthawi)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -186,8 +186,14 @@ COPY --chown=app:app settings/lms/*.py ./lms/envs/tutor/
 COPY --chown=app:app settings/cms/*.py ./cms/envs/tutor/
 
 # Pull latest translations via atlas
-RUN atlas pull --repository='{{ ATLAS_REPOSITORY }}' --branch='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \
-    translations/edx-platform/conf/locale:conf/locale
+RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+RUN ./manage.py lms --settings=tutor.i18n pull_xblock_translations --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+RUN atlas pull --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \
+    translations/edx-platform/conf/locale:conf/locale \
+    translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend
+RUN ./manage.py lms --settings=tutor.i18n compile_xblock_translations
+RUN ./manage.py cms --settings=tutor.i18n compile_xblock_translations
+RUN ./manage.py lms --settings=tutor.i18n compile_plugin_translations
 RUN ./manage.py lms --settings=tutor.i18n compilemessages -v1
 RUN ./manage.py lms --settings=tutor.i18n compilejsi18n
 RUN ./manage.py cms --settings=tutor.i18n compilejsi18n


### PR DESCRIPTION
Pulls translations for plugins and XBlock using the newly introduced commands:

 - https://github.com/openedx/edx-platform/pull/33698
 - https://github.com/openedx/edx-platform/pull/33922

### TODO

 - [x] Rebuild on `master`
 - [x] Check local translations update in `openedx` image file system

<details><summary>atlas pull results</summary>

```
$ docker run -it docker.io/overhangio/openedx:17.0.2-nightly bash
~/edx-platform$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   cms/static/js/i18n/ar/djangojs.js
	modified:   cms/static/js/i18n/az/djangojs.js
	modified:   cms/static/js/i18n/bg-bg/djangojs.js
	modified:   cms/static/js/i18n/ca/djangojs.js
	modified:   cms/static/js/i18n/ca@valencia/djangojs.js
	modified:   cms/static/js/i18n/cs/djangojs.js
	modified:   cms/static/js/i18n/da/djangojs.js
	modified:   cms/static/js/i18n/de-de/djangojs.js
	modified:   cms/static/js/i18n/el/djangojs.js
	modified:   cms/static/js/i18n/en-uk/djangojs.js
	modified:   cms/static/js/i18n/en/djangojs.js
	modified:   cms/static/js/i18n/eo/djangojs.js
	modified:   cms/static/js/i18n/es-419/djangojs.js
	modified:   cms/static/js/i18n/es-ar/djangojs.js
	modified:   cms/static/js/i18n/es-ec/djangojs.js
	modified:   cms/static/js/i18n/es-es/djangojs.js
	modified:   cms/static/js/i18n/es-mx/djangojs.js
	modified:   cms/static/js/i18n/es-pe/djangojs.js
	modified:   cms/static/js/i18n/eu-es/djangojs.js
	modified:   cms/static/js/i18n/fi-fi/djangojs.js
	modified:   cms/static/js/i18n/fr/djangojs.js
	modified:   cms/static/js/i18n/gl/djangojs.js
	modified:   cms/static/js/i18n/he/djangojs.js
	modified:   cms/static/js/i18n/hi/djangojs.js
	modified:   cms/static/js/i18n/id/djangojs.js
	modified:   cms/static/js/i18n/it-it/djangojs.js
	modified:   cms/static/js/i18n/ja-jp/djangojs.js
	modified:   cms/static/js/i18n/kn/djangojs.js
	modified:   cms/static/js/i18n/ko-kr/djangojs.js
	modified:   cms/static/js/i18n/ms/djangojs.js
	modified:   cms/static/js/i18n/nl-nl/djangojs.js
	modified:   cms/static/js/i18n/pl/djangojs.js
	modified:   cms/static/js/i18n/pt-br/djangojs.js
	modified:   cms/static/js/i18n/pt-pt/djangojs.js
	modified:   cms/static/js/i18n/ru/djangojs.js
	modified:   cms/static/js/i18n/sk/djangojs.js
	modified:   cms/static/js/i18n/sl/djangojs.js
	modified:   cms/static/js/i18n/sq/djangojs.js
	modified:   cms/static/js/i18n/sr/djangojs.js
	modified:   cms/static/js/i18n/sv/djangojs.js
	modified:   cms/static/js/i18n/th/djangojs.js
	modified:   cms/static/js/i18n/tr-tr/djangojs.js
	modified:   cms/static/js/i18n/uk/djangojs.js
	modified:   cms/static/js/i18n/uz/djangojs.js
	modified:   cms/static/js/i18n/vi/djangojs.js
	modified:   cms/static/js/i18n/zh-cn/djangojs.js
	modified:   conf/locale/ar/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/ar/LC_MESSAGES/djangojs.po
	modified:   conf/locale/de_DE/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/de_DE/LC_MESSAGES/djangojs.po
	modified:   conf/locale/el/LC_MESSAGES/django.mo
	modified:   conf/locale/el/LC_MESSAGES/django.po
	modified:   conf/locale/el/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/el/LC_MESSAGES/djangojs.po
	modified:   conf/locale/en/LC_MESSAGES/django.po
	modified:   conf/locale/en/LC_MESSAGES/djangojs.po
	modified:   conf/locale/es_419/LC_MESSAGES/django.mo
	modified:   conf/locale/es_419/LC_MESSAGES/django.po
	modified:   conf/locale/es_419/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/es_419/LC_MESSAGES/djangojs.po
	modified:   conf/locale/he/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/he/LC_MESSAGES/djangojs.po
	modified:   conf/locale/hi/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/hi/LC_MESSAGES/djangojs.po
	modified:   conf/locale/id/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/id/LC_MESSAGES/djangojs.po
	modified:   conf/locale/it_IT/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/it_IT/LC_MESSAGES/djangojs.po
	modified:   conf/locale/pt_BR/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/pt_BR/LC_MESSAGES/djangojs.po
	modified:   conf/locale/pt_PT/LC_MESSAGES/django.mo
	modified:   conf/locale/pt_PT/LC_MESSAGES/django.po
	modified:   conf/locale/pt_PT/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/pt_PT/LC_MESSAGES/djangojs.po
	modified:   conf/locale/ru/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/ru/LC_MESSAGES/djangojs.po
	modified:   conf/locale/th/LC_MESSAGES/django.mo
	modified:   conf/locale/th/LC_MESSAGES/django.po
	modified:   conf/locale/th/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/th/LC_MESSAGES/djangojs.po
	modified:   conf/locale/tr_TR/LC_MESSAGES/django.mo
	modified:   conf/locale/tr_TR/LC_MESSAGES/django.po
	modified:   conf/locale/tr_TR/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/tr_TR/LC_MESSAGES/djangojs.po
	modified:   conf/locale/uk/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/uk/LC_MESSAGES/djangojs.po
	modified:   conf/locale/zh_CN/LC_MESSAGES/django.mo
	modified:   conf/locale/zh_CN/LC_MESSAGES/django.po
	modified:   conf/locale/zh_CN/LC_MESSAGES/djangojs.mo
	modified:   conf/locale/zh_CN/LC_MESSAGES/djangojs.po
	modified:   lms/static/js/i18n/ar/djangojs.js
	modified:   lms/static/js/i18n/az/djangojs.js
	modified:   lms/static/js/i18n/bg-bg/djangojs.js
	modified:   lms/static/js/i18n/ca/djangojs.js
	modified:   lms/static/js/i18n/ca@valencia/djangojs.js
	modified:   lms/static/js/i18n/cs/djangojs.js
	modified:   lms/static/js/i18n/da/djangojs.js
	modified:   lms/static/js/i18n/de-de/djangojs.js
	modified:   lms/static/js/i18n/el/djangojs.js
	modified:   lms/static/js/i18n/en-uk/djangojs.js
	modified:   lms/static/js/i18n/en/djangojs.js
	modified:   lms/static/js/i18n/eo/djangojs.js
	modified:   lms/static/js/i18n/es-419/djangojs.js
	modified:   lms/static/js/i18n/es-ar/djangojs.js
	modified:   lms/static/js/i18n/es-ec/djangojs.js
	modified:   lms/static/js/i18n/es-es/djangojs.js
	modified:   lms/static/js/i18n/es-mx/djangojs.js
	modified:   lms/static/js/i18n/es-pe/djangojs.js
	modified:   lms/static/js/i18n/eu-es/djangojs.js
	modified:   lms/static/js/i18n/fi-fi/djangojs.js
	modified:   lms/static/js/i18n/fr/djangojs.js
	modified:   lms/static/js/i18n/gl/djangojs.js
	modified:   lms/static/js/i18n/he/djangojs.js
	modified:   lms/static/js/i18n/hi/djangojs.js
	modified:   lms/static/js/i18n/id/djangojs.js
	modified:   lms/static/js/i18n/it-it/djangojs.js
	modified:   lms/static/js/i18n/ja-jp/djangojs.js
	modified:   lms/static/js/i18n/kn/djangojs.js
	modified:   lms/static/js/i18n/ko-kr/djangojs.js
	modified:   lms/static/js/i18n/ms/djangojs.js
	modified:   lms/static/js/i18n/nl-nl/djangojs.js
	modified:   lms/static/js/i18n/pl/djangojs.js
	modified:   lms/static/js/i18n/pt-br/djangojs.js
	modified:   lms/static/js/i18n/pt-pt/djangojs.js
	modified:   lms/static/js/i18n/ru/djangojs.js
	modified:   lms/static/js/i18n/sk/djangojs.js
	modified:   lms/static/js/i18n/sl/djangojs.js
	modified:   lms/static/js/i18n/sq/djangojs.js
	modified:   lms/static/js/i18n/sr/djangojs.js
	modified:   lms/static/js/i18n/sv/djangojs.js
	modified:   lms/static/js/i18n/th/djangojs.js
	modified:   lms/static/js/i18n/tr-tr/djangojs.js
	modified:   lms/static/js/i18n/uk/djangojs.js
	modified:   lms/static/js/i18n/uz/djangojs.js
	modified:   lms/static/js/i18n/vi/djangojs.js
	modified:   lms/static/js/i18n/zh-cn/djangojs.js

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	bindmount-canary
	cms/envs/tutor/
	cms/static/js/i18n/fr-ca/
	conf/locale/da/
	conf/locale/es_ES/
	conf/locale/fr_CA/
	lms/envs/tutor/
	lms/static/js/i18n/fr-ca/
	results.txt
	uwsgi.ini

no changes added to commit (use "git add" and/or "git commit -a")







~/edx-platform$ find conf/plugins-locale/
conf/plugins-locale/
conf/plugins-locale/plugins
conf/plugins-locale/plugins/edx_toggles
conf/plugins-locale/plugins/completion
conf/plugins-locale/plugins/completion/fr_CA
conf/plugins-locale/plugins/completion/fr_CA/LC_MESSAGES
conf/plugins-locale/plugins/completion/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/plugins/completion/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/completion/en
conf/plugins-locale/plugins/completion/en/LC_MESSAGES
conf/plugins-locale/plugins/completion/en/LC_MESSAGES/django.po
conf/plugins-locale/plugins/completion/en/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/super_csv
conf/plugins-locale/plugins/edx_name_affirmation
conf/plugins-locale/plugins/bulk_grades
conf/plugins-locale/plugins/bulk_grades/fr_CA
conf/plugins-locale/plugins/bulk_grades/fr_CA/LC_MESSAGES
conf/plugins-locale/plugins/bulk_grades/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/plugins/bulk_grades/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/bulk_grades/en
conf/plugins-locale/plugins/bulk_grades/en/LC_MESSAGES
conf/plugins-locale/plugins/bulk_grades/en/LC_MESSAGES/django.po
conf/plugins-locale/plugins/bulk_grades/en/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_when
conf/plugins-locale/plugins/edx_proctoring
conf/plugins-locale/plugins/edx_proctoring/es_ES
conf/plugins-locale/plugins/edx_proctoring/es_ES/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/es_ES/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/es_ES/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/fr_CA
conf/plugins-locale/plugins/edx_proctoring/fr_CA/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/fr_CA/LC_MESSAGES/djangojs.po
conf/plugins-locale/plugins/edx_proctoring/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/fr_CA/LC_MESSAGES/djangojs.mo
conf/plugins-locale/plugins/edx_proctoring/en
conf/plugins-locale/plugins/edx_proctoring/en/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/en/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/en/LC_MESSAGES/djangojs.po
conf/plugins-locale/plugins/edx_proctoring/en/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/en/LC_MESSAGES/djangojs.mo
conf/plugins-locale/plugins/edx_proctoring/uk
conf/plugins-locale/plugins/edx_proctoring/uk/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/uk/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/uk/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/pt_PT
conf/plugins-locale/plugins/edx_proctoring/pt_PT/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/pt_PT/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/pt_PT/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/es_419
conf/plugins-locale/plugins/edx_proctoring/es_419/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/es_419/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/es_419/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/it_IT
conf/plugins-locale/plugins/edx_proctoring/it_IT/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/it_IT/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/it_IT/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/tr_TR
conf/plugins-locale/plugins/edx_proctoring/tr_TR/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/tr_TR/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/tr_TR/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/de
conf/plugins-locale/plugins/edx_proctoring/de/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/de/LC_MESSAGES/djangojs.po
conf/plugins-locale/plugins/edx_proctoring/de/LC_MESSAGES/djangojs.mo
conf/plugins-locale/plugins/edx_proctoring/ar
conf/plugins-locale/plugins/edx_proctoring/ar/LC_MESSAGES
conf/plugins-locale/plugins/edx_proctoring/ar/LC_MESSAGES/django.po
conf/plugins-locale/plugins/edx_proctoring/ar/LC_MESSAGES/djangojs.po
conf/plugins-locale/plugins/edx_proctoring/ar/LC_MESSAGES/django.mo
conf/plugins-locale/plugins/edx_proctoring/ar/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1
conf/plugins-locale/xblock.v1/edx_sga
conf/plugins-locale/xblock.v1/crowdsourcehinter
conf/plugins-locale/xblock.v1/lti_consumer
conf/plugins-locale/xblock.v1/lti_consumer/fr_CA
conf/plugins-locale/xblock.v1/lti_consumer/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/lti_consumer/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/lti_consumer/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/lti_consumer/en
conf/plugins-locale/xblock.v1/lti_consumer/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/lti_consumer/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/lti_consumer/en/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/recommender
conf/plugins-locale/xblock.v1/recommender/fr_CA
conf/plugins-locale/xblock.v1/recommender/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/recommender/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/recommender/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/recommender/en
conf/plugins-locale/xblock.v1/recommender/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/recommender/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/recommender/en/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment
conf/plugins-locale/xblock.v1/openassessment/es_ES
conf/plugins-locale/xblock.v1/openassessment/es_ES/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/es_ES/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/es_ES/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/es_ES/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/es_ES/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/fr_CA
conf/plugins-locale/xblock.v1/openassessment/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/fr_CA/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/fr_CA/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/en
conf/plugins-locale/xblock.v1/openassessment/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/en/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/en/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/en/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/id
conf/plugins-locale/xblock.v1/openassessment/id/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/id/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/id/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/id/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/id/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/hi
conf/plugins-locale/xblock.v1/openassessment/hi/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/hi/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/hi/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/el
conf/plugins-locale/xblock.v1/openassessment/el/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/el/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/el/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/el/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/el/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/zh_CN
conf/plugins-locale/xblock.v1/openassessment/zh_CN/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/zh_CN/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/zh_CN/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/zh_CN/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/zh_CN/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/uk
conf/plugins-locale/xblock.v1/openassessment/uk/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/uk/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/uk/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/he
conf/plugins-locale/xblock.v1/openassessment/he/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/he/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/he/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/he/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/he/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/pt_PT
conf/plugins-locale/xblock.v1/openassessment/pt_PT/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/pt_PT/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/pt_PT/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/pt_PT/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/pt_PT/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/pt_BR
conf/plugins-locale/xblock.v1/openassessment/pt_BR/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/pt_BR/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/pt_BR/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/pt_BR/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/pt_BR/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/de_DE
conf/plugins-locale/xblock.v1/openassessment/de_DE/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/de_DE/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/de_DE/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/de_DE/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/de_DE/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/es_419
conf/plugins-locale/xblock.v1/openassessment/es_419/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/es_419/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/es_419/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/es_419/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/es_419/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/ru
conf/plugins-locale/xblock.v1/openassessment/ru/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/ru/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/ru/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/ru/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/ru/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/it_IT
conf/plugins-locale/xblock.v1/openassessment/it_IT/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/it_IT/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/it_IT/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/it_IT/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/it_IT/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/tr_TR
conf/plugins-locale/xblock.v1/openassessment/tr_TR/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/tr_TR/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/tr_TR/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/tr_TR/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/tr_TR/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/de
conf/plugins-locale/xblock.v1/openassessment/de/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/de/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/de/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/da
conf/plugins-locale/xblock.v1/openassessment/da/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/da/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/da/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/da/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/da/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openassessment/ar
conf/plugins-locale/xblock.v1/openassessment/ar/LC_MESSAGES
conf/plugins-locale/xblock.v1/openassessment/ar/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/openassessment/ar/LC_MESSAGES/djangojs.po
conf/plugins-locale/xblock.v1/openassessment/ar/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/openassessment/ar/LC_MESSAGES/djangojs.mo
conf/plugins-locale/xblock.v1/openedxscorm
conf/plugins-locale/xblock.v1/done
conf/plugins-locale/xblock.v1/done/es_ES
conf/plugins-locale/xblock.v1/done/es_ES/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/es_ES/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/es_ES/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/fr_CA
conf/plugins-locale/xblock.v1/done/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/en
conf/plugins-locale/xblock.v1/done/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/en/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/el
conf/plugins-locale/xblock.v1/done/el/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/el/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/el/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/uk
conf/plugins-locale/xblock.v1/done/uk/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/uk/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/uk/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/pt_PT
conf/plugins-locale/xblock.v1/done/pt_PT/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/pt_PT/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/pt_PT/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/pt_BR
conf/plugins-locale/xblock.v1/done/pt_BR/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/pt_BR/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/pt_BR/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/de_DE
conf/plugins-locale/xblock.v1/done/de_DE/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/de_DE/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/de_DE/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/es_419
conf/plugins-locale/xblock.v1/done/es_419/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/es_419/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/es_419/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/ru
conf/plugins-locale/xblock.v1/done/ru/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/ru/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/ru/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/it_IT
conf/plugins-locale/xblock.v1/done/it_IT/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/it_IT/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/it_IT/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/tr_TR
conf/plugins-locale/xblock.v1/done/tr_TR/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/tr_TR/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/tr_TR/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/de
conf/plugins-locale/xblock.v1/done/de/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/de/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/de/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/da
conf/plugins-locale/xblock.v1/done/da/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/da/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/da/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/done/ar
conf/plugins-locale/xblock.v1/done/ar/LC_MESSAGES
conf/plugins-locale/xblock.v1/done/ar/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/done/ar/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/staff_graded
conf/plugins-locale/xblock.v1/poll
conf/plugins-locale/xblock.v1/acid
conf/plugins-locale/xblock.v1/drag_and_drop_v2
conf/plugins-locale/xblock.v1/drag_and_drop_v2/fr_CA
conf/plugins-locale/xblock.v1/drag_and_drop_v2/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/en
conf/plugins-locale/xblock.v1/drag_and_drop_v2/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/en/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/el
conf/plugins-locale/xblock.v1/drag_and_drop_v2/el/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/el/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/el/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/zh_CN
conf/plugins-locale/xblock.v1/drag_and_drop_v2/zh_CN/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/zh_CN/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/zh_CN/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/he
conf/plugins-locale/xblock.v1/drag_and_drop_v2/he/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/he/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/he/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_PT
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_PT/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_PT/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_PT/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_BR
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_BR/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_BR/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/pt_BR/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/de_DE
conf/plugins-locale/xblock.v1/drag_and_drop_v2/de_DE/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/de_DE/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/de_DE/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/es_419
conf/plugins-locale/xblock.v1/drag_and_drop_v2/es_419/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/es_419/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/es_419/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ru
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ru/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ru/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ru/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ar
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ar/LC_MESSAGES
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ar/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/drag_and_drop_v2/ar/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/google_drive
conf/plugins-locale/xblock.v1/google_drive/fr_CA
conf/plugins-locale/xblock.v1/google_drive/fr_CA/LC_MESSAGES
conf/plugins-locale/xblock.v1/google_drive/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/google_drive/fr_CA/LC_MESSAGES/django.mo
conf/plugins-locale/xblock.v1/google_drive/en
conf/plugins-locale/xblock.v1/google_drive/en/LC_MESSAGES
conf/plugins-locale/xblock.v1/google_drive/en/LC_MESSAGES/django.po
conf/plugins-locale/xblock.v1/google_drive/en/LC_MESSAGES/django.mo
conf/plugins-locale/studio-frontend
conf/plugins-locale/studio-frontend/es_ES.json
conf/plugins-locale/studio-frontend/uk.json
conf/plugins-locale/studio-frontend/fr_CA.json
conf/plugins-locale/studio-frontend/de_DE.json
conf/plugins-locale/studio-frontend/pt_BR.json
conf/plugins-locale/studio-frontend/it_IT.json
conf/plugins-locale/studio-frontend/de.json
conf/plugins-locale/studio-frontend/zh_CN.json
conf/plugins-locale/studio-frontend/pt_PT.json
conf/plugins-locale/studio-frontend/da.json
conf/plugins-locale/studio-frontend/tr_TR.json
conf/plugins-locale/studio-frontend/es_419.json
conf/plugins-locale/studio-frontend/ru.json
conf/plugins-locale/studio-frontend/ar.json
```

</details> 



This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).