### PR TITLE
refactor: move uswgi out of platform directory

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -299,7 +299,7 @@ ENV UWSGI_WORKERS=2
 COPY --chown=app:app settings/uwsgi.ini /openedx
 
 # Run server
-CMD ["uwsgi", "uwsgi.ini"]
+CMD ["uwsgi", "/openedx/uwsgi.ini"]
 
 {{ patch("openedx-dockerfile-final") }}
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -296,7 +296,7 @@ FROM production AS final
 ENV UWSGI_WORKERS=2
 
 # Copy the default uWSGI configuration
-COPY --chown=app:app settings/uwsgi.ini .
+COPY --chown=app:app settings/uwsgi.ini /openedx
 
 # Run server
 CMD ["uwsgi", "uwsgi.ini"]

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -95,7 +95,7 @@ spec:
               name: settings-cms
             - mountPath: /openedx/config
               name: config
-            - mountPath: /openedx/edx-platform/uwsgi.ini
+            - mountPath: /openedx/uwsgi.ini
               name: uwsgi-config
               subPath: uwsgi.ini
           resources:
@@ -204,7 +204,7 @@ spec:
               name: settings-cms
             - mountPath: /openedx/config
               name: config
-            - mountPath: /openedx/edx-platform/uwsgi.ini
+            - mountPath: /openedx/uwsgi.ini
               name: uwsgi-config
               subPath: uwsgi.ini
           resources:

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
       - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
       - ../apps/openedx/config:/openedx/config:ro
-      - ../apps/openedx/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
+      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:ro
       - ../../data/lms:/openedx/data
       - ../../data/openedx-media:/openedx/media
       {%- for mount in iter_mounts(MOUNTS, "openedx", "lms") %}
@@ -135,7 +135,7 @@ services:
       - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
       - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
       - ../apps/openedx/config:/openedx/config:ro
-      - ../apps/openedx/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
+      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:ro
       - ../../data/cms:/openedx/data
       - ../../data/openedx-media:/openedx/media
       {%- for mount in iter_mounts(MOUNTS, "openedx", "cms") %}


### PR DESCRIPTION
Moves uwsgi file to openedx directory instead of edx-platform, resolves https://github.com/overhangio/tutor/issues/846. 
Both local and k8s are working on my system after this change (did a clean image build).