### PR TITLE
Improve the "Working on edx-platform Python dependencies" documentation

### DIFF
--- a/changelog.d/20240425_105236_braden_bind_mount_docs.md
+++ b/changelog.d/20240425_105236_braden_bind_mount_docs.md
@@ -1,0 +1,1 @@
+- [Improvement] Auto-detect bind mounts of openedx-learning for edx-platform (by @bradenmacdonald)

--- a/docs/tutorials/edx-platform.rst
+++ b/docs/tutorials/edx-platform.rst
@@ -100,6 +100,8 @@ Verify that your repository is properly bind-mounted by running ``tutor mounts l
     - service: cms-job
         container_path: /mnt/edx-ora2
 
+(If the ``_mounts`` entries are empty, it didn't work automatically - see below.)
+
 You should then re-build the "openedx" Docker image to pick up your changes::
 
     tutor images build openedx-dev
@@ -110,6 +112,18 @@ To push your changes in production, you should do the same with ``tutor local`` 
 
     tutor images build openedx
     tutor local start -d
+
+What if my edx-platform package is not automatically bind-mounted?
+------------------------------------------------------------------
+
+It is quite possible that your package is not automatically recognized and bind-mounted by Tutor. Out of the box, Tutor defines a set of regular expressions: if your package name matches this regular expression, it will be automatically bind-mounted. But if it does not, you have to tell Tutor about it.
+
+To do so, you will need to create a :ref:`Tutor plugin <plugin_development_tutorial>` that implements the :py:data:`tutor.hooks.Filters.MOUNTED_DIRECTORIES` filter::
+
+    from tutor import hooks
+    hooks.Filters.MOUNTED_DIRECTORIES.add_item(("openedx", "my-package"))
+
+After you implement and enable that plugin, ``tutor mounts list`` should display your directory among the bind-mounted directories.
 
 Debugging with breakpoints
 --------------------------
@@ -152,18 +166,6 @@ Then, run unit tests with ``pytest`` commands::
 
 .. note::
     Getting all edx-platform unit tests to pass on Tutor is currently a work-in-progress. Some unit tests are still failing. If you manage to fix some of these, please report your findings in the `Open edX forum <https://discuss.openedx.org/tag/tutor>`__.
-
-What if my edx-platform package is not automatically bind-mounted?
-------------------------------------------------------------------
-
-It is quite possible that your package is not automatically recognized and bind-mounted by Tutor. Out of the box, Tutor defines a set of regular expressions: if your package name matches this regular expression, it will be automatically bind-mounted. But if it does not, you have to tell Tutor about it.
-
-To do so, you will need to create a :ref:`Tutor plugin <plugin_development_tutorial>` that implements the :py:data:`tutor.hooks.Filters.MOUNTED_DIRECTORIES` filter::
-
-    from tutor import hooks
-    hooks.Filters.MOUNTED_DIRECTORIES.add_item(("openedx", "my-package"))
-
-After you implement and enable that plugin, ``tutor mounts list`` should display your directory among the bind-mounted directories.
 
 Do I have to re-build the "openedx" Docker image after every change?
 --------------------------------------------------------------------

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -65,6 +65,7 @@ hooks.Filters.MOUNTED_DIRECTORIES.add_items(
         ("openedx", "edx-enterprise"),
         ("openedx", "edx-ora2"),
         ("openedx", "edx-search"),
+        ("openedx", "openedx-learning"),
         ("openedx", r"platform-plugin-.*"),
     ]
 )


### PR DESCRIPTION
I couldn't get the edx-platform to persistently use my bind-mounted version of its dependency `openedx-learning`. I was about to write a giant post on Discourse to ask for help when I happened to notice that the documentation _does_ contain the answer I needed ("What if my edx-platform package is not automatically bind-mounted?"). The problem was, this key section was separated from the related section ("Working on edx-platform Python dependencies") by unrelated topics like how to run the unit tests.

So, this PR:
1) Moves that important section of the documentation up to where it's more relevant, and adds an explicit call out.
2) Also updates tutor to be able to auto-detect `openedx-learning` without a plugin - as it is becoming a key platform dependency and at least at OpenCraft, many developers need to use a bind-mounted version of this dependency.

I didn't include a changelog entry as this is primarily a documentation-only change.