### PR TITLE
mongodb update

### DIFF
--- a/changelog.d/20240329_164354_dawoud.sheraz_mongo_update.md
+++ b/changelog.d/20240329_164354_dawoud.sheraz_mongo_update.md
@@ -1,10 +1,10 @@
 - 💥[Feature] Update MongoDB to v7.0.7 (by @dawoudsheraz)
 
-MongoDB is updating from 4.4 to 7. Since there have been major releases since 4.4, the upgrade would need to go through them before running Mongo 7. Mongo would need to follow 4.4 --> 5.0 --> 6.0 --> 7.0 upgrade path to work correctly.
-The container will keep on restarting with featureCompatibility error if the upgrade path is not followed. 
+  MongoDB is updating from 4.4 to 7. Since there have been major releases since 4.4, the upgrade would need to go through them before running Mongo 7. Mongo would need to follow 4.4 --> 5.0 --> 6.0 --> 7.0 upgrade path to work correctly.
+  The container will keep on restarting with featureCompatibility error if the upgrade path is not followed. 
 
-To upgrade mongo, run the following command based in the appropriate environment:
-```
-tutor <dev|local|k8s> upgrade --from=quince
-``` 
-For k8s only, the above command will not perform the upgrade automatically. Instead, the command will output will print out a series of commands that would need to be run manually to carry out the upgrade.
+  To upgrade mongo, run the following command based in the appropriate environment:
+  ```
+  tutor <dev|local|k8s> upgrade --from=quince
+  ``` 
+  For k8s only, the above command will not perform the upgrade automatically. Instead, the command will output a series of commands that would need to be run manually to carry out the upgrade.

--- a/changelog.d/20240329_164354_dawoud.sheraz_mongo_update.md
+++ b/changelog.d/20240329_164354_dawoud.sheraz_mongo_update.md
@@ -1,0 +1,10 @@
+- 💥[Feature] Update MongoDB to v7.0.7 (by @dawoudsheraz)
+
+MongoDB is updating from 4.4 to 7. Since there have been major releases since 4.4, the upgrade would need to go through them before running Mongo 7. Mongo would need to follow 4.4 --> 5.0 --> 6.0 --> 7.0 upgrade path to work correctly.
+The container will keep on restarting with featureCompatibility error if the upgrade path is not followed. 
+
+To upgrade mongo, run the following command based in the appropriate environment:
+```
+tutor <dev|local|k8s> upgrade --from=quince
+``` 
+For k8s only, the above command will not perform the upgrade automatically. Instead, the command will output will print out a series of commands that would need to be run manually to carry out the upgrade.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -75,7 +75,7 @@ This configuration parameter defines which Caddy Docker image to use.
 
 This configuration parameter defines which Elasticsearch Docker image to use.
 
-- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:4.4.22"``)
+- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:7.0.7"``)
 
 This configuration parameter defines which MongoDB Docker image to use.
 

--- a/tutor/commands/upgrade/common.py
+++ b/tutor/commands/upgrade/common.py
@@ -49,7 +49,7 @@ def get_mongo_upgrade_parameters(
     """
     Helper utility to get parameters required during mongo upgrade.
     """
-    mongo_version = int(docker_version.split('.')[0])
+    mongo_version = int(docker_version.split(".")[0])
     admin_command: dict[str, int | str] = {
         "setFeatureCompatibilityVersion": compatibility_version
     }

--- a/tutor/commands/upgrade/common.py
+++ b/tutor/commands/upgrade/common.py
@@ -49,7 +49,7 @@ def get_mongo_upgrade_parameters(
     """
     Helper utility to get parameters required during mongo upgrade.
     """
-    mongo_version = int(docker_version[0])
+    mongo_version = int(docker_version.split('.')[0])
     admin_command: dict[str, int | str] = {
         "setFeatureCompatibilityVersion": compatibility_version
     }

--- a/tutor/commands/upgrade/common.py
+++ b/tutor/commands/upgrade/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 from tutor import config as tutor_config
@@ -39,6 +41,23 @@ def upgrade_from_nutmeg(context: click.Context, config: Config) -> None:
     context.obj.job_runner(config).run_task(
         "lms", "./manage.py lms compute_grades -v1 --all_courses"
     )
+
+
+def get_mongo_upgrade_parameters(
+    docker_version: str, compatibility_version: str
+) -> tuple[int, dict[str, int | str]]:
+    """
+    Helper utility to get parameters required during mongo upgrade.
+    """
+    mongo_version = int(docker_version[0])
+    admin_command: dict[str, int | str] = {
+        "setFeatureCompatibilityVersion": compatibility_version
+    }
+    if mongo_version == 7:
+        # Explicit confirmation is required to upgrade to 7 from 6
+        # https://www.mongodb.com/docs/manual/reference/command/setFeatureCompatibilityVersion/#confirm
+        admin_command.update({"confirm": 1})
+    return mongo_version, admin_command
 
 
 PALM_RENAME_ORA2_FOLDER_COMMAND = """

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -20,7 +20,7 @@ DOCKER_IMAGE_CADDY: "docker.io/caddy:2.7.4"
 # https://hub.docker.com/_/elasticsearch/tags
 DOCKER_IMAGE_ELASTICSEARCH: "docker.io/elasticsearch:7.17.13"
 # https://hub.docker.com/_/mongo/tags
-DOCKER_IMAGE_MONGODB: "docker.io/mongo:4.4.25"
+DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.7"
 # https://hub.docker.com/_/mysql/tags
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.1.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -352,7 +352,7 @@ spec:
       containers:
         - name: mongodb
           image: {{ DOCKER_IMAGE_MONGODB }}
-          args: ["mongod", "--nojournal", "--storageEngine", "wiredTiger"]
+          args: ["mongod", "--storageEngine", "wiredTiger"]
           ports:
             - containerPort: 27017
           volumeMounts:

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   mongodb:
     image: {{ DOCKER_IMAGE_MONGODB }}
     # Use WiredTiger in all environments, just like at edx.org
-    command: mongod --nojournal --storageEngine wiredTiger
+    command: mongod --storageEngine wiredTiger
     restart: unless-stopped
     user: "999:999"
     volumes:


### PR DESCRIPTION
Resolves https://github.com/overhangio/tutor/issues/1020

Because mongo is going from 4.4 --> 7, starting containers directly wouldn't work out of box. The container will keep on restarting with featureCompatibility error. Before running the containers, run `tutor <dev/local/k8s> upgrade --from=quince` to ensure Mongo is upgraded properly. See https://github.com/overhangio/tutor/issues/1020#issuecomment-2024794174 for more context for certain changes.