### PR TITLE
feat: add `do` command to update the authentication plugin of MySQL users

### DIFF
--- a/changelog.d/20240718_171945_danyal.faheem_mysql_authentication_plugin_change.md
+++ b/changelog.d/20240718_171945_danyal.faheem_mysql_authentication_plugin_change.md
@@ -1,0 +1,1 @@
+- [Improvement] Add a do command to update the authentication plugin of existing MySQL users from mysql_native_password to caching_sha2_password for compatibility with MySQL v8.4.0 and above. (by @Danyal-Faheem)

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -183,6 +183,8 @@ The password will not be required for official plugins that have database users 
 
     tutor local do update-mysql-authentication-plugin USERNAME --password=PASSWORD
 
+.. warning:: Since we are generating a new password hash, whatever password is entered here will be considered as the new password for the user. Please make similar changes to any connection strings to avoid database connection issues.
+
 To update the database users for a vanilla tutor installation::
 
     tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME)

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -168,6 +168,26 @@ By default, only the tables in the openedx database are changed. For upgrading t
 
     tutor local do convert-mysql-utf8mb4-charset --database=discovery
 
+.. _update_mysql_authentication_plugin:
+
+Updating the authentication plugin of MySQL users
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As of MySQL v8.4.0, the ``mysql_native_password`` authentication plugin has been deprecated. Users created with this authentication plugin should ideally be updated to use the latest ``caching_sha2_password`` authentication plugin.
+
+Tutor makes it easy do so with this handy command::
+
+    tutor local do update-mysql-authentication-plugin all
+
+The above command will update all the database users created by Tutor. If you only want to update the authentication plugin of specific users, you can use the ``--users`` option. This option takes comma seperated names of users to upgrade::
+
+    tutor local do update-mysql-authentication-plugin discovery ecommerce
+
+For this command, Tutor expects specific entries in the configuration for the mysql username and password of a database user. For example, if you are trying to update the user ``myuser``, the following case sensitive entries need to be present in the configuration::
+
+    MYUSER_MYSQL_USERNAME
+    MYUSER_MYSQL_PASSWORD
+
 Running arbitrary ``manage.py`` commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -177,17 +177,15 @@ As of MySQL v8.4.0, the ``mysql_native_password`` authentication plugin has been
 
 Tutor makes it easy do so with this handy command::
 
-    tutor local do update-mysql-authentication-plugin all
+    tutor local do update-mysql-authentication-plugin myuser
 
-The above command will update all the database users created by Tutor. If you only want to update the authentication plugin of specific users, you can use the ``--users`` option. This option takes comma seperated names of users to upgrade::
+The password will be required to be entered interactively. Optionally, the password can also be provided as part of the command::
 
-    tutor local do update-mysql-authentication-plugin discovery ecommerce
+    tutor local do update-mysql-authentication-plugin myuser --password=mypassword
 
-For this command, Tutor expects specific entries in the configuration for the mysql username and password of a database user. For example, if you are trying to update the user ``myuser``, the following case sensitive entries need to be present in the configuration::
+Tutor may prompt you with some warnings if the entered password is suspected to be wrong. To avoid these prompts, use the non-interactive option::
 
-    MYUSER_MYSQL_USERNAME
-    MYUSER_MYSQL_PASSWORD
-
+    tutor local do update-mysql-authentication-plugin myuser --password=mypassword --non-interactive
 Running arbitrary ``manage.py`` commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -179,13 +179,15 @@ Tutor makes it easy do so with this handy command::
 
     tutor local do update-mysql-authentication-plugin USERNAME
 
-The password will be required to be entered interactively. Optionally, the password can also be provided as part of the command. To update the openedx mysql user::
+The password will not be required for official plugins that have database users as tutor can infer it from the config. If the password cannot be found by tutor, you will be prompted to enter the password interactively. Alternatively, the password can also be provided as an option::
 
-    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME) --password=$(tutor config printvalue OPENEDX_MYSQL_PASSWORD)
+    tutor local do update-mysql-authentication-plugin USERNAME --password=PASSWORD
 
-Tutor may prompt you with some warnings if the entered password is suspected to be wrong. To avoid these prompts, the non-interactive option should be used. To update the root mysql user non-interactively::
+To update the database users for a vanilla tutor installation::
 
-    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME) --password=$(tutor config printvalue MYSQL_ROOT_PASSWORD) --non-interactive
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME)
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME)
+
 
 Running arbitrary ``manage.py`` commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -177,15 +177,16 @@ As of MySQL v8.4.0, the ``mysql_native_password`` authentication plugin has been
 
 Tutor makes it easy do so with this handy command::
 
-    tutor local do update-mysql-authentication-plugin myuser
+    tutor local do update-mysql-authentication-plugin USERNAME
 
-The password will be required to be entered interactively. Optionally, the password can also be provided as part of the command::
+The password will be required to be entered interactively. Optionally, the password can also be provided as part of the command. To update the openedx mysql user::
 
-    tutor local do update-mysql-authentication-plugin myuser --password=mypassword
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME) --password=$(tutor config printvalue OPENEDX_MYSQL_PASSWORD)
 
-Tutor may prompt you with some warnings if the entered password is suspected to be wrong. To avoid these prompts, use the non-interactive option::
+Tutor may prompt you with some warnings if the entered password is suspected to be wrong. To avoid these prompts, the non-interactive option should be used. To update the root mysql user non-interactively::
 
-    tutor local do update-mysql-authentication-plugin myuser --password=mypassword --non-interactive
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME) --password=$(tutor config printvalue MYSQL_ROOT_PASSWORD) --non-interactive
+
 Running arbitrary ``manage.py`` commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -222,4 +222,7 @@ The detailed steps are mentioned in `tutor-mfe <https://github.com/overhangio/tu
 
 This issue can occur when Tutor is upgraded from v15 (Olive) or earlier to v18 (Redwood) because the users created in Tutor v15 utilize the mysql_native_password authentication plugin by default. This plugin has been deprecated as of MySQL v8.4.0 which is the default MySQL server used in Tutor v18.
 
-The handy :ref:`update-mysql-authentication-plugin <update_mysql_authentication_plugin>` do command in tutor can be used to fix this issue.
+The handy :ref:`update-mysql-authentication-plugin <update_mysql_authentication_plugin>` do command in tutor can be used to fix this issue. To update the database users for a vanilla tutor installation::
+
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME) --password=$(tutor config printvalue OPENEDX_MYSQL_PASSWORD) --non-interactive
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME) --password=$(tutor config printvalue MYSQL_ROOT_PASSWORD) --non-interactive

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -216,3 +216,10 @@ NPM Dependency Conflict When overriding ``@edx/frontend-component-header`` or ``
 ----------------------------------------------------------------------------------------------------------------
 
 The detailed steps are mentioned in `tutor-mfe <https://github.com/overhangio/tutor-mfe?tab=readme-ov-file#npm-dependency-conflict-when-overriding-edxfrontend-component-header-or-edxfrontend-component-footer>`__ documentation.
+
+"Plugin 'mysql_native_password' is not loaded"
+----------------------------------------------
+
+This issue can occur when Tutor is upgraded from v15 (Olive) or earlier to v18 (Redwood) because the users created in Tutor v15 utilize the mysql_native_password authentication plugin by default. This plugin has been deprecated as of MySQL v8.4.0 which is the default MySQL server used in Tutor v18.
+
+The handy :ref:`update-mysql-authentication-plugin <update_mysql_authentication_plugin>` do command in tutor can be used to fix this issue.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -220,9 +220,9 @@ The detailed steps are mentioned in `tutor-mfe <https://github.com/overhangio/tu
 "Plugin 'mysql_native_password' is not loaded"
 ----------------------------------------------
 
-This issue can occur when Tutor is upgraded from v15 (Olive) or earlier to v18 (Redwood) because the users created in Tutor v15 utilize the mysql_native_password authentication plugin by default. This plugin has been deprecated as of MySQL v8.4.0 which is the default MySQL server used in Tutor v18.
+This issue can occur when Tutor is upgraded from v15 (Olive) or earlier to v18 (Redwood) or later because the users created in Tutor v15 and earlier utilize the mysql_native_password authentication plugin by default. This plugin has been deprecated as of MySQL v8.4.0 which is the default MySQL server used in Tutor v18 and onwards.
 
 The handy :ref:`update-mysql-authentication-plugin <update_mysql_authentication_plugin>` do command in tutor can be used to fix this issue. To update the database users for a vanilla tutor installation::
 
-    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME) --password=$(tutor config printvalue OPENEDX_MYSQL_PASSWORD) --non-interactive
-    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME) --password=$(tutor config printvalue MYSQL_ROOT_PASSWORD) --non-interactive
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME)
+    tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME)

--- a/tests/commands/test_jobs.py
+++ b/tests/commands/test_jobs.py
@@ -165,3 +165,36 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
             self.assertIn("NOT", dc_args[-1])
             self.assertIn("course", dc_args[-1])
             self.assertIn("auth", dc_args[-1])
+
+    def test_update_mysql_authentication_plugin_all_users(self) -> None:
+        with temporary_root() as root:
+            self.invoke_in_root(root, ["config", "save"])
+            with patch("tutor.utils.docker_compose") as mock_docker_compose:
+                result = self.invoke_in_root(
+                    root,
+                    ["local", "do", "update-mysql-authentication-plugin", "all"],
+                )
+                dc_args, _dc_kwargs = mock_docker_compose.call_args
+
+            self.assertIsNone(result.exception)
+            self.assertEqual(0, result.exit_code)
+            self.assertIn("lms-job", dc_args)
+            self.assertIn("caching_sha2_password", dc_args[-1])
+            self.assertIn("openedx", dc_args[-1])
+            self.assertIn("root", dc_args[-1])
+
+    def test_update_mysql_authentication_plugin_one_user(self) -> None:
+        with temporary_root() as root:
+            self.invoke_in_root(root, ["config", "save"])
+            with patch("tutor.utils.docker_compose") as mock_docker_compose:
+                result = self.invoke_in_root(
+                    root,
+                    ["local", "do", "update-mysql-authentication-plugin", "openedx"],
+                )
+                dc_args, _dc_kwargs = mock_docker_compose.call_args
+
+            self.assertIsNone(result.exception)
+            self.assertEqual(0, result.exit_code)
+            self.assertIn("lms-job", dc_args)
+            self.assertIn("caching_sha2_password", dc_args[-1])
+            self.assertIn("openedx", dc_args[-1])

--- a/tests/commands/test_jobs.py
+++ b/tests/commands/test_jobs.py
@@ -166,7 +166,7 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
             self.assertIn("course", dc_args[-1])
             self.assertIn("auth", dc_args[-1])
 
-    def test_update_mysql_authentication_plugin(self) -> None:
+    def test_update_mysql_authentication_plugin_official_plugin(self) -> None:
         with temporary_root() as root:
             self.invoke_in_root(root, ["config", "save"])
             with patch("tutor.utils.docker_compose") as mock_docker_compose:
@@ -177,8 +177,6 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
                         "do",
                         "update-mysql-authentication-plugin",
                         "openedx",
-                        "--password=password",
-                        "--non-interactive",
                     ],
                 )
                 dc_args, _dc_kwargs = mock_docker_compose.call_args
@@ -188,4 +186,26 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
             self.assertIn("lms-job", dc_args)
             self.assertIn("caching_sha2_password", dc_args[-1])
             self.assertIn("openedx", dc_args[-1])
-            self.assertIn("password", dc_args[-1])
+
+    def test_update_mysql_authentication_plugin_custom_plugin(self) -> None:
+        with temporary_root() as root:
+            self.invoke_in_root(root, ["config", "save"])
+            with patch("tutor.utils.docker_compose") as mock_docker_compose:
+                result = self.invoke_in_root(
+                    root,
+                    [
+                        "local",
+                        "do",
+                        "update-mysql-authentication-plugin",
+                        "mypluginuser",
+                        "--password=mypluginpassword",
+                    ],
+                )
+                dc_args, _dc_kwargs = mock_docker_compose.call_args
+
+            self.assertIsNone(result.exception)
+            self.assertEqual(0, result.exit_code)
+            self.assertIn("lms-job", dc_args)
+            self.assertIn("caching_sha2_password", dc_args[-1])
+            self.assertIn("mypluginuser", dc_args[-1])
+            self.assertIn("mypluginpassword", dc_args[-1])

--- a/tests/commands/test_jobs.py
+++ b/tests/commands/test_jobs.py
@@ -166,13 +166,20 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
             self.assertIn("course", dc_args[-1])
             self.assertIn("auth", dc_args[-1])
 
-    def test_update_mysql_authentication_plugin_all_users(self) -> None:
+    def test_update_mysql_authentication_plugin(self) -> None:
         with temporary_root() as root:
             self.invoke_in_root(root, ["config", "save"])
             with patch("tutor.utils.docker_compose") as mock_docker_compose:
                 result = self.invoke_in_root(
                     root,
-                    ["local", "do", "update-mysql-authentication-plugin", "all"],
+                    [
+                        "local",
+                        "do",
+                        "update-mysql-authentication-plugin",
+                        "openedx",
+                        "--password=password",
+                        "--non-interactive",
+                    ],
                 )
                 dc_args, _dc_kwargs = mock_docker_compose.call_args
 
@@ -181,20 +188,4 @@ class JobsTests(PluginsTestCase, TestCommandMixin):
             self.assertIn("lms-job", dc_args)
             self.assertIn("caching_sha2_password", dc_args[-1])
             self.assertIn("openedx", dc_args[-1])
-            self.assertIn("root", dc_args[-1])
-
-    def test_update_mysql_authentication_plugin_one_user(self) -> None:
-        with temporary_root() as root:
-            self.invoke_in_root(root, ["config", "save"])
-            with patch("tutor.utils.docker_compose") as mock_docker_compose:
-                result = self.invoke_in_root(
-                    root,
-                    ["local", "do", "update-mysql-authentication-plugin", "openedx"],
-                )
-                dc_args, _dc_kwargs = mock_docker_compose.call_args
-
-            self.assertIsNone(result.exception)
-            self.assertEqual(0, result.exit_code)
-            self.assertIn("lms-job", dc_args)
-            self.assertIn("caching_sha2_password", dc_args[-1])
-            self.assertIn("openedx", dc_args[-1])
+            self.assertIn("password", dc_args[-1])

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -410,26 +410,27 @@ def update_mysql_authentication_plugin(
         return
 
     # Official plugins that have their own mysql user
-    known_plugins_with_mysql_keys = [
+    known_mysql_users = [
+        # Plugin users
         "credentials",
         "discovery",
-        "ecommerce",
         "jupyter",
         "notes",
-        "openedx",
         "xqueue",
+        # Core user
+        "openedx",
     ]
 
-    # Create a list of the usernames and passwords
+    # Create a list of the usernames and password config variables/keys
     known_mysql_credentials_keys = [
         (f"{plugin.upper()}_MYSQL_USERNAME", f"{plugin.upper()}_MYSQL_PASSWORD")
-        for plugin in known_plugins_with_mysql_keys
+        for plugin in known_mysql_users
     ]
     # Add the root user as it is the only one that is different from the rest
     known_mysql_credentials_keys.append(("MYSQL_ROOT_USERNAME", "MYSQL_ROOT_PASSWORD"))
 
     known_mysql_credentials = {}
-    # Build the dictionary of known credentials
+    # Build the dictionary of known credentials from config
     for k, v in known_mysql_credentials_keys:
         if username := config.get(k):
             known_mysql_credentials[username] = config[v]

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -386,7 +386,7 @@ def convert_mysql_utf8mb4_charset(
 @click.option(
     "-p",
     "--password",
-    help="Specify password from the command line.",
+    help="Specify password from the command line. Updates the password for the user if a password that is different from the current one is specified.",
 )
 @click.argument(
     "user",
@@ -441,7 +441,7 @@ def update_mysql_authentication_plugin(
     # Prompt the user if password was not found in config
     if not password:
         password = click.prompt(
-            f"Please enter the password for the user {user}",
+            f"Please enter the password for the user {user}. Note that entering a different password here than the current one will update the password for user {user}.",
             type=str,
         )
 

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -380,7 +380,7 @@ def convert_mysql_utf8mb4_charset(
 @click.command(
     short_help="Update the authentication plugin of a mysql user to caching_sha2_password.",
     help=(
-        "Update the authentication plugin of a mysql user to caching_sha2_password from mysql_native_password. You can specify either specific users to update or all to update all users."
+        "Update the authentication plugin of a mysql user to caching_sha2_password from mysql_native_password."
     ),
 )
 @click.option(

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -393,7 +393,6 @@ def convert_mysql_utf8mb4_charset(
 )
 @click.argument(
     "user",
-    nargs=1,
 )
 @click.option("-I", "--non-interactive", is_flag=True, help="Run non-interactively")
 @click.pass_obj

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -442,12 +442,17 @@ Would you still like to continue with the upgrade process? Note: a wrong passwor
 
     query = f"ALTER USER IF EXISTS '{user}'@'{host}' IDENTIFIED with caching_sha2_password BY '{password}';"
 
-    mysql_command = (
-        "mysql --user={{ MYSQL_ROOT_USERNAME }} --password={{ MYSQL_ROOT_PASSWORD }} --host={{ MYSQL_HOST }} --port={{ MYSQL_PORT }} --database={{ OPENEDX_MYSQL_DATABASE }} --show-warnings "
-        + shlex.join(["-e", query])
-    )
-
-    yield ("lms", mysql_command)
+    yield ("lms", shlex.join([
+        "mysql",
+        "--user={{ MYSQL_ROOT_USERNAME }}",
+        "--password={{ MYSQL_ROOT_PASSWORD }}",
+        "--host={{ MYSQL_HOST }}",
+        "--port={{ MYSQL_PORT }}",
+        "--database={{ OPENEDX_MYSQL_DATABASE }}",
+        "--show-warnings",
+        "-e",
+        query,
+    ]))
 
 
 def add_job_commands(do_command_group: click.Group) -> None:

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -442,17 +442,22 @@ Would you still like to continue with the upgrade process? Note: a wrong passwor
 
     query = f"ALTER USER IF EXISTS '{user}'@'{host}' IDENTIFIED with caching_sha2_password BY '{password}';"
 
-    yield ("lms", shlex.join([
-        "mysql",
-        "--user={{ MYSQL_ROOT_USERNAME }}",
-        "--password={{ MYSQL_ROOT_PASSWORD }}",
-        "--host={{ MYSQL_HOST }}",
-        "--port={{ MYSQL_PORT }}",
-        "--database={{ OPENEDX_MYSQL_DATABASE }}",
-        "--show-warnings",
-        "-e",
-        query,
-    ]))
+    yield (
+        "lms",
+        shlex.join(
+            [
+                "mysql",
+                "--user={{ MYSQL_ROOT_USERNAME }}",
+                "--password={{ MYSQL_ROOT_PASSWORD }}",
+                "--host={{ MYSQL_HOST }}",
+                "--port={{ MYSQL_PORT }}",
+                "--database={{ OPENEDX_MYSQL_DATABASE }}",
+                "--show-warnings",
+                "-e",
+                query,
+            ]
+        ),
+    )
 
 
 def add_job_commands(do_command_group: click.Group) -> None:

--- a/tutor/commands/jobs_utils.py
+++ b/tutor/commands/jobs_utils.py
@@ -3,7 +3,13 @@ This module provides utility methods for tutor `do` commands
 
 Methods:
 - `get_mysql_change_charset_query`: Generates MySQL queries to upgrade the charset and collation of columns, tables, and databases.
+- `get_mysql_change_authentication_plugin_query`: Generates MySQL queries to update the authentication plugin for MySQL users.
 """
+
+from typing import Sequence
+
+from tutor import fmt
+from tutor.types import Config, ConfigValue
 
 
 def get_mysql_change_charset_query(
@@ -130,3 +136,71 @@ def get_mysql_change_charset_query(
             CALL UpdateColumns();
             CALL UpdateTables();
             """
+
+
+def get_mysql_change_authentication_plugin_query(
+    config: Config, users: Sequence[str], all_users: bool
+) -> str:
+    """
+    Generates MySQL queries to update the authentication plugin for MySQL users.
+
+    This method constructs queries to change the authentication plugin to
+    `caching_sha2_password`. User credentials must be provided in the tutor
+    configuration under the keys `<user>_MYSQL_USERNAME` and `<user>_MYSQL_PASSWORD`.
+
+    Args:
+        config (Config): Tutor configuration object
+        users (List[str]): List of specific MySQL users to update.
+        all_users (bool): Flag indicating whether to include ROOT and OPENEDX users
+                          in addition to those specified in the `users` list.
+
+    Returns:
+        str: A string containing the SQL queries to execute.
+
+    Raises:
+        TutorError: If any user in the `users` list does not have corresponding
+                    username or password entries in the configuration.
+    """
+
+    host = "%"
+    query = ""
+
+    def generate_mysql_authentication_plugin_update_query(
+        username: ConfigValue, password: ConfigValue, host: str
+    ) -> str:
+        fmt.echo_info(
+            f"Authentication plugin of user {username} will be updated to caching_sha2_password"
+        )
+        return f"ALTER USER IF EXISTS '{username}'@'{host}' IDENTIFIED with caching_sha2_password BY '{password}';"
+
+    def generate_user_queries(users: Sequence[str]) -> str:
+        query = ""
+        for user in users:
+            user_uppercase = user.upper()
+            if not (
+                f"{user_uppercase}_MYSQL_USERNAME" in config
+                and f"{user_uppercase}_MYSQL_PASSWORD" in config
+            ):
+                fmt.echo_alert(
+                    f"Username or Password for User {user} not found in config. Skipping update process for User {user}."
+                )
+                continue
+
+            query += generate_mysql_authentication_plugin_update_query(
+                config[f"{user_uppercase}_MYSQL_USERNAME"],
+                config[f"{user_uppercase}_MYSQL_PASSWORD"],
+                host,
+            )
+        return query
+
+    if not all_users:
+        return generate_user_queries(users)
+
+    query += generate_mysql_authentication_plugin_update_query(
+        config["MYSQL_ROOT_USERNAME"], config["MYSQL_ROOT_PASSWORD"], host
+    )
+    query += generate_mysql_authentication_plugin_update_query(
+        config["OPENEDX_MYSQL_USERNAME"], config["OPENEDX_MYSQL_PASSWORD"], host
+    )
+
+    return query + generate_user_queries(users)

--- a/tutor/commands/jobs_utils.py
+++ b/tutor/commands/jobs_utils.py
@@ -1,18 +1,12 @@
-"""
-This module provides utility methods for tutor `do` commands
-
-Methods:
-- `create_user_template`: Generates the necessary commands to create a user in openedx.
-- `get_mysql_change_charset_query`: Generates MySQL queries to upgrade the charset and collation of columns, tables, and databases.
-- `set_theme_template`: Generates the necessary commands to set a theme on a specific domain in openedx.
-"""
-
 from __future__ import annotations
 
 
 def create_user_template(
     superuser: str, staff: bool, username: str, email: str, password: str
 ) -> str:
+    """
+    Helper utility to generate the necessary commands to create a user in openedx
+    """
     opts = ""
     if superuser:
         opts += " --superuser"


### PR DESCRIPTION
closes #1095

This PR is a continuation of the issue mentioned in #1089. 

- Add a do command to update the authentication plugin of MySQL users from mysql_native_password to caching_sha2_password.
- The command requires a username and password to function. The password can be provided as a CLI option with the `--password` option or interactively. The command can also be run non-interactively with the `--non-interactive` option as it might prompt for some confirmations otherwise. 

The commands necessary to update a native installation of tutor would be:

```
tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME) --password=$(tutor config printvalue OPENEDX_MYSQL_PASSWORD) --non-interactive
tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME) --password=$(tutor config printvalue MYSQL_ROOT_PASSWORD) --non-interactive

```

**Note:** Any passwords entered here will be considered as the new password for that user as new hashes are being generated.