### PR TITLE
build: remove auto-add for PRs

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,9 +1,6 @@
-name: Auto Add Issues and Pull Requests to Project
+name: Auto Add Issues to Project
 
 on:
-  pull_request:
-    types:
-      - opened
   issues:
     types:
       - opened


### PR DESCRIPTION
The auto-add for Issues and PRs was added in https://github.com/overhangio/tutor/pull/978. However, it did not work as expected for PRs. It was failing on PRs created from fork and increasing the noise.
The reason was that when PRs were created from forks, the Personal access token from main repo was not passed. This results in GA not getting the appropriate auth token to auto-add the PR to the project. Additionally,  the workflows on PR needed to be triggered manually (both auto-add and CI), thus keeping the manual intervention just like before. 
