### PR TITLE
security: add upstream security patch in dockerfile

### DIFF
--- a/changelog.d/20240521_115552_dawoud.sheraz_security_patch.md
+++ b/changelog.d/20240521_115552_dawoud.sheraz_security_patch.md
@@ -1,0 +1,1 @@
+- [Security] Add Upstream "Privilege re-escalation in Studio after staff access removed" git security patch in Open edX Image(by @dawoudsheraz)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -56,6 +56,10 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Prevent course structure cache infinite growth
 # https://github.com/openedx/edx-platform/pull/34210
 RUN curl -fsSL https://github.com/openedx/edx-platform/commit/ad201cd664b6c722cbefcbda23ae390c06daf621.patch | git am
+# Security patch for "Privilege re-escalation in Studio after staff access removed"
+# https://github.com/openedx/edx-platform/security/advisories/GHSA-99vw-2wrq-xh9x
+# https://discuss.openedx.org/t/upcoming-security-fix-for-edx-platform-on-2024-05-17/13004
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/3ff69fd5813256f935f19c237ea0c42d4c16edbf.patch | git am
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}


### PR DESCRIPTION
Part 1 for https://github.com/overhangio/tutor/issues/1067. 
Adds git patch for non-nightly mode for upstream security fix upstream  for "Privilege re-escalation in Studio after staff access removed"

- https://github.com/openedx/edx-platform/security/advisories/GHSA-99vw-2wrq-xh9x
- https://discuss.openedx.org/t/upcoming-security-fix-for-edx-platform-on-2024-05-17/13004
- https://github.com/openedx/edx-platform/commit/3ff69fd5813256f935f19c237ea0c42d4c16edbf

- [x] Verify openedx image build is working with patch.