### PR TITLE
feat: Implement kill command for local and development environments

### DIFF
--- a/changelog.d/20240725_212933_codewithemad_kill.md
+++ b/changelog.d/20240725_212933_codewithemad_kill.md
@@ -1,0 +1,1 @@
+- [Improvement] New `kill` command for local and development environments. (by @CodeWithEmad)

--- a/tests/commands/test_images.py
+++ b/tests/commands/test_images.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 from tests.helpers import PluginsTestCase, temporary_root
-from tutor import images, plugins, utils
+from tutor import images, plugins
 from tutor.__about__ import __version__
 from tutor.commands.images import ImageNotFoundError
 

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -257,6 +257,14 @@ def stop(context: BaseComposeContext, services: list[str]) -> None:
     context.job_runner(config).docker_compose("stop", *services)
 
 
+@click.command(help="Kill all running containers immediately")
+@click.argument("services", metavar="service", nargs=-1)
+@click.pass_obj
+def kill(context: BaseComposeContext, services: list[str]) -> None:
+    config = tutor_config.load(context.root)
+    context.job_runner(config).docker_compose("kill", *services)
+
+
 @click.command(
     short_help="Reboot an existing platform",
     help="This is more than just a restart: with reboot, the platform is fully stopped before being restarted again",
@@ -434,6 +442,7 @@ def add_commands(command_group: click.Group) -> None:
     command_group.add_command(upgrade)
     command_group.add_command(start)
     command_group.add_command(stop)
+    command_group.add_command(kill)
     command_group.add_command(restart)
     command_group.add_command(reboot)
     command_group.add_command(dc_command)

--- a/tutor/templates/apps/redis/redis.conf
+++ b/tutor/templates/apps/redis/redis.conf
@@ -1,4 +1,5 @@
-# https://raw.githubusercontent.com/redis/redis/6.0/redis.conf
+# https://raw.githubusercontent.com/redis/redis/7.2.4/redis.conf
+
 port 6379
 
 tcp-backlog 511


### PR DESCRIPTION
In a development setting, gracefully stopping containers can be time-consuming and unnecessary. This introduces a command to kill containers directly, improving efficiency.