### PR TITLE
Add IS_FILE_RENDERED filter to enhance file processing flexibility

### DIFF
--- a/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
+++ b/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
@@ -1,2 +1,1 @@
-- [Feature] Introduces the IS_FILE_RENDERED Filter, which allows developers to specify files that should be copied directly without rendering. This update empowers
-developers to manage special file types, ensuring that they are transferred intact without undergoing template processing. (by @Abdul-Muqadim-Arbisoft)
+- [Feature] Introduces the IS_FILE_RENDERED Filter, which allows developers to specify files that should be copied directly without rendering. This update empowers developers to manage special file types, ensuring that they are transferred intact without undergoing template processing. (by @Abdul-Muqadim-Arbisoft)

--- a/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
+++ b/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
@@ -1,1 +1,2 @@
-- [Feature] Introduces the IS_FILE_RENDERED Filter, enabling developers to specify files that should be copied without rendering. (by @Abdul-Muqadim-Arbisoft)
+- [Feature] Introduces the IS_FILE_RENDERED Filter, which allows developers to specify files that should be copied directly without rendering. This update empowers
+developers to manage special file types, ensuring that they are transferred intact without undergoing template processing. (by @Abdul-Muqadim-Arbisoft)

--- a/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
+++ b/changelog.d/20240508_111948_abdul.muqadim_is_file_rendered_filter.md
@@ -1,0 +1,1 @@
+- [Feature] Introduces the IS_FILE_RENDERED Filter, enabling developers to specify files that should be copied without rendering. (by @Abdul-Muqadim-Arbisoft)

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -554,7 +554,20 @@ def _delete_plugin_templates(plugin: str, root: str, _config: Config) -> None:
 
 @hooks.Filters.IS_FILE_RENDERED.add()
 def _do_not_render_binary_files(result: bool, path: str) -> bool:
-    """Return bianry file"""
+    """
+    Determine whether a file should be rendered based on its binary nature.
+
+    This function checks if a file is binary and updates the rendering decision accordingly.
+    If the initial decision (`result`) is to render the file, but the file is detected as binary,
+    the function will override this decision to prevent rendering.
+
+    Parameters:
+    - result (bool): The initial decision on whether the file should be rendered.
+    - path (str): The file path to check for binary content.
+
+    Returns:
+    - bool: False if the file is binary and was initially set to be rendered, otherwise returns the initial decision.
+    """
     if result and is_binary_file(path):
         result = False
     return result

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -194,8 +194,7 @@ class Renderer:
         The template_name *always* uses "/" separators, and is not os-dependent. Do not pass the result of
         os.path.join(...) to this function.
         """
-        if is_binary_file(template_name):
-            # Don't try to render binary files
+        if not hooks.Filters.IS_FILE_RENDERED.apply(True, template_name):
             return self.environment.read_bytes(template_name)
 
         try:
@@ -551,3 +550,11 @@ def _delete_plugin_templates(plugin: str, root: str, _config: Config) -> None:
                 raise exceptions.TutorError(
                     f"Could not delete file {e.filename} from plugin {plugin} in folder {path}"
                 )
+
+
+@hooks.Filters.IS_FILE_RENDERED.add()
+def _do_not_render_binary_files(result: bool, path: str) -> bool:
+    """Return bianry file"""
+    if result and is_binary_file(path):
+        result = False
+    return result

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -493,6 +493,15 @@ class Filters:
     #:   filter themselves, but they can apply it to check whether other plugins are enabled.
     PLUGINS_LOADED: Filter[list[str], []] = Filter()
 
+    #: Use this filter to determine whether a file should be rendered. This can be useful in scenarios where
+    #: certain types of files need special handling, such as binary files, which should not be rendered as text.
+    #:
+    #: :param bool should_render: Initial decision on rendering the file, typically set to True.
+    #: :param str file_path: The path to the file being checked.
+    #: This filter expects a boolean return value that indicates whether the file should be rendered.
+    IS_FILE_RENDERED: Filter[bool, str] = Filter()
+
+
 
 class Contexts:
     """

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -2,6 +2,7 @@
 List of all the action, filter and context names used across Tutor. This module is used
 to generate part of the reference documentation.
 """
+
 from __future__ import annotations
 
 # The Tutor plugin system is licensed under the terms of the Apache 2.0 license.
@@ -197,10 +198,9 @@ class Filters:
     #:   added as subcommands to the ``local/dev/k8s do`` commands. They must return a list of
     #:   ("service name", "service command") tuples. Each "service command" will be executed
     #:   in the "service" container, both in local, dev and k8s mode.
-    CLI_DO_COMMANDS: Filter[
-        list[Callable[[Any], Iterable[tuple[str, str]]]], []
-    ] = Filter()
-
+    CLI_DO_COMMANDS: Filter[list[Callable[[Any], Iterable[tuple[str, str]]]], []] = (
+        Filter()
+    )
     #: List of initialization tasks (scripts) to be run in the ``init`` job. This job
     #: includes all database migrations, setting up, etc. To run some tasks before or
     #: after others, they should be assigned a different priority.
@@ -499,8 +499,7 @@ class Filters:
     #: :param bool should_render: Initial decision on rendering the file, typically set to True.
     #: :param str file_path: The path to the file being checked.
     #: This filter expects a boolean return value that indicates whether the file should be rendered.
-    IS_FILE_RENDERED: Filter[bool,[str]] = Filter()
-
+    IS_FILE_RENDERED: Filter[bool, [str]] = Filter()
 
 
 class Contexts:

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -2,7 +2,6 @@
 List of all the action, filter and context names used across Tutor. This module is used
 to generate part of the reference documentation.
 """
-
 from __future__ import annotations
 
 # The Tutor plugin system is licensed under the terms of the Apache 2.0 license.
@@ -198,9 +197,10 @@ class Filters:
     #:   added as subcommands to the ``local/dev/k8s do`` commands. They must return a list of
     #:   ("service name", "service command") tuples. Each "service command" will be executed
     #:   in the "service" container, both in local, dev and k8s mode.
-    CLI_DO_COMMANDS: Filter[list[Callable[[Any], Iterable[tuple[str, str]]]], []] = (
-        Filter()
-    )
+    CLI_DO_COMMANDS: Filter[
+        list[Callable[[Any], Iterable[tuple[str, str]]]], []
+    ] = Filter()
+
     #: List of initialization tasks (scripts) to be run in the ``init`` job. This job
     #: includes all database migrations, setting up, etc. To run some tasks before or
     #: after others, they should be assigned a different priority.

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -499,7 +499,7 @@ class Filters:
     #: :param bool should_render: Initial decision on rendering the file, typically set to True.
     #: :param str file_path: The path to the file being checked.
     #: This filter expects a boolean return value that indicates whether the file should be rendered.
-    IS_FILE_RENDERED: Filter[bool, str] = Filter()
+    IS_FILE_RENDERED: Filter[bool,[str]] = Filter()
 
 
 

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -496,9 +496,10 @@ class Filters:
     #: Use this filter to determine whether a file should be rendered. This can be useful in scenarios where
     #: certain types of files need special handling, such as binary files, which should not be rendered as text.
     #:
+    #: This filter expects a boolean return value that indicates whether the file should be rendered.
+    #:
     #: :param bool should_render: Initial decision on rendering the file, typically set to True.
     #: :param str file_path: The path to the file being checked.
-    #: This filter expects a boolean return value that indicates whether the file should be rendered.
     IS_FILE_RENDERED: Filter[bool, [str]] = Filter()
 
 


### PR DESCRIPTION
**Description:**
This pull request introduces a new filter, IS_FILE_RENDERED, designed to enhance the flexibility of file handling within Tutor plugins. The new IS_FILE_RENDERED filter allows plugin developers to specify files that should not be rendered but instead copied .

**Implementation Details:**
The IS_FILE_RENDERED filter works by accepting a boolean flag and a file path. It returns a boolean indicating whether the file should be rendered. By default, all files are set to be rendered unless explicitly specified .