### PR TITLE
Change command to reset build context

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -194,7 +194,7 @@ Now build again::
 
     tutor images build
 
-All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker buildx use default``. 
+All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker contextuse default``. 
 
 .. note::	
 	Setting a too low value for maximum parallelism will result in longer build times.


### PR DESCRIPTION
When I tried to run the specified command, docker told me to run `docker context use default`