### PR TITLE
fix: re-pull Atlas translations for mounted edx-platform

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -186,6 +186,7 @@ COPY --chown=app:app settings/lms/*.py ./lms/envs/tutor/
 COPY --chown=app:app settings/cms/*.py ./cms/envs/tutor/
 
 # Pull latest translations via atlas
+RUN rm -rf conf/locale conf/plugins-locale
 RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
 RUN ./manage.py lms --settings=tutor.i18n pull_xblock_translations --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
 RUN atlas pull --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \

--- a/tutor/templates/jobs/init/mounted-directories.sh
+++ b/tutor/templates/jobs/init/mounted-directories.sh
@@ -36,6 +36,21 @@ pip install -e .
 # Regenerate node_modules
 npm clean-install
 
+# Pull latest translations via atlas
+rm -rf conf/locale conf/plugins-locale
+./manage.py lms pull_plugin_translations --verbose --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+./manage.py lms pull_xblock_translations --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+rm -rf conf/locale
+atlas pull --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \
+	translations/edx-platform/conf/locale:conf/locale \
+	translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend
+./manage.py lms compile_xblock_translations
+./manage.py cms compile_xblock_translations
+./manage.py lms compile_plugin_translations
+./manage.py lms compilemessages -v1
+./manage.py lms compilejsi18n
+./manage.py cms compilejsi18n
+
 # Regenerate static assets.
 openedx-assets build --env=dev
 


### PR DESCRIPTION
This follows up on https://github.com/overhangio/tutor/pull/993

![image](https://github.com/overhangio/tutor/assets/3628148/057cb6cc-7b30-436d-a2d1-0b28ae982a36)


## Description

The new Atlas-based translations system stores important translations artifacts in edx-platform.

Unfortunately, when edx-platform is bind-mounted, these translations artifacts are overwritten. This means that edx-platform developers will see 404s on various i18n-related assets in Django-rendered LMS and CMS pages.

We work around this in the same way we do for static assets, egg_info, and node_modules: Just re-generate the translations artifacts as part of the dev init job, using **mounted-directories.sh** . This is a waste of time and bandwidth, but it's the system we have, for now at least.

## Reviewer notes

@OmarIthawi , I've lifted the entire i18n block from the Dockerfile into mounted-directories.sh. That means that we will re-run every i18n command when a user is provisioning a bind-mounted edx-platform directory with `tutor dev launch`.

Does that look right? Do we need all of those lines, or can we take some out? Keep in mind that the i18n lines from the Dockerfile will have already been executed, so we only need to re-run whose artifacts are *within* bind-mounted directories, namely edx-platform.

I've also added `rm -rf` calls, because Atlas told me that I can't pull into an existing directory. Does that seem right?

## Long-term notes

Heads up @regisb and @DawoudSheraz , this adds even more time and repetative downloads to `tutor dev launch`. I think we should move to a system where the init scripts *copy* egg_info, node_modules, assets, and i18n files from the Docker image instead of re-downloading and re-generating them. I [have a version of this working on my experimental branch](https://github.com/kdmccormick/tutor/pull/34) but I haven't had the time yet to polish it and make a PR.

