### PR TITLE
fix: ensure mounted installable packages are installed as expected

### DIFF
--- a/changelog.d/20240315_163331_dawoud.sheraz_tutor_997.md
+++ b/changelog.d/20240315_163331_dawoud.sheraz_tutor_997.md
@@ -1,0 +1,1 @@
+- [BugFix] Ensure mounted installable packages are installed as expected upon initialization. (by @dawoudsheraz)

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -45,7 +45,7 @@ def _add_core_init_tasks() -> None:
         hooks.Filters.CLI_DO_INIT_TASKS.add_item(
             (
                 "lms",
-                env.read_core_template_file("jobs", "init", "mounted-edx-platform.sh"),
+                env.read_core_template_file("jobs", "init", "mounted-directories.sh"),
             ),
             # If edx-platform is mounted, then we may need to perform some setup
             # before other initialization scripts can be run.

--- a/tutor/templates/jobs/init/mounted-directories.sh
+++ b/tutor/templates/jobs/init/mounted-directories.sh
@@ -1,20 +1,21 @@
 # The initialization job contains various re-install operations needed to be done
-# on mounted directories (edx-platform, /mnt/*xblock)
-# 1. /mnt/*xblock
-# Whenever xblocks are mounted, during the image build time, they are copied over to container and
-# installed. This results in egg_info generation for the mounted xblocks. However, the egg_info is not carried
+# on mounted directories (edx-platform, /mnt/*xblock, /mnt/<edx-ora, search, enterprise>)
+# 1. /mnt/*
+# Whenever xblocks or other installable packages are mounted, during the image build, they are copied over to container
+# and installed. This results in egg_info generation for the mounted directories. However, the egg_info is not carried
 # over to host. When the containers are launched, the host directories without egg_info are mounted on runtime
 # and disappear from pip list.
+#
 # 2. edx-platform
 # When a new local copy of edx-platform is bind-mounted, certain build
 # artifacts from the openedx image's edx-platform directory are lost.
 # We regenerate them here.
 
 
-for mounted_xblock in /mnt/*xblock/; do
-    if ! ls "$mounted_xblock"*.egg-info >/dev/null 2>&1; then
-        echo "Unable to locate egg-info in $mounted_xblock"
-        pip install -e $mounted_xblock
+for mounted_dir in /mnt/*; do
+    if [ -f $mounted_dir/setup.py ] && ! ls $mounted_dir/*.egg-info >/dev/null 2>&1 ; then
+        echo "Unable to locate egg-info in $mounted_dir"
+        pip install -e $mounted_dir
     fi
 done
 

--- a/tutor/templates/jobs/init/mounted-directories.sh
+++ b/tutor/templates/jobs/init/mounted-directories.sh
@@ -1,6 +1,22 @@
+# The initialization job contains various re-install operations needed to be done
+# on mounted directories (edx-platform, /mnt/*xblock)
+# 1. /mnt/*xblock
+# Whenever xblocks are mounted, during the image build time, they are copied over to container and
+# installed. This results in egg_info generation for the mounted xblocks. However, the egg_info is not carried
+# over to host. When the containers are launched, the host directories without egg_info are mounted on runtime
+# and disappear from pip list.
+# 2. edx-platform
 # When a new local copy of edx-platform is bind-mounted, certain build
 # artifacts from the openedx image's edx-platform directory are lost.
 # We regenerate them here.
+
+
+for mounted_xblock in /mnt/*xblock/; do
+    if ! ls "$mounted_xblock"*.egg-info >/dev/null 2>&1; then
+        echo "Unable to locate egg-info in $mounted_xblock"
+        pip install -e $mounted_xblock
+    fi
+done
 
 if [ -f /openedx/edx-platform/bindmount-canary ] ; then
 	# If this file exists, then edx-platform has not been bind-mounted,


### PR DESCRIPTION
Fixes https://github.com/overhangio/tutor/issues/997

When xblocks and other installed packages are mounted, they are installed during image build. The dirs are copied over and then pip install takes place (resulting in egg-file generation). However, the dirs are not updated in host directories. When running tutor, the host files are re-mounted at run time. Due to missing egg-info, the installed packages no longer appear in pip list. This PR adds a small step during initialization that runs pip install on the mounted dirs if egg-info is missing.

### Testing
- Checkout the branch & install.
- Clone scorm or any other xblock (as mentioned in https://github.com/overhangio/tutor/issues/997)
- mount the xblock
- Re-build open edx image. This might not be needed if you already have recent image build. In that case, running `tutor dev do init -l lms` would be enough
- Bash into lms and run `pip list | grep mnt`. The mounted xblock(s) will show up.