### PR TITLE
build: add python 3.12 checks alongside 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+         python-version: ['3.8', '3.12']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version:  ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: requirements/dev.txt
       - name: Upgrade pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,8 @@ nitpick_ignore = [
     # python 3.10
     ("py:class", "NoneType"),
     ("py:class", "click.core.Command"),
+    # Python 3.12
+    ("py:class", "FilterCallbackFunc"),
 ]
 # Resolve type aliases here
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
@@ -58,6 +60,15 @@ autodoc_type_aliases: dict[str, str] = {
     # python 3.10
     "T": "tutor.core.hooks.actions.T",
     "T2": "tutor.core.hooks.filters.T2",
+    # # python 3.12
+    "L": "tutor.core.hooks.filters.L",
+    "FilterCallbackFunc": "tutor.core.hooks.filters.FilterCallbackFunc",
+    # https://stackoverflow.com/questions/73223417/type-aliases-in-type-hints-are-not-preserved
+    # https://github.com/sphinx-doc/sphinx/issues/10455
+    # https://github.com/sphinx-doc/sphinx/issues/10785
+    # https://github.com/emdgroup/baybe/pull/67
+    "Action": "tutor.core.hooks.actions.Action",
+    "Filter": "tutor.core.hooks.filters.Filter",
 }
 
 


### PR DESCRIPTION
For #1006 

### Description

- Adds Python 3.12 checks in CI alongside 3.8
- Fix `make docs` in Python 3.12

`make docs` in Python 3.12 was failing for various reasons for variety of items (Action, Filter, FilterCallbackFunc). Mainly, the generic `type` does not get translated to `py:class` and is instead picked up as `py:data`. There were a few issues on Sphinx and some related items on Stackoverflow. Everyone handled it differently in some capacity. One suggestion was to ignore some of the type params but it did not result in docs building as expected (https://github.com/overhangio/tutor/pull/1008#issuecomment-1968906467). The appropriate fix for "Action & Filter" was to add entries in autodoc_type_aliases. FilterCallbackFunc was needed to be ignore because it does not translate to a py:class.