### PR TITLE
chore: add missing requirement

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,7 @@ click>=8.0
 jinja2>=2.10
 kubernetes
 mypy
+packaging
 pycryptodome>=3.17.0
 pyyaml>=6.0
 typing-extensions>=4.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,6 +38,8 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
+packaging==24.1
+    # via -r requirements/base.in
 pyasn1==0.5.0
     # via
     #   pyasn1-modules

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,8 +113,9 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   kubernetes
     #   requests-oauthlib
-packaging==23.2
+packaging==24.1
     # via
+    #   -r requirements/base.txt
     #   black
     #   build
     #   pyinstaller

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -69,8 +69,10 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   kubernetes
     #   requests-oauthlib
-packaging==23.2
-    # via sphinx
+packaging==24.1
+    # via
+    #   -r requirements/base.txt
+    #   sphinx
 pyasn1==0.5.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description

The [latest commit](https://github.com/overhangio/tutor/commit/0f2229b181c584c760442be6f063ea77f120a41e) to nighly is breaking deployments because it's using the [packaging](https://github.com/overhangio/tutor/blob/master/tutor/commands/upgrade/common.py) package, which is not included in the requirements.

This PR adds that as a requirement.

## Other information

Private Ref : [BB-9216](https://tasks.opencraft.com/browse/BB-9216)