### PR TITLE
fix: merge conflicts due to edx-platform patches in nightly

### DIFF
--- a/changelog.d/20240222_101904_regis_fix_nightly_patches.md
+++ b/changelog.d/20240222_101904_regis_fix_nightly_patches.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix merge conflicts in nightly when trying to apply patches from the master branch. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -49,8 +49,10 @@ RUN git config --global user.email "tutor@overhang.io" \
 {%- if patch("openedx-dockerfile-git-patches-default") %}
 # Custom edx-platform patches
 {{ patch("openedx-dockerfile-git-patches-default") }}
+{%- elif EDX_PLATFORM_VERSION == "master" -%}
+# Patches in nightly node
 {%- else %}
-# Patch edx-platform
+# Patches in non-nightly mode
 # Prevent course structure cache infinite growth
 # https://github.com/openedx/edx-platform/pull/34210
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/ad201cd664b6c722cbefcbda23ae390c06daf621.patch | git am


### PR DESCRIPTION
When building the nightly images, some patches fail because they come from the master branch. To address this, we apply certain patches only if we are not in nightly mode.