### PR TITLE
feat!: don't run Celery workers in dev mode

### DIFF
--- a/changelog.d/20240416_162659_arbrandes_no_workers_in_dev.md
+++ b/changelog.d/20240416_162659_arbrandes_no_workers_in_dev.md
@@ -1,0 +1,2 @@
+- 💥[Feature] Use Docker compose profiles to control services. (by @arbrandes) -->
+- [Fix] Don't start Celery workers in dev mode, as they're never used. (by @arbrandes) -->

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -23,8 +23,9 @@ from tutor.types import Config
 
 
 class ComposeTaskRunner(BaseComposeTaskRunner):
-    def __init__(self, root: str, config: Config):
+    def __init__(self, root: str, config: Config, profile: str):
         super().__init__(root, config)
+        self.profile = profile
         self.project_name = ""
         self.docker_compose_files: list[str] = []
         self.docker_compose_job_files: list[str] = []
@@ -37,14 +38,19 @@ class ComposeTaskRunner(BaseComposeTaskRunner):
             # Note that we don't trigger the action on "run". That's because we
             # don't want to trigger the action for every initialization script.
             hooks.Actions.COMPOSE_PROJECT_STARTED.do(
-                self.root, self.config, self.project_name
+                self.root, self.config, self.profile, self.project_name
             )
         args = []
         for docker_compose_path in self.docker_compose_files:
             if os.path.exists(docker_compose_path):
                 args += ["-f", docker_compose_path]
         return utils.docker_compose(
-            *args, "--project-name", self.project_name, *command
+            *args,
+            "--profile",
+            self.profile,
+            "--project-name",
+            self.project_name,
+            *command,
         )
 
     def run_task(self, service: str, command: str) -> int:

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -39,7 +39,7 @@ class Actions:
     instance, to add a callback to the :py:data:`COMPOSE_PROJECT_STARTED` action::
 
         @hooks.Actions.COMPOSE_PROJECT_STARTED.add():
-        def run_this_on_start(root, config, name):
+        def run_this_on_start(root, config, profile, name):
             print(root, config["LMS_HOST", name])
 
     Your callback function will then be called whenever the ``COMPOSE_PROJECT_STARTED.do`` method
@@ -54,8 +54,9 @@ class Actions:
     #:
     #: :parameter str root: project root.
     #: :parameter dict config: project configuration.
+    #: :parameter str profile: docker-compose profile.
     #: :parameter str name: docker-compose project name.
-    COMPOSE_PROJECT_STARTED: Action[[str, Config, str]] = Action()
+    COMPOSE_PROJECT_STARTED: Action[[str, Config, str, str]] = Action()
 
     #: Triggered after all interactive questions have been asked.
     #: You should use this action if you want to add new questions.

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -170,6 +170,8 @@ services:
       {%- endfor %}
     depends_on:
       - lms
+    profiles:
+      - local
 
   cms-worker:
     image: {{ DOCKER_IMAGE_OPENEDX }}
@@ -189,5 +191,7 @@ services:
       {%- endfor %}
     depends_on:
       - cms
+    profiles:
+      - local
 
   {{ patch("local-docker-compose-services")|indent(2) }}


### PR DESCRIPTION
Tutor's importing * from devstack.py[1] for the development settings, and that means that we aren't using Celery workers at all in dev mode (see [2]).  This removes them from the dev compose file, thus saving everyboding a significant chunk of RAM.

[1] https://github.com/overhangio/tutor/blob/master/tutor/templates/apps/openedx/settings/lms/development.py#L3
[2] https://github.com/openedx/edx-platform/blob/master/lms/envs/devstack.py#L35

To do so, we rely on Docker compose profiles[3].
    
[3] https://docs.docker.com/compose/profiles/
    
BREAKING CHANGE: the `COMPOSE_PROJECT_STARTED` hook signature had to be changed to accomodate profile selection.