### PR TITLE
security: add upstream security patch in Open edX image

### DIFF
--- a/changelog.d/20240725_221432_dawoud.sheraz_july_25_security_patch.md
+++ b/changelog.d/20240725_221432_dawoud.sheraz_july_25_security_patch.md
@@ -1,0 +1,1 @@
+- [Security] Add upstream security fix as patch in Open edX image (by @dawoudsheraz)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -53,6 +53,11 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Patches in nightly node
 {%- else %}
 # Patches in non-nightly mode
+# Security patch around content library permissions
+# https://discuss.openedx.org/t/security-upcoming-security-release-for-edx-platform-2024-07-25/13473
+# https://github.com/openedx/edx-platform/pull/35180
+RUN curl -fsSL https://github.com/openedx/edx-platform/commit/3160ff68ca4a4516375af3307fe84f22cd5e5b36.patch | git am
+
 {%- endif %}
 
 {# Example: RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}


### PR DESCRIPTION
Part 1 for https://discuss.openedx.org/t/security-upcoming-security-release-for-edx-platform-2024-07-25/13473, adds the commit patch in Dockerfile

upstream backport: https://github.com/openedx/edx-platform/pull/35180
