### PR TITLE
docs: Update Google SMTP Setup to Use Application-Specific Passwords

### DIFF
--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -8,14 +8,14 @@ By default, Tutor comes with a simple SMTP server for sending emails. Such a ser
 
 Authorization for Third-Party Access :
 
-Google has deprecated the "Less Secure App Access." Instead, it is recommended to use "Application-Specific Passwords" for more secure access:
+To enhance security, Google recommends the use of "Application-Specific Passwords" for third-party access to Google services:
 
-1. Ensure 2-Step Verification is enabled on your Google Account.
-2. Visit Google Account Security.
-3. Under "Signing in to Google," choose "App passwords."
-4. You might need to sign in again. Once you do, select "Select app" and choose "Other (Custom name)" from the dropdown.
-5. Enter a name that helps you remember the purpose of this password, like "Tutor SMTP".
-6. Generate and note your 16-character app-specific password.
+1. Activation of 2-Step Verification is required for the Google Account.
+2. Visit the Google Account Security page.
+3. Under "Signing in to Google," select "App passwords."
+4. It may be necessary to sign in again. After signing in, choose "Select app" and select "Other (Custom name)" from the dropdown.
+5. Provide a name that identifies the purpose of this password, such as "Tutor SMTP".
+6. Generate and record the 16-character app-specific password.
 
 Reference: https://support.google.com/mail/answer/185833
 

--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -6,22 +6,19 @@ By default, Tutor comes with a simple SMTP server for sending emails. Such a ser
 .. warning::
   Google Mail SMTP servers come with their own set of limitations. For instance, you are limited to sending 500 emails a day. Reference: https://support.google.com/mail/answer/22839
 
-Authorization for Third-party Access
+Authorization for Third-Party Access ::
 
-As Google has deprecated the "Less Secure App Access," it's recommended to use "Application-Specific Passwords" for a more secure connection. These passwords allow applications to access your Google Account securely and are necessary if you have 2-Step Verification enabled.
+Google has deprecated the "Less Secure App Access." Instead, it is recommended to use "Application-Specific Passwords" for more secure access:
 
-When to Use App Passwords
+1. Ensure 2-Step Verification is enabled on your Google Account.
+2. Visit Google Account Security.
+3. Under "Signing in to Google," choose "App passwords."
+4. You might need to sign in again. Once you do, select "Select app" and choose "Other (Custom name)" from the dropdown.
+5. Enter a name that helps you remember the purpose of this password, like "Tutor SMTP".
+6. Generate and note your 16-character app-specific password.
 
-Use an app password in cases where "Sign in with Google" is not available. App passwords can be a secure way to connect applications to your Google account, especially when the application does not support OAuth.
+Reference: https://support.google.com/mail/answer/185833
 
-Create and Use App Passwords
-
-Ensure you have 2-Step Verification enabled on your Google Account.
-Go to your Google Account settings.
-Under "Signing in to Google," select "App passwords."
-At the bottom of the page, select "Select app" and choose "Other (Custom name)." Enter "Tutor SMTP."
-Select "Generate." The 16-character code generated is your app password.
-Use this app password in your SMTP server configuration instead of your regular pas sword.
 Then, check that you can reach the Google Mail SMTP service from your own server:: 
 
     $ telnet smtp.gmail.com 587

--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -8,14 +8,14 @@ By default, Tutor comes with a simple SMTP server for sending emails. Such a ser
 
 Authorization for Third-Party Access :
 
-To enhance security, Google recommends the use of "Application-Specific Passwords" for third-party access to Google services:
+To enhance security, Google recommends the use of "Application-Specific Passwords" for third-party access to Google services. It's crucial to follow these steps to enable this feature:
 
-1. Activation of 2-Step Verification is required for the Google Account.
+1. Activate 2-Step Verification for the Google Account. This is essential for setting up application-specific passwords.
 2. Visit the Google Account Security page.
-3. Under "Signing in to Google," select "App passwords."
-4. It may be necessary to sign in again. After signing in, choose "Select app" and select "Other (Custom name)" from the dropdown.
-5. Provide a name that identifies the purpose of this password, such as "Tutor SMTP".
-6. Generate and record the 16-character app-specific password.
+3. Under 'Signing in to Google,' select 'App passwords.'
+4. It may be necessary to sign in again. After signing in, choose "Select app" and select "Other (Custom name)" from the dropdown menu.
+5. Enter a name that describes the purpose of this password, such as 'Tutor SMTP'.
+6. Click 'Generate' to receive your 16-character app-specific password. Make sure to record this password securely.
 
 Reference: https://support.google.com/mail/answer/185833
 

--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -6,7 +6,7 @@ By default, Tutor comes with a simple SMTP server for sending emails. Such a ser
 .. warning::
   Google Mail SMTP servers come with their own set of limitations. For instance, you are limited to sending 500 emails a day. Reference: https://support.google.com/mail/answer/22839
 
-Authorization for Third-Party Access ::
+Authorization for Third-Party Access :
 
 Google has deprecated the "Less Secure App Access." Instead, it is recommended to use "Application-Specific Passwords" for more secure access:
 
@@ -19,7 +19,7 @@ Google has deprecated the "Less Secure App Access." Instead, it is recommended t
 
 Reference: https://support.google.com/mail/answer/185833
 
-Then, check that you can reach the Google Mail SMTP service from your own server:: 
+Then, check that you can reach the Google Mail SMTP service from your own server::
 
     $ telnet smtp.gmail.com 587
 

--- a/docs/tutorials/google-smtp.rst
+++ b/docs/tutorials/google-smtp.rst
@@ -6,9 +6,23 @@ By default, Tutor comes with a simple SMTP server for sending emails. Such a ser
 .. warning::
   Google Mail SMTP servers come with their own set of limitations. For instance, you are limited to sending 500 emails a day. Reference: https://support.google.com/mail/answer/22839
 
-You should authorize third-party to access your Google Mail account. In your Google Mail account, select "Manage Account", "Security", and turn on "Less Secure App Access". Check the Google documentation for more information on "less secure apps": https://support.google.com/accounts/answer/6010255
+Authorization for Third-party Access
 
-Then, check that you can reach the Google Mail SMTP service from your own server::
+As Google has deprecated the "Less Secure App Access," it's recommended to use "Application-Specific Passwords" for a more secure connection. These passwords allow applications to access your Google Account securely and are necessary if you have 2-Step Verification enabled.
+
+When to Use App Passwords
+
+Use an app password in cases where "Sign in with Google" is not available. App passwords can be a secure way to connect applications to your Google account, especially when the application does not support OAuth.
+
+Create and Use App Passwords
+
+Ensure you have 2-Step Verification enabled on your Google Account.
+Go to your Google Account settings.
+Under "Signing in to Google," select "App passwords."
+At the bottom of the page, select "Select app" and choose "Other (Custom name)." Enter "Tutor SMTP."
+Select "Generate." The 16-character code generated is your app password.
+Use this app password in your SMTP server configuration instead of your regular pas sword.
+Then, check that you can reach the Google Mail SMTP service from your own server:: 
 
     $ telnet smtp.gmail.com 587
 


### PR DESCRIPTION
Resolved #1025 
This pull request updates the documentation for setting up Google Mail as an SMTP server in Tutor. It replaces the deprecated "Less Secure Apps" access method with "Application-Specific Passwords" as recommended by Google for enhanced security.

Key Changes:
- Removed instructions related to enabling "Less Secure App Access," which Google has deprecated.
- Added detailed steps to set up "Application-Specific Passwords," including enabling 2-Step Verification and generating a secure 16-digit password.
- Included links to Google's official support page for creating app-specific passwords and a relevant discussion from the Open edX community forum that highlights issues related to SMTP setup.