### PR TITLE
revert: fix JWT scopes in XBlock callbacks

### DIFF
--- a/changelog.d/20240207_173504_cmltawt0_revert_jwt_security.md
+++ b/changelog.d/20240207_173504_cmltawt0_revert_jwt_security.md
@@ -1,0 +1,2 @@
+- [Security] Revert XBlock JWT security patch introduced in https://github.com/overhangio/tutor/pull/986
+  since https://github.com/openedx/edx-platform/pull/34047 is merged. (by @cmltawt0)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -51,8 +51,6 @@ RUN git config --global user.email "tutor@overhang.io" \
 {{ patch("openedx-dockerfile-git-patches-default") }}
 {%- else %}
 # Patch edx-platform
-# XBlock JWT security fix https://github.com/openedx/edx-platform/pull/34047
-RUN curl -fsSL https://github.com/openedx/edx-platform/commit/89f5f69682a5e1422f89e867491e8974dd0a8208.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}


### PR DESCRIPTION
Reverts https://github.com/overhangio/tutor/pull/986

@regisb Please advice about naming for Revert changes in changelog.
I didn't find a [Revert] example in generated changelog template.
Is it ok to leave it as is `- [Security] Revert ...` or better to change to `- [Revert] XBlock JWT security patch introduced in ... `

---


How to test:
```
> tutor config save --set EDX_PLATFORM_VERSION=open-release/quince.master
> tutor images build openedx
...
 => ERROR [code 4/4] RUN curl -fsSL https://github.com/openedx/edx-platform/commit/89f5f69682a5e1422f89e867491e8974dd0a8208.patch | git am                  0.8s
------
 > [code 4/4] RUN curl -fsSL https://github.com/openedx/edx-platform/commit/89f5f69682a5e1422f89e867491e8974dd0a8208.patch | git am:
0.692 error: patch failed: lms/djangoapps/courseware/block_render.py:27
0.692 error: lms/djangoapps/courseware/block_render.py: patch does not apply
0.692 error: patch failed: lms/djangoapps/courseware/tests/test_block_render.py:91
0.692 error: lms/djangoapps/courseware/tests/test_block_render.py: patch does not apply
0.693 hint: Use 'git am --show-current-patch' to see the failed patch
0.693 Applying: fix: add `JwtRestrictedApplication` check to XBlock callback
0.693 Patch failed at 0001 fix: add `JwtRestrictedApplication` check to XBlock callback
0.693 When you have resolved this problem, run "git am --continue".
0.693 If you prefer to skip this patch, run "git am --skip" instead.
0.693 To restore the original branch and stop patching, run "git am --abort".
------
Dockerfile:50
--------------------
  48 |     # Patch edx-platform
  49 |     # XBlock JWT security fix https://github.com/openedx/edx-platform/pull/34047
  50 | >>> RUN curl -fsSL https://github.com/openedx/edx-platform/commit/89f5f69682a5e1422f89e867491e8974dd0a8208.patch | git am
```