### PR TITLE
Fix: Remove base_url from grades_download

### DIFF
--- a/changelog.d/20240206_151901_fahad.khalid.md
+++ b/changelog.d/20240206_151901_fahad.khalid.md
@@ -1,0 +1,1 @@
+[Improvement] Remove base_url from GRADES_DOWNLOAD. (by @FahadKhalid210)

--- a/changelog.d/20240206_151901_fahad.khalid.md
+++ b/changelog.d/20240206_151901_fahad.khalid.md
@@ -1,1 +1,1 @@
-[Improvement] Remove base_url from GRADES_DOWNLOAD. (by @FahadKhalid210)
+- [Bugfix] Fix a 500 error on downloading profile information as CSV when the minio plugin is enabled. (by @FahadKhalid210)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -119,7 +119,7 @@ VIDEO_TRANSCRIPTS_SETTINGS["STORAGE_KWARGS"]["location"] = MEDIA_ROOT
 GRADES_DOWNLOAD = {
     "STORAGE_TYPE": "",
     "STORAGE_KWARGS": {
-        "location": "/openedx/media/grades",
+        "location": "/openedx/media/",
     },
 }
 

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -119,7 +119,6 @@ VIDEO_TRANSCRIPTS_SETTINGS["STORAGE_KWARGS"]["location"] = MEDIA_ROOT
 GRADES_DOWNLOAD = {
     "STORAGE_TYPE": "",
     "STORAGE_KWARGS": {
-        "base_url": "/media/grades/",
         "location": "/openedx/media/grades",
     },
 }


### PR DESCRIPTION
Getting Error when click on `Download profile information as a CSV`. 

Steps to reproduce:

- Launch Tutor with `Quince` version and with `minio` plugin.

- In the LMS, head to Data Downloads section under the Instrutor tab. Click the` Download profile information as a CSV`.

- The download will fail and LMS logs will show below mentioned error
```

2024-02-06 15:13:50 2024-02-06 10:13:50,430 ERROR 673 [django.request] [user None] [ip None] log.py:241 - Internal Server Error: /courses/course-v1:edX+DemoX+Demo_Course/instructor/api/list_report_downloads
2024-02-06 15:13:50 Traceback (most recent call last):
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 55, in inner
2024-02-06 15:13:50     response = get_response(request)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 197, in _get_response
2024-02-06 15:13:50     response = wrapped_callback(request, *callback_args, **callback_kwargs)
2024-02-06 15:13:50   File "/opt/pyenv/versions/3.8.18/lib/python3.8/contextlib.py", line 75, in inner
2024-02-06 15:13:50     return func(*args, **kwds)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/http.py", line 43, in inner
2024-02-06 15:13:50     return func(request, *args, **kwargs)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 134, in _wrapper_view
2024-02-06 15:13:50     response = view_func(request, *args, **kwargs)
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor/views/api.py", line 2468, in list_report_downloads
2024-02-06 15:13:50     return _list_report_downloads(request=request, course_id=course_id)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/cache.py", line 40, in _cache_controlled
2024-02-06 15:13:50     response = viewfunc(request, *args, **kw)
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor/views/api.py", line 227, in wrapped
2024-02-06 15:13:50     return func(*args, **kwargs)
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor/views/api.py", line 2480, in _list_report_downloads
2024-02-06 15:13:50     report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor_task/models.py", line 250, in from_config
2024-02-06 15:13:50     return DjangoStorageReportStore.from_config(config_name)
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor_task/models.py", line 287, in from_config
2024-02-06 15:13:50     return cls(
2024-02-06 15:13:50   File "/openedx/edx-platform/lms/djangoapps/instructor_task/models.py", line 270, in __init__
2024-02-06 15:13:50     self.storage = get_storage(storage_class, **storage_kwargs)
2024-02-06 15:13:50   File "/openedx/edx-platform/openedx/core/storage.py", line 114, in get_storage
2024-02-06 15:13:50     return get_storage_class(storage_class)(**kwargs)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/storages/backends/s3.py", line 280, in __init__
2024-02-06 15:13:50     super().__init__(**settings)
2024-02-06 15:13:50   File "/openedx/venv/lib/python3.8/site-packages/storages/base.py", line 15, in __init__
2024-02-06 15:13:50     raise ImproperlyConfigured(
2024-02-06 15:13:50 django.core.exceptions.ImproperlyConfigured: Invalid setting 'base_url' for S3Storage
```

See the initial conversation here: https://github.com/hastexo/tutor-contrib-s3/pull/70#discussion_r1484022869