### PR TITLE
Revert "Revert "chore: upgrade to node 18 in edx-platform""

### DIFF
--- a/changelog.d/20240410_102248_regis_node18.md
+++ b/changelog.d/20240410_102248_regis_node18.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgrade Nodejs from 16.14.0 to 18.20.1 in edx-platform. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -122,7 +122,7 @@ ENV PATH /openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 # https://github.com/openedx/edx-platform/blob/master/requirements/edx/base.txt
 # https://github.com/pyenv/pyenv/releases
 RUN pip install nodeenv==1.8.0
-RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
+RUN nodeenv /openedx/nodeenv --node=18.20.1 --prebuilt
 
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}


### PR DESCRIPTION
Reverts overhangio/tutor#1040, restoring the Node 16->18 upgrade.

Upstream PR: https://github.com/openedx/edx-platform/pull/34503