### PR TITLE
build: update macos runner for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-20.04
             locale: C.UTF-8
           # https://endoflife.date/macos
-          - os: macos-11
+          - os: macos-12
             locale: en_US.UTF-8
     env:
       LC_ALL: ${{ matrix.locale }}


### PR DESCRIPTION
Update macos in release.yml to macos-12 as 11 has been deprecated https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/