### PR TITLE
feat: set `EDXAPP_TEST_MONGO_HOST=mongodb` in openedx-dev

### DIFF
--- a/changelog.d/20240624_105125_kyle_test_mongo_host.md
+++ b/changelog.d/20240624_105125_kyle_test_mongo_host.md
@@ -1,0 +1,1 @@
+[Improvement] Set `EDXAPP_TEST_MONGO_HOST` env var in the openedx-dev image so that it no longer needs to be set by hand when running edx-platform unit tests (by @kdmccormick).

--- a/docs/tutorials/edx-platform.rst
+++ b/docs/tutorials/edx-platform.rst
@@ -151,7 +151,6 @@ Then, run unit tests with ``pytest`` commands::
     # Run tests on common apps
     unset DJANGO_SETTINGS_MODULE
     unset SERVICE_VARIANT
-    export EDXAPP_TEST_MONGO_HOST=mongodb
     pytest common
     pytest openedx
     pytest xmodule

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -276,7 +276,8 @@ RUN pip install -e "/mnt/{{ name }}"
 ENV PYTHONBREAKPOINT=ipdb.set_trace
 
 # Point unit tests at the MongoDB container
-ENV EDXAPP_TEST_MONGO_HOST=mongodb
+ENV EDXAPP_TEST_MONGO_HOST={{ MONGODB_HOST }}
+ENV EDXAPP_TEST_MONGO_PORT_NUM={{ MONGODB_PORT }}
 
 # Recompile static assets: in development mode all static assets are stored in edx-platform,
 # and the location of these files is stored in webpack-stats.json. If we don't recompile

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -275,6 +275,9 @@ RUN pip install -e "/mnt/{{ name }}"
 # Add ipdb as default PYTHONBREAKPOINT
 ENV PYTHONBREAKPOINT=ipdb.set_trace
 
+# Point unit tests at the MongoDB container
+ENV EDXAPP_TEST_MONGO_HOST=mongodb
+
 # Recompile static assets: in development mode all static assets are stored in edx-platform,
 # and the location of these files is stored in webpack-stats.json. If we don't recompile
 # static assets, then production assets will be served instead.


### PR DESCRIPTION
Currently, we are asking devs to set this env var manually before they run tests.

Why not just set it in the development image for them?