### PR TITLE
fix: npm EINTEGRITY error in openedx build

### DIFF
--- a/changelog.d/20240607_110444_regis_fix_npm_eintegrity.md
+++ b/changelog.d/20240607_110444_regis_fix_npm_eintegrity.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix EINTEGRITY error during `tutor images build openedx`. (by @regisb)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -120,9 +120,9 @@ ENV PATH /openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 
 # Install nodeenv with the version provided by edx-platform
 # https://github.com/openedx/edx-platform/blob/master/requirements/edx/base.txt
-# https://github.com/pyenv/pyenv/releases
+# https://github.com/ekalinin/nodeenv/releases
 RUN pip install nodeenv==1.8.0
-RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
+RUN nodeenv /openedx/nodeenv --node=16.20.2 --prebuilt
 
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}


### PR DESCRIPTION
Running `tutor images build openedx` was failing with multiple integrity errors, such as:

    	npm ERR! code EINTEGRITY
	npm ERR!
	sha512-47o2Wkyr6JDdoRNqUz+KocYY0Yvijmfp7EdaUbOBcT5hK8lqIe5yaH0LfbmSGx5gIrVVOkramUWu2RecxzZZ4Q==
	integrity checksum failed when using sha512: wanted
	sha512-47o2Wkyr6JDdoRNqUz+KocYY0Yvijmfp7EdaUbOB
	cT5hK8lqIe5yaH0LfbmSGx5gIrVVOkramUWu2RecxzZZ4Q== but got
	sha512-eZda0NBpWnQAO3nn8/hDtFqMuJTGlw2Sqbiy27B+Hfu/8Kgbbz6Xk3eu9bjtxOhrR730oe04gXWuOeygbChmXg==.
	(5101 bytes)
	npm ERR! A complete log of this run can be found in:
	npm ERR!     /home/regis/.npm/_logs/2024-06-07T08_55_52_935Z-debug-0.log

The error can be reproduced by installing nodejs dependencies straight from edx-platform:

    cd edx-platform
    npm clean-install

This error is documented elsewhere:
https://stackoverflow.com/questions/47545940/when-i-run-npm-install-it-returns-with-err-code-eintegrity-npm-5-3-0 https://github.com/npm/npm/issues/16861

None of the solutions related to cache worked for me. But after upgrading nodejs and npm, the errors were replaced by the following warnings:

	npm WARN skipping integrity check for git dependency https://git@github.com/velesin/jasmine-jquery.git
	npm WARN skipping integrity check for git dependency https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git
	npm WARN skipping integrity check for git dependency ssh://git@github.com/openedx/mockprock.git

Sooooo it seems that after upgrading npm, integrity checks are no longer performed for github dependencies... which is a good thing? I guess?

I don't know why this error was not happening in CI before. I suspect it has to do with some npm cache black magic. But another user has faced this issue before: https://discuss.openedx.org/t/tutor-npm-error/12868