### PR TITLE
feat: update release to quince.3

### DIFF
--- a/changelog.d/20240409_175748_dawoud.sheraz_quince_3.md
+++ b/changelog.d/20240409_175748_dawoud.sheraz_quince_3.md
@@ -1,0 +1,1 @@
+- [Improvement] Update release to open-release/quince.3 (by @dawoudsheraz)

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -59,7 +59,7 @@ OPENEDX_LMS_UWSGI_WORKERS: 2
 OPENEDX_MYSQL_DATABASE: "openedx"
 OPENEDX_MYSQL_USERNAME: "openedx"
 # the common version will be automatically set to "master" in the nightly branch
-OPENEDX_COMMON_VERSION: "open-release/quince.2"
+OPENEDX_COMMON_VERSION: "open-release/quince.3"
 OPENEDX_EXTRA_PIP_REQUIREMENTS: []
 MYSQL_HOST: "mysql"
 MYSQL_PORT: 3306


### PR DESCRIPTION
Updating to open-release/quince.3, to be merged once tag is available after Tuesday, April 9, 4-5PM UTC
