### PR TITLE
chore: upgrade to node 18 in edx-platform

### DIFF
--- a/changelog.d/20240410_102248_regis_node18.md
+++ b/changelog.d/20240410_102248_regis_node18.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgrade Nodejs from 16.14.0 to 18.20.1 in edx-platform. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -122,7 +122,7 @@ ENV PATH /openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 # https://github.com/openedx/edx-platform/blob/master/requirements/edx/base.txt
 # https://github.com/pyenv/pyenv/releases
 RUN pip install nodeenv==1.8.0
-RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
+RUN nodeenv /openedx/nodeenv --node=18.20.1 --prebuilt
 
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}


### PR DESCRIPTION
Without this fix, openedx Docker image building fails with the following error:

     	> [linux/arm64 nodejs-requirements 4/4] RUN
	--mount=type=bind,from=edx-platform,source=/package.json,target=/openedx/edx-platform/package.json
	--mount=type=bind,from=edx-platform,source=/package-lock.json,target=/openedx/edx-platform/package-lock.json
	--mount=type=bind,from=edx-platform,source=/scripts/copy-node-modules.sh,target=/openedx/edx-platform/scripts/copy-node-modules.sh
	--mount=type=cache,target=/root/.npm,sharing=shared     npm
	clean-install --no-audit --registry=https://registry.npmjs.org/:
	95.51 npm notice
	95.51 npm notice New major version of npm available! 8.3.1 -> 10.5.1
	95.51 npm notice Changelog:
	   <https://github.com/npm/cli/releases/tag/v10.5.1>
	95.51 npm notice Run `npm install -g npm@10.5.1` to update!
	95.51 npm notice
	95.51 npm ERR! code EINTEGRITY
	95.51 npm ERR!
	   sha512-sWMb40chzlUOKrHZCGpZoUrVnGm6khfL/fAMKO8vLtUR8yOmWIVVN7MRmep3/DSFhy1Hilon6qAH+UbLZgGG0w==
	integrity checksum failed when using sha512: wanted
	sha512-sWMb40chzlUOKrHZCGpZoUrVnGm6khfL/fAMKO8vLtUR8yOmWIVVN7MRmep3/DSFhy1Hilon6qAH+UbLZgGG0w==
	but got
	sha512-P9aZDwDEAVgAbdHG/ViapRzAUJ6zBSq/4I1lJFluIbrld6Sv6LI+HT2J4dgWqtfaCgIyDnHBHSHiJ/anter7wQ==.
	(11488 bytes)