### PR TITLE
fix: permissions error on windows when running `tutor dev start`

### DIFF
--- a/changelog.d/20240604_221238_danyal.faheem_permissions_host_fix_on_windows.md
+++ b/changelog.d/20240604_221238_danyal.faheem_permissions_host_fix_on_windows.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix permissions error on windows when running `tutor dev start` (by @Danyal-Faheem)

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -10,7 +10,7 @@ x-openedx-service:
 services:
   permissions:
     environment:
-      OPENEDX_USER_ID: "{{ HOST_USER_ID }}"
+      OPENEDX_USER_ID: "{{ HOST_USER_ID or 1000 }}"
 
   lms:
     <<: *openedx-service


### PR DESCRIPTION
Fixes #1034.

Made the change as suggested by @regisb in the issue.

Tested the change on windows by running `tutor dev start` and `tutor local start`. Both seem to be running fine.