### PR TITLE
feat: add `patches show ...` command

### DIFF
--- a/changelog.d/20240816_141531_regis_patches_show.md
+++ b/changelog.d/20240816_141531_regis_patches_show.md
@@ -1,0 +1,1 @@
+- [Feature] Add a `patches show my-patch-name`. This is a convenient command for the troubleshooting of plugins. (by @regisb)

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -106,3 +106,8 @@ class PatchesTests(unittest.TestCase, TestCommandMixin):
             result = self.invoke_in_root(root, ["config", "patches", "list"])
         self.assertFalse(result.exception)
         self.assertEqual(0, result.exit_code)
+
+    def test_config_patches_show(self) -> None:
+        result = self.invoke(["config", "patches", "show", "mypatch"])
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual("", result.stdout)

--- a/tutor/commands/config.py
+++ b/tutor/commands/config.py
@@ -220,8 +220,20 @@ def patches_list(context: Context) -> None:
     renderer.print_patches_locations()
 
 
+@click.command(name="show", help="Print the rendered contents of a template patch")
+@click.argument("name")
+@click.pass_obj
+def patches_show(context: Context, name: str) -> None:
+    config = tutor_config.load_full(context.root)
+    renderer = env.Renderer(config)
+    rendered = renderer.patch(name)
+    if rendered:
+        print(rendered)
+
+
 config_command.add_command(save)
 config_command.add_command(printroot)
 config_command.add_command(printvalue)
 patches_command.add_command(patches_list)
+patches_command.add_command(patches_show)
 config_command.add_command(patches_command)

--- a/tutor/plugins/__init__.py
+++ b/tutor/plugins/__init__.py
@@ -4,12 +4,10 @@ Provide API for plugin features.
 
 from __future__ import annotations
 
-import functools
 import typing as t
-from copy import deepcopy
 
 from tutor import exceptions, fmt, hooks
-from tutor.types import Config, get_typed
+from tutor.types import Config
 
 # Import modules to trigger hook creation
 from . import openedx, v0, v1


### PR DESCRIPTION
I found myself in a situation where I wasn't sure if a patch was correctly added by the Indigo plugin. To troubleshoot that issue, I wanted to print that rendered patch. I thought it would make a nice addition to the CLI.