### PR TITLE
feat: enhance importdemocourse ; add importdemolibraries

### DIFF
--- a/changelog.d/20240110_101228_kyle_importnewdemocourse.md
+++ b/changelog.d/20240110_101228_kyle_importnewdemocourse.md
@@ -1,0 +1,7 @@
+- [Feature] Several enhancements to the Demo Course (by @kdmccormick):
+  - The [Open edX Demo Course](https://github.com/openedx/openedx-demo-course) has been re-built from scratch with up-to-date instruction-focused content. Its directory structure has changed.
+  - In order to support both the old and new structures of the Demo Course's repository, the command `tutor local do importdemocourse` will now auto-determine the course root based on the location of `course.xml`. Use the `--repo-dir` argument to override this behavior.
+  - The new command `tutor local do importdemolibraries` will import any content libraries defined within the Demo Course repository. At the moment, that is just the "Respiratory System Question Bank", which is an optional but helpful extension to the new Demo Course.
+  - To try out the new Demo Course now, run: `tutor local do importdemocourse --version master`.
+  - To try out the demo Respiratory System Question Bank now, run: `tutor local do importdemolibraries --version master`.
+  - To revert back to an older Demo Course version at any point, run: `tutor local do importdemocourse --version open-release/quince.2`, replacing `quince.2` with your preferred course version.

--- a/tests/commands/test_jobs.py
+++ b/tests/commands/test_jobs.py
@@ -38,7 +38,32 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
         self.assertEqual(0, result.exit_code)
         self.assertIn("cms-job", dc_args)
         self.assertIn(
-            "git clone https://github.com/openedx/edx-demo-course", dc_args[-1]
+            "git clone https://github.com/openedx/openedx-demo-course", dc_args[-1]
+        )
+
+    def test_import_demo_libraries(self) -> None:
+        with temporary_root() as root:
+            self.invoke_in_root(root, ["config", "save"])
+            with patch("tutor.utils.docker_compose") as mock_docker_compose:
+                result = self.invoke_in_root(
+                    root,
+                    [
+                        "local",
+                        "do",
+                        "importdemolibraries",
+                        "admin",
+                    ],
+                )
+                dc_args, _dc_kwargs = mock_docker_compose.call_args
+        self.assertIsNone(result.exception)
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("cms-job", dc_args)
+        self.assertIn(
+            "git clone https://github.com/openedx/openedx-demo-course", dc_args[-1]
+        )
+        self.assertIn(
+            "./manage.py cms import_content_library /tmp/library.tar.gz admin",
+            dc_args[-1],
         )
 
     def test_set_theme(self) -> None:


### PR DESCRIPTION
## Description

This is a redo of https://github.com/overhangio/tutor/pull/976, with the following differences:

* Per @regisb's [suggestion](https://github.com/overhangio/tutor/pull/976#discussion_r1461952913), in `importdemocourse`, we now auto-find course.xml if `--repo-dir` is not provided. This simplifies the CLI and makes the command backwards-compatible 🎉
* Since the change is now compatible with any demo course version, I'm merging it to **master** instead of nightly. This means Tutor users can use it right away instead of waiting until Redwood.
* I changed importdemolibrary to **importdemolibraries**. Furthermore, instead of taking a `--repo-library-tar` argument, the command now searches for directories with library.xml files, run `tar` on them, and imports them. I've done this to:
  1. Make its behavior more similar to importdemocourse.
  2. Leave room for the introduction of more demo libraries, which I think is likely. 
*  ~There's excitement to have the new demo course available ASAP, so in my second commit, I take the liberty of bumping the version to **v17.0.2** and running `scriv collect`. If you'd rather do that yourself @regisb , please feel free to chop off that last commit.~ No need to bump the version now since Quince.2 is coming out tomorrow.

## Testing

### Happy paths

#### Import the old demo course

```bash
tutor dev do importdemocourse  # after Redwood, will require '--version open-release/quince.1'
```

#### Import the new demo course and library

```bash
tutor dev do importdemocourse --version master
tutor dev do importdemolibraries admin --version master   # Replace 'admin' with any username
```
See https://github.com/overhangio/tutor/pull/976 for more details.

### Sad paths

#### Fail to import a demo course (no course.xml)
```bash
tutor dev do importdemocourse --version kdmccormick/zero-course-xmls
```
```
INFO: Found course.xml files(s):  
ERROR: Could not find course.xml. Are you sure this is the right repository?
```

#### Fail to import a demo course (multiple course.xmls)
```bash
tutor dev do importdemocourse --version kdmccormick/multiple-course-xmls
```
```
INFO: Found course.xml files(s): /tmp/course/demo-course/another-course/course.xml /tmp/course/demo-course/course/course.xml
ERROR: Found multiple course.xml files--course root is ambiguous!
       Please specify a course root dir (relative to repo root) using --repo-dir.
```

#### Fail to import demo libraries (no library.xmls)
```bash
tutor dev do importdemolibraries admin --version open-release/quince.1
```
```
ERROR: No library.xml files found in repository. Are you sure this is the right repository and version?
```

#### Fail to import demo libraries (library.xml outside of library/ dir)
```
tutor dev do importdemolibraries admin --version kdmccormick/misplaced-library-xml
```
```
INFO: Will import library at /tmp/library/demo-course/course
ERROR: can only import library.xml files that are within a directory named 'library'
```