### PR TITLE
docs: add tutor compatibility notes

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -130,6 +130,34 @@ The process for upgrading from one major release to the next works similarly to 
     tutor local upgrade --from=quince
     tutor local launch
 
+
+Running older releases of Open edX
+-------------------------------------
+
+Instructions for installing the appropriate Tutor version for older Open edX releases. Each command ensures compatibility between Open edX and its corresponding Tutor version. For more details on versioning conventions in Tutor, see the :ref:`versioning` section.
+
++-------------------+---------------+--------------------------------------------+
+| Open edX Release  | Tutor version | Installation command                       |
++===================+===============+============================================+
+| Juniper           | v10           | pip install 'tutor[full]>=10.0.0,<11.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Koa               | v11           | pip install 'tutor[full]>=11.0.0,<12.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Lilac             | v12           | pip install 'tutor[full]>=12.0.0,<13.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Maple             | v13           | pip install 'tutor[full]>=13.0.0,<14.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Nutmeg            | v14           | pip install 'tutor[full]>=14.0.0,<15.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Olive             | v15           | pip install 'tutor[full]>=15.0.0,<16.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Palm              | v16           | pip install 'tutor[full]>=16.0.0,<17.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Quince            | v17           | pip install 'tutor[full]>=17.0.0,<18.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Redwood           | v18           | pip install 'tutor[full]>=18.0.0,<19.0.0'  |
++-------------------+---------------+--------------------------------------------+
+
 .. _autocomplete:
 
 Shell autocompletion


### PR DESCRIPTION
## Description

This PR adds Running an older version of Open edX in the Installation section.

Context: Sometimes, we need another Open edX release different from the latest. So, by adding this documentation, we can guide what tutor version the person should install for different Open edX releases.

## How to test

- Check the build test in the actions of this PR.

## Screenshots
![image](https://github.com/user-attachments/assets/e26799ba-72a4-4dd8-9dd2-3ab1af8607b7)


