### PR TITLE
fix: site name limited to 50 characters

### DIFF
--- a/changelog.d/20241023_155157_codewithemad_long_domain.md
+++ b/changelog.d/20241023_155157_codewithemad_long_domain.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fixed an issue where the site name was not limited to 50 characters when creating a new site configuration. (by @CodeWithEmad)

--- a/tutor/templates/build/openedx/bin/site-configuration
+++ b/tutor/templates/build/openedx/bin/site-configuration
@@ -60,7 +60,9 @@ def get_site_configuration(domain):
     domain = domain or settings.LMS_BASE
     site, site_created = Site.objects.get_or_create(domain=domain)
     if site_created:
-        site.name = domain
+        # Limit the site name to 50 characters
+        # https://github.com/django/django/blob/4.2.16/django/contrib/sites/models.py#L86
+        site.name = domain[:50]
         site.save()
     configuration, configuration_created = SiteConfiguration.objects.get_or_create(site=site)
     if configuration_created:


### PR DESCRIPTION
Before this, building organizations with longer URLs failed since the name field inside Site model has a max_length=50

Close #1144