### PR TITLE
fix: add turn on mysql-native-password authentication plugin to fix broken connection for users upgrading from Tutor 15 or earlier

### DIFF
--- a/changelog.d/20240704_112127_danyal.faheem_fix_mysql_native_password_plugin.md
+++ b/changelog.d/20240704_112127_danyal.faheem_fix_mysql_native_password_plugin.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix `mysql-native-password is not loaded` error in MySQL 8.4 when upgrading from tutor 15 or an earlier release to tutor 18 by enabling the plugin. (by @Danyal-Faheem)

--- a/tutor/templates/k8s/deployments.yml
+++ b/tutor/templates/k8s/deployments.yml
@@ -397,6 +397,7 @@ spec:
             - "--character-set-server=utf8mb4"
             - "--collation-server=utf8mb4_unicode_ci"
             - "--binlog-expire-logs-seconds=259200"
+            - "--mysql-native-password=ON"
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: "{{ MYSQL_ROOT_PASSWORD }}"

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci
       --binlog-expire-logs-seconds=259200
+      --mysql-native-password=ON
     restart: unless-stopped
     user: "999:999"
     volumes:


### PR DESCRIPTION
fixes #1089.

For tutor instances that were created with tutor 15 and earlier and then upgraded to tutor 18, the launch process would fail as the MySQL connection could not be made. 

This is because mysql-native-password was removed in MySQL 8.4.0. We turn it on temporarily to fix failing connections.