### PR TITLE
chore: ensure plugins are installed from nightly branches in nightly

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,14 +1,14 @@
-# change version ranges when upgrading from redwood
-tutor-android>=18.0.0,<19.0.0
-tutor-cairn>=18.0.0,<19.0.0
-tutor-credentials>=18.0.0,<19.0.0
-tutor-discovery>=18.0.0,<19.0.0
-tutor-ecommerce>=18.0.0,<19.0.0
-tutor-forum>=18.0.0,<19.0.0
-tutor-indigo>=18.0.0,<19.0.0
-tutor-jupyter>=18.0.0,<19.0.0
-tutor-mfe>=18.0.0,<19.0.0
-tutor-minio>=18.0.0,<19.0.0
-tutor-notes>=18.0.0,<19.0.0
-tutor-webui>=18.0.0,<19.0.0
-tutor-xqueue>=18.0.0,<19.0.0
+# # For Tutor Nightly, we install plugins from their nightly branches instead of from PyPI
+tutor-android@git+https://github.com/overhangio/tutor-android@nightly
+tutor-cairn@git+https://github.com/overhangio/tutor-cairn@nightly
+tutor-credentials@git+https://github.com/overhangio/tutor-credentials@nightly
+tutor-discovery@git+https://github.com/overhangio/tutor-discovery@nightly
+tutor-ecommerce@git+https://github.com/overhangio/tutor-ecommerce@nightly
+tutor-forum@git+https://github.com/overhangio/tutor-forum@nightly
+tutor-indigo@git+https://github.com/overhangio/tutor-indigo@nightly
+tutor-jupyter@git+https://github.com/overhangio/tutor-jupyter@nightly
+tutor-mfe@git+https://github.com/overhangio/tutor-mfe@nightly
+tutor-minio@git+https://github.com/overhangio/tutor-minio@nightly
+tutor-notes@git+https://github.com/overhangio/tutor-notes@nightly
+tutor-webui@git+https://github.com/overhangio/tutor-webui@nightly
+tutor-xqueue@git+https://github.com/overhangio/tutor-xqueue@nightly


### PR DESCRIPTION
This is one of post-redwood release actions in nightly and updates plugins.txt to install plugins from their nightly branches instead of from PyPI.