### PR TITLE
Adds CONFIG_USER Filter

### DIFF
--- a/changelog.d/20240319_140241_andrew.bonnell_add_config_user_filter.md
+++ b/changelog.d/20240319_140241_andrew.bonnell_add_config_user_filter.md
@@ -1,0 +1,1 @@
+- [Feature] Introduces the CONFIG_USER Filter. (by @abonnell)

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -111,6 +111,12 @@ def get_user(root: str) -> Config:
         config = get_yaml_file(path)
     upgrade_obsolete(config)
     update_with_env(config)
+
+    extra_config: list[tuple[str, ConfigValue]] = []
+    extra_config = hooks.Filters.CONFIG_USER.apply(extra_config)
+    for name, value in extra_config:
+        config[name] = value
+    
     return config
 
 

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -112,9 +112,7 @@ def get_user(root: str) -> Config:
     upgrade_obsolete(config)
     update_with_env(config)
 
-    extra_config: list[tuple[str, ConfigValue]] = []
-    extra_config = hooks.Filters.CONFIG_USER.apply(extra_config)
-    for name, value in extra_config:
+    for name, value in hooks.Filters.CONFIG_USER.iterate():
         config[name] = value
     
     return config

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -114,7 +114,6 @@ def get_user(root: str) -> Config:
 
     for name, value in hooks.Filters.CONFIG_USER.iterate():
         config[name] = value
-    
     return config
 
 

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -257,9 +257,12 @@ class Filters:
     #:   names must be prefixed with the plugin name in all-caps.
     CONFIG_UNIQUE: Filter[list[tuple[str, Any]], []] = Filter()
 
-    #: Declare unique configuration settings that must be saved in the user ``config.yml`` file. This is where
-    #: you should declare passwords and randomly-generated values that are different from one environment to the next.
-    #: Callbacks using this Filter will overwrite the values of existing keys
+    #: Used to declare unique key:value pairs in the ``config.yml`` file that will be overwritten on ``tutor config save``.
+    #: This is where you should declare passwords and other secrets that need to be fetched live from an external secrets
+    #: store. Most users will not need to use this filter but it will allow you to programmatically fetch and set secrets
+    #: from an external secrets store such as AWS Secrets Manager via boto3.
+    #:
+    #: Values passed in to this filter will overwrite existing values in the ``config.yml`` file.
     #:
     #: :parameter list[tuple[str, ...]] items: list of (name, value) new settings. All
     #:   names must be prefixed with the plugin name in all-caps.

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -257,6 +257,14 @@ class Filters:
     #:   names must be prefixed with the plugin name in all-caps.
     CONFIG_UNIQUE: Filter[list[tuple[str, Any]], []] = Filter()
 
+    #: Declare unique configuration settings that must be saved in the user ``config.yml`` file. This is where
+    #: you should declare passwords and randomly-generated values that are different from one environment to the next.
+    #: Callbacks using this Filter will overwrite the values of existing keys
+    #:
+    #: :parameter list[tuple[str, ...]] items: list of (name, value) new settings. All
+    #:   names must be prefixed with the plugin name in all-caps.
+    CONFIG_USER: Filter[list[tuple[str, Any]], []] = Filter()
+
     #: Use this filter to modify the ``docker build`` command.
     #:
     #: :parameter list[str] command: the full build command, including options and


### PR DESCRIPTION
[Context](https://discuss.openedx.org/t/tutor-config-unique-filter-not-overwriting-16-1-4/11712/2)

Implements a `CONFIG_USER` Filter that users can hook into and replace key values in their `config.yml` files

Similar in usage to the `CONFIG_UNIQUE` filter but it will always replace the value of a given key with the new value being passed in instead of skipping over it

Example usage in a tutor plugin, being used to fetch secrets from AWS Secrets Manager and put that dictionary of key:value pairs into config.yml to be ingested by tutor patches
```
@hooks.Filters.CONFIG_USER.add()
def fetch_secrets_from_aws(config):
    secrets = s.do_config()

    for secret in secrets:
        config.append(
            (secret, secrets[secret])
        )
        
    return config
```