### PR TITLE
Build OCI-compatible image cache

### DIFF
--- a/tutor/commands/images.py
+++ b/tutor/commands/images.py
@@ -227,7 +227,7 @@ def build(
                 image_build_args.append(f"--cache-from=type=registry,ref={tag}-cache")
             if cache_to_registry:
                 image_build_args.append(
-                    f"--cache-to=type=registry,mode=max,ref={tag}-cache"
+                    f"--cache-to=image-manifest=true,type=registry,mode=max,ref={tag}-cache"
                 )
 
             # Build contexts


### PR DESCRIPTION
Fixes #1118 

Add image-manifest=true to build context to support OCI-compatible image cache.
This allows using the registry cache in other registries, like AWS ECR.