### PR TITLE
feat: migrate from *.local.edly.io to *.local.openedx.io

### DIFF
--- a/changelog.d/20241010_131903_regis_local_openedx_io.md
+++ b/changelog.d/20241010_131903_regis_local_openedx_io.md
@@ -1,0 +1,1 @@
+- 💥[Feature] Migrate from local.edly.io to local.openedx.io. (by @regisb)

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -28,7 +28,7 @@ This will perform several tasks. It will:
 * build the "openedx-dev" Docker image, which is based on the "openedx" production image but is `specialized for developer usage`_ (eventually with your fork),
 * stop any existing locally-running Tutor containers,
 * disable HTTPS,
-* set ``LMS_HOST`` to `local.edly.io <http://local.edly.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.edly.io>`_),
+* set ``LMS_HOST`` to `local.openedx.io <http://local.openedx.io>`_ (a convenience domain that simply `points at 127.0.0.1 <https://dnschecker.org/#A/local.openedx.io>`_),
 * prompt for a platform details (with suitable defaults),
 * start LMS, CMS, supporting services, and any plugged-in services,
 * ensure databases are created and migrated, and
@@ -42,8 +42,8 @@ Additionally, when a local clone of edx-platform is bind-mounted, it will:
 
 Once setup is complete, the platform will be running in the background:
 
-* LMS will be accessible at `http://local.edly.io:8000 <http://local.edly.io:8000>`_.
-* CMS will be accessible at `http://studio.local.edly.io:8001 <http://studio.local.edly.io:8001>`_.
+* LMS will be accessible at `http://local.openedx.io:8000 <http://local.openedx.io:8000>`_.
+* CMS will be accessible at `http://studio.local.openedx.io:8001 <http://studio.local.openedx.io:8001>`_.
 * Plugged-in services should be accessible at their documented URLs.
 
 Now, use the ``tutor dev ...`` command-line interface to manage the development environment. Some common commands are described below.

--- a/docs/tutorials/theming.rst
+++ b/docs/tutorials/theming.rst
@@ -46,7 +46,7 @@ Then, run a local webserver::
 
     tutor dev start lms
 
-The LMS can then be accessed at http://local.edly.io:8000. You will then have to :ref:`enable that theme <settheme>`::
+The LMS can then be accessed at http://local.openedx.io:8000. You will then have to :ref:`enable that theme <settheme>`::
 
     tutor dev do settheme mythemename
 
@@ -54,4 +54,4 @@ Watch the themes folders for changes (in a different terminal)::
 
     tutor dev run watchthemes
 
-Make changes to some of the files inside the theme directory: the theme assets should be automatically recompiled and visible at http://local.edly.io:8000.
+Make changes to some of the files inside the theme directory: the theme assets should be automatically recompiled and visible at http://local.openedx.io:8000.

--- a/tutor/interactive.py
+++ b/tutor/interactive.py
@@ -28,6 +28,7 @@ def ask_questions(
     defaults = tutor_config.get_defaults()
     if run_for_prod is None:
         run_for_prod = not config.get("LMS_HOST") in [
+            "local.openedx.io",
             "local.edly.io",
             "local.overhang.io",
         ]
@@ -41,8 +42,8 @@ def ask_questions(
         )
     if not run_for_prod:
         dev_values: Config = {
-            "LMS_HOST": "local.edly.io",
-            "CMS_HOST": "studio.local.edly.io",
+            "LMS_HOST": "local.openedx.io",
+            "CMS_HOST": "studio.local.openedx.io",
             "ENABLE_HTTPS": False,
         }
         fmt.echo_info(

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
     networks:
       default:
         # These aliases are for internal communication between containers when running locally
-        # with *.local.edly.io hostnames.
+        # with *.local.openedx.io hostnames.
         aliases:
           - "{{ LMS_HOST }}"
           {{ patch("local-docker-compose-caddy-aliases")|indent(10) }}


### PR DESCRIPTION
This makes it more clear for everyone that Tutor is an Open edX distribution.

Close #1120

After this PR is merged, I'll push the corresponding changes to all plugins. It's mostly the READMEs that will be affected.