### PR TITLE
Install tutor-indigo by default with tutor[full]

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -5,6 +5,7 @@ tutor-credentials>=17.0.0,<18.0.0
 tutor-discovery>=17.0.0,<18.0.0
 tutor-ecommerce>=17.0.0,<18.0.0
 tutor-forum>=17.0.0,<18.0.0
+tutor-indigo>=17.0.0,<18.0.0
 tutor-jupyter>=17.0.0,<18.0.0
 tutor-mfe>=17.0.0,<18.0.0
 tutor-minio>=17.0.0,<18.0.0


### PR DESCRIPTION
As `tutor-indigo` is enabled in `quince` by default but it is not installed when run `pip install tutor[full]`. `tutor plugins list` show this warning: `⚠️  Failed to enable plugin 'indigo': plugin 'indigo' is not installed.`

### **Before:**
It is not installing `tutor-indigo`. I did fresh install of tutor by `pip install tutor[full]`
<img width="1676" alt="Screenshot 2024-03-14 at 9 58 45 AM" src="https://github.com/overhangio/tutor/assets/112946189/613821be-4830-4f34-8d69-96bdb0619a88">
<img width="526" alt="Screenshot 2024-03-14 at 10 00 43 AM" src="https://github.com/overhangio/tutor/assets/112946189/9f32ab8b-b247-46c6-bb6a-75195b465341">



### **Now:**
It installs `tutor-indigo` by default as other plugins are being installed. 
<img width="526" alt="Screenshot 2024-03-14 at 10 35 24 AM" src="https://github.com/overhangio/tutor/assets/112946189/e70d4784-221e-4ade-a6e2-b9f7ea1ddddf">
