### PR TITLE
fix: allow setting ACE enabled channels from the env

### DIFF
--- a/changelog.d/20240618_001743_glib.glugovskiy_allow_setting_ace_channels_from_env.md
+++ b/changelog.d/20240618_001743_glib.glugovskiy_allow_setting_ace_channels_from_env.md
@@ -1,0 +1,1 @@
+- [Bugfix] Allow setting ACE_ENABLED_CHANNELS from the environment, making it possible to easily override it with other ACE channels. (by @GlugovGrGlib)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -172,7 +172,7 @@ SILENCED_SYSTEM_CHECKS = ["2_0.W001", "fields.W903"]
 # Email
 EMAIL_USE_SSL = {{ SMTP_USE_SSL }}
 # Forward all emails from edX's Automated Communication Engine (ACE) to django.
-ACE_ENABLED_CHANNELS = ["django_email"]
+ACE_ENABLED_CHANNELS = ENV_TOKENS.get("ACE_ENABLED_CHANNELS", ["django_email"])
 ACE_CHANNEL_DEFAULT_EMAIL = "django_email"
 ACE_CHANNEL_TRANSACTIONAL_EMAIL = "django_email"
 EMAIL_FILE_PATH = "/tmp/openedx/emails"


### PR DESCRIPTION
During the work on the new edx-ace channel for [push notifications](https://github.com/openedx/edx-ace/pull/277), we faced the issue with extending `ACE_ENABLED_CHANNELS` via `ENV_PATCHES` with a new channel.
Eventually, we found that the issue is in hardcoded value in tutor common_all template for `ACE_ENABLED_CHANNELS` introduced with the bugfix for development mode - https://github.com/overhangio/tutor/commit/724c2c84dac6652f10f196e0f0f4fc871ad9e3d0.

By taking `ACE_ENABLED_CHANNELS` from `ENV_TOKENS` with a fallback to `["django_email"]` this variable works for development mode as well as allowing override in local mode.