### PR TITLE
build: don't apply release patches in nightly

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -49,13 +49,6 @@ RUN git config --global user.email "tutor@overhang.io" \
 {%- if patch("openedx-dockerfile-git-patches-default") %}
 # Custom edx-platform patches
 {{ patch("openedx-dockerfile-git-patches-default") }}
-{%- elif EDX_PLATFORM_VERSION == "master" %}
-# Patches in nightly node
-{%- else %}
-# Patches in non-nightly mode
-# Prevent course structure cache infinite growth
-# https://github.com/openedx/edx-platform/pull/34210
-RUN curl -fsSL https://github.com/openedx/edx-platform/commit/ad201cd664b6c722cbefcbda23ae390c06daf621.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}


### PR DESCRIPTION
The Dockerfile applies some patches to edx-platform. These patches are only meant to work on named releases. So, the Dockerfile avoids applying the patches to Nightly by checking if EDX_PLATFORM_VERSION is "master" 

However, people running Nightly will often use a *branch off of master*, causing that conditional to miss, which will lead to build errors like this:

> ERROR: failed to solve: process "/bin/sh -c curl -fsSL https://github.com/openedx/edx-platform/commit/ad201cd664b6c722cbefcbda23ae390c06daf621.patch | git am" did not complete successfully: exit code: 128

As a solution, we simply will remove the patches from Tutor's nightly branch. We can also remove the same conditional from Tutor's master branch.