### PR TITLE
chore: fixed typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -387,7 +387,7 @@ If you don't create your fork from this tag, you *will* have important compatibi
 Getting and customizing Translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tutor builds images with the latest translations using the ``atlas pull`` `command <https://github.com/openedx/openedx-atlas>`__.
+Tutor builds images with the latest translations using the ``atlas pull`` `command <https://github.com/openedx/openedx-atlas>`_.
 
 By default the translations are pulled from the `openedx-translations repository <https://github.com/openedx/openedx-translations>`_
 from the ``ATLAS_REVISION`` branch. You can use custom translations on your fork of the openedx-translations repository by setting the following configuration parameters:

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -99,7 +99,7 @@ To open a python shell in the LMS or CMS, run::
 
 You can then import edx-platform and django modules and execute python code.
 
-To rebuild assets, you can run the ``build-dev`` NPM script that comes with edx-plaform::
+To rebuild assets, you can run the ``build-dev`` NPM script that comes with edx-platform::
 
     tutor dev run lms npm run build-dev
 

--- a/docs/k8s.rst
+++ b/docs/k8s.rst
@@ -152,7 +152,7 @@ Plugins can customize any Kubernetes resource in Tutor by overriding the definit
 ::
 
     # myplugin/tutormyplugin/patches/k8s-override
-    
+
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -176,7 +176,7 @@ To learn more, check out `this GitHub issue <https://github.com/overhangio/tutor
 High resource consumption by Docker on ``tutor images build``
 -------------------------------------------------------------
 
-Some Docker images include many independent layers which are built in parallel by BuildKit. As a consequence, building these images will use up a lot of resources, sometimes even crashing the Docker daemon. To bypass this issue, we should explicitely limit the `maximum parallelism of BuildKit <https://docs.docker.com/build/buildkit/configure/#max-parallelism>`__. Create a ``buildkit.toml`` configuration file with the following contents::
+Some Docker images include many independent layers which are built in parallel by BuildKit. As a consequence, building these images will use up a lot of resources, sometimes even crashing the Docker daemon. To bypass this issue, we should explicitly limit the `maximum parallelism of BuildKit <https://docs.docker.com/build/buildkit/configure/#max-parallelism>`__. Create a ``buildkit.toml`` configuration file with the following contents::
 
     [worker.oci]
     max-parallelism = 2


### PR DESCRIPTION
This will fix a couple of typos and an issue with a URL, and remove trailing whitespace from a piece of code.