### PR TITLE
docs: add git clone eof error troubleshooting

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -169,6 +169,8 @@ This issue should only happen in development mode. Long story short, it can be s
 
 If you'd like to learn more, please take a look at `this Github issue <https://github.com/overhangio/tutor/issues/302>`__.
 
+.. _high_resource_comsumption:
+
 High resource consumption on ``tutor images build`` by docker 
 -------------------------------------------------------------
 
@@ -194,15 +196,14 @@ Now build again::
 
 All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker buildx use default``. 
 
-fatal: the remote end hung up unexpectedly / fatal: early EOF / fatal: index-pack failed when running `tutor images build ...`
-------------------------------------------------------------------------------------------------------------------------------
-
-This issue can occur due to problems with your network while cloning edx-platform which is a fairly large repository.
-
-First, try to run the same command once again to see if it works as your network connection can sometimes drop during the build process.
-
-If that does not work, you can follow the tutorial above for `High resource consumption <#high-resource-consumption-on-tutor-images-build-by-docker>`_ to limit the number of concurrent build steps so that your network is not being shared between multiple layers at once.
-
 .. note::	
-	The build for the image will be considerably slow now.
+	Setting a too low value for maximum parallelism will result in longer build times.
 
+fatal: the remote end hung up unexpectedly / fatal: early EOF / fatal: index-pack failed when running ``tutor images build ...``
+--------------------------------------------------------------------------------------------------------------------------------
+
+This issue can occur due to problems with the network connection while cloning edx-platform which is a fairly large repository.
+
+First, try to run the same command once again to see if it works as the network connection can sometimes drop during the build process.
+
+If that does not work, follow the tutorial above for :ref:`High resource consumption <high_resource_consumption>` to limit the number of concurrent build steps so that the network connection is not being shared between multiple layers at once.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -169,7 +169,7 @@ This issue should only happen in development mode. Long story short, it can be s
 
 If you'd like to learn more, please take a look at `this Github issue <https://github.com/overhangio/tutor/issues/302>`__.
 
-.. _high_resource_comsumption:
+.. _high_resource_consumption:
 
 High resource consumption on ``tutor images build`` by docker 
 -------------------------------------------------------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -193,3 +193,16 @@ Now build again::
     tutor images build
 
 All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker buildx use default``. 
+
+fatal: the remote end hung up unexpectedly / fatal: early EOF / fatal: index-pack failed
+----------------------------------------------------------------------------------------
+
+This issue can occur due to problems with your network while cloning edx-platform which is a fairly large repository.
+
+You should first of all try to rerun the command you were trying to run to see if it works.
+
+If that does not work, you can follow the tutorial above for `High resource consumption <#high-resource-consumption-on-tutor-images-build-by-docker>`_ and set `max-parallelism = 1` so that while edx-platform is being cloned, the network is not being utilized by another command.
+
+.. note::	
+	The build for the image will be considerably slow now as each step will be built one by one.
+

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -194,15 +194,15 @@ Now build again::
 
 All build commands should now make use of the newly configured builder. To later revert to the default builder, run ``docker buildx use default``. 
 
-fatal: the remote end hung up unexpectedly / fatal: early EOF / fatal: index-pack failed
-----------------------------------------------------------------------------------------
+fatal: the remote end hung up unexpectedly / fatal: early EOF / fatal: index-pack failed when running `tutor images build ...`
+------------------------------------------------------------------------------------------------------------------------------
 
 This issue can occur due to problems with your network while cloning edx-platform which is a fairly large repository.
 
-You should first of all try to rerun the command you were trying to run to see if it works.
+First, try to run the same command once again to see if it works as your network connection can sometimes drop during the build process.
 
-If that does not work, you can follow the tutorial above for `High resource consumption <#high-resource-consumption-on-tutor-images-build-by-docker>`_ and set `max-parallelism = 1` so that while edx-platform is being cloned, the network is not being utilized by another command.
+If that does not work, you can follow the tutorial above for `High resource consumption <#high-resource-consumption-on-tutor-images-build-by-docker>`_ to limit the number of concurrent build steps so that your network is not being shared between multiple layers at once.
 
 .. note::	
-	The build for the image will be considerably slow now as each step will be built one by one.
+	The build for the image will be considerably slow now.
 


### PR DESCRIPTION
**Issue**

- Git throws an EOF error while cloning large repositories on slow/unstable networks.

```
RUN mkdir -p /openedx/edx-platform &&     git clone https://github.com/openedx/edx-platform.git --branch open-release/quince.1 --depth 1 /openedx/edx-platform:
Cloning into '/openedx/edx-platform'...
fatal: the remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
```

- This error is thrown while cloning `edx-platform` during the build process of the `openedx`/`openedx-dev` image.
https://github.com/overhangio/tutor/blob/13c420cb0a722b90bf7bb7984a3ee44eb150114d/tutor/templates/build/openedx/Dockerfile#L41-L43

**Changes**

- Added a troubleshooting guide for the issue thrown by git while cloning large repositories on slow/unstable networks.
- Since this issue is subjective to every users network connection, I have instead just added a troubleshooting guide to reduce resources in the buildkit which does fix the issue.

This error has been reported by multiple users, for example [here](https://discuss.openedx.org/t/the-remote-end-hung-up-unexpectedly-early-eof-index-pack-failed/12094) and [here](https://discuss.openedx.org/t/problem-when-tutor-images-build-openedx/12237). I myself have faced this as well.
The max I could try it out was on a 25 Mb/s wired connection and it still threw the error. 



