### PR TITLE
chore: update redis

### DIFF
--- a/changelog.d/20240320_131420_dawoud.sheraz_redis_update.md
+++ b/changelog.d/20240320_131420_dawoud.sheraz_redis_update.md
@@ -1,0 +1,1 @@
+- [Improvement] Update Redis to 7.2.4 (by @dawoudsheraz)

--- a/changelog.d/20240320_131420_dawoud.sheraz_redis_update.md
+++ b/changelog.d/20240320_131420_dawoud.sheraz_redis_update.md
@@ -1,1 +1,1 @@
-- [Improvement] Update Redis to 7.2.4 (by @dawoudsheraz)
+- [Security] Update Redis to 7.2.4 (by @dawoudsheraz)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -87,7 +87,7 @@ This configuration parameter defines which MySQL Docker image to use.
 
 .. https://hub.docker.com/_/redis/tags
 
-- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.0.11"``)
+- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.2.4"``)
 
 This configuration parameter defines which Redis Docker image to use.
 

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -22,7 +22,7 @@ DOCKER_IMAGE_MONGODB: "docker.io/mongo:4.4.25"
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.1.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/redis/tags
-DOCKER_IMAGE_REDIS: "docker.io/redis:7.2.1"
+DOCKER_IMAGE_REDIS: "docker.io/redis:7.2.4"
 # https://hub.docker.com/r/devture/exim-relay/tags
 DOCKER_IMAGE_SMTP: "docker.io/devture/exim-relay:4.96-r1-0"
 EDX_PLATFORM_REPOSITORY: "https://github.com/openedx/edx-platform.git"


### PR DESCRIPTION
- Update redis to latest available version.

I updated the redis, pulled in latest images (when running launch), enabled discovery, and poked around a bit on Studio and Discovery. I did not see anything unusual in Redis logs. Only one error, some PID save, occurs at start of container. Though that error is also present for 7.2.1.