### PR TITLE
feat!: upgrade default mysql charset and collation to utf8mb4

### DIFF
--- a/changelog.d/20240614_180451_danyal.faheem_upgrade_mysql_utf8mb4.md
+++ b/changelog.d/20240614_180451_danyal.faheem_upgrade_mysql_utf8mb4.md
@@ -1,0 +1,1 @@
+- 💥[Feature] Upgrade default charset and collation of mysql to utf8mb4 and utf8mb4_unicode_ci respectively (by @Danyal-Faheem)

--- a/changelog.d/20240614_180451_danyal.faheem_upgrade_mysql_utf8mb4.md
+++ b/changelog.d/20240614_180451_danyal.faheem_upgrade_mysql_utf8mb4.md
@@ -1,1 +1,2 @@
 - 💥[Feature] Upgrade default charset and collation of mysql to utf8mb4 and utf8mb4_unicode_ci respectively (by @Danyal-Faheem)
+    This upgrade should be automatic for most users. However, if you are running a third-party MySQL (i.e., RUN_MYSQL=false), you are expected to upgrade manually. Please refer to the third-party provider's documentation for detailed upgrade instructions. Ensuring that your MySQL version is up-to-date is crucial for maintaining compatibility and security.

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -309,7 +309,7 @@ def sqlshell(args: list[str]) -> t.Iterable[tuple[str, str]]:
     Extra arguments will be passed to the `mysql` command verbatim. For instance, to
     show tables from the "openedx" database, run `do sqlshell openedx -e 'show tables'`.
     """
-    command = "mysql --user={{ MYSQL_ROOT_USERNAME }} --password={{ MYSQL_ROOT_PASSWORD }} --host={{ MYSQL_HOST }} --port={{ MYSQL_PORT }} --default-character-set=utf8mb3"
+    command = "mysql --user={{ MYSQL_ROOT_USERNAME }} --password={{ MYSQL_ROOT_PASSWORD }} --host={{ MYSQL_HOST }} --port={{ MYSQL_PORT }} --default-character-set=utf8mb4"
     if args:
         command += " " + shlex.join(args)  # pylint: disable=protected-access
     yield ("lms", command)

--- a/tutor/templates/apps/openedx/config/partials/auth.yml
+++ b/tutor/templates/apps/openedx/config/partials/auth.yml
@@ -18,7 +18,7 @@ DATABASES:
     OPTIONS:
       init_command: "SET sql_mode='STRICT_TRANS_TABLES'"
       {%- if RUN_MYSQL %}
-      charset: "utf8mb3"
+      charset: "utf8mb4"
       {%- endif %}
 EMAIL_HOST_USER: "{{ SMTP_USERNAME }}"
 EMAIL_HOST_PASSWORD: "{{ SMTP_PASSWORD }}"

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -394,8 +394,8 @@ spec:
           image: {{ DOCKER_IMAGE_MYSQL }}
           args:
             - "mysqld"
-            - "--character-set-server=utf8mb3"
-            - "--collation-server=utf8mb3_general_ci"
+            - "--character-set-server=utf8mb4"
+            - "--collation-server=utf8mb4_general_ci"
             - "--binlog-expire-logs-seconds=259200"
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -41,8 +41,8 @@ services:
     image: {{ DOCKER_IMAGE_MYSQL }}
     command: >
       mysqld
-      --character-set-server=utf8mb3
-      --collation-server=utf8mb3_general_ci
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
       --binlog-expire-logs-seconds=259200
     restart: unless-stopped
     user: "999:999"


### PR DESCRIPTION
fixes #938.

**Changes**
- Changes the default character set of MySQL to `utf8mb4` and the default collation to `utf8mb4_unicode_ci`.
- Also updated the `dosqlshell` command to use `utf8mb4` as the default character set.

**Testing**
- I have tested these changes on tutor dev and tutor K8s. I followed these steps:
  - Ran `tutor [dev|k8s] launch`
  - Imported the demo course and made sure it was working fine
  - Created admin and student users successfully
  - Created a new course with emojis in the title and in subsection titles and made sure changes were being published and reflected in the LMS

**Future Work**

A new do command `tutor local do change-charset-collation` to allow users to upgrade the charset and collation of their previous tutor installations will be added in a separate PR. A WIP PR is already up at #1079.
