### PR TITLE
feat: adds `tutor config edit`

### DIFF
--- a/changelog.d/20241114_115534_arunmozhi_add_config_edit_command.md
+++ b/changelog.d/20241114_115534_arunmozhi_add_config_edit_command.md
@@ -1,0 +1,1 @@
+- [Feature] Adds `tutor config edit`. This opens the active tutor environment's config.yaml in an editor for manual editing. (by @tecoholic)

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -261,7 +261,7 @@ def patches_show(context: Context, name: str) -> None:
 
 @click.command(name="edit", help="Edit config.yml of the current environment")
 @click.pass_obj
-def edit(context: Context, editor: str, save: bool) -> None:
+def edit(context: Context) -> None:
     config_file = tutor_config.config_path(context.root)
 
     if not os.path.isfile(config_file):

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os.path
-import subprocess
 import typing as t
 
 import click


### PR DESCRIPTION
Quickly launch the default YAML editor for editing the `config.yml` file.

### Background

As a developer working with multiple projects, I am constantly changing the tutor config and re-running the `tutor dev launch` to update the devstack. While it is as simple as running `vim $(tutor config printroot)/config.yml`, I often found myself wanting to simply express this better using tutor config edit. So this is an attempt at cross-platform solution doing the same. It might not be the best solution, but something to start with if someone else finds this useful and improves their DevEx.

*Caveat:* I have only tested this on Linux (both open and `xdg-open` works in mine, so it could be said Unix).