### PR TITLE
fix: attach container stdin on tutor dev start <service>

### DIFF
--- a/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
+++ b/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
@@ -1,1 +1,1 @@
-- [Improvement] Attach container stdin when running tutor dev start <service> for debugging. (by @Danyal-Faheem)
+- [Bugfix] Fix breakpoint debugging by attaching container stdin when running tutor dev start <service> for a single <service>. (by @Danyal-Faheem)

--- a/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
+++ b/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
@@ -1,1 +1,1 @@
-- [Bugfix] Fix breakpoint debugging by attaching container stdin when running tutor dev start <service> for a single <service>. (by @Danyal-Faheem)
+- [Bugfix] Fix breakpoint debugging by attaching container stdin when running tutor dev start <service> for a single service. (by @Danyal-Faheem)

--- a/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
+++ b/changelog.d/20241205_211837_danyal.faheem_add_dev_attach_command.md
@@ -1,0 +1,1 @@
+- [Improvement] Attach container stdin when running tutor dev start <service> for debugging. (by @Danyal-Faheem)

--- a/docs/tutorials/edx-platform.rst
+++ b/docs/tutorials/edx-platform.rst
@@ -139,6 +139,8 @@ To debug a local edx-platform repository, first, start development in detached m
   # Or, debugging CMS:
   tutor dev start cms
 
+To detach from the service without shutting it down, use ``Ctrl+p`` followed with ``Ctrl+q``.
+
 Running edx-platform unit tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -245,23 +245,25 @@ def start(
     services: list[str],
 ) -> None:
     command = ["up", "--remove-orphans"]
-    attach = len(services) == 1
+    attach = len(services) == 1 and not detach
     if build:
         command.append("--build")
     # We have to run the container in detached mode first to attach to it
     if detach or attach:
         command.append("-d")
-
+    else:
+        fmt.echo_info("ℹ️  To exit logs without stopping the containers, use ctrl+z")
+    
     # Start services
     config = tutor_config.load(context.root)
     context.job_runner(config).docker_compose(*command, *services)
-    if attach and not detach:
+    
+    if attach:
         fmt.echo_info(
             f"""Attaching to service {services[0]}
 ℹ️  To detach without stopping the service, use ctrl+p followed by ctrl+q"""
         )
         context.job_runner(config).docker_compose("attach", *services)
-
 
 @click.command(help="Stop a running platform")
 @click.argument("services", metavar="service", nargs=-1)

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -256,10 +256,11 @@ def start(
     config = tutor_config.load(context.root)
     context.job_runner(config).docker_compose(*command, *services)
     if attach and not detach:
-        fmt.echo_info(f"""Attaching to service {services[0]}
-ℹ️  To detach without stopping the service, use ctrl+p followed by ctrl+q""")
+        fmt.echo_info(
+            f"""Attaching to service {services[0]}
+ℹ️  To detach without stopping the service, use ctrl+p followed by ctrl+q"""
+        )
         context.job_runner(config).docker_compose("attach", *services)
-   
 
 
 @click.command(help="Stop a running platform")

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -253,17 +253,18 @@ def start(
         command.append("-d")
     else:
         fmt.echo_info("ℹ️  To exit logs without stopping the containers, use ctrl+z")
-    
+
     # Start services
     config = tutor_config.load(context.root)
     context.job_runner(config).docker_compose(*command, *services)
-    
+
     if attach:
         fmt.echo_info(
             f"""Attaching to service {services[0]}
 ℹ️  To detach without stopping the service, use ctrl+p followed by ctrl+q"""
         )
         context.job_runner(config).docker_compose("attach", *services)
+
 
 @click.command(help="Stop a running platform")
 @click.argument("services", metavar="service", nargs=-1)

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -245,14 +245,21 @@ def start(
     services: list[str],
 ) -> None:
     command = ["up", "--remove-orphans"]
+    attach = len(services) == 1
     if build:
         command.append("--build")
-    if detach:
+    # We have to run the container in detached mode first to attach to it
+    if detach or attach:
         command.append("-d")
 
     # Start services
     config = tutor_config.load(context.root)
     context.job_runner(config).docker_compose(*command, *services)
+    if attach and not detach:
+        fmt.echo_info(f"""Attaching to service {services[0]}
+ℹ️  To detach without stopping the service, use ctrl+p followed by ctrl+q""")
+        context.job_runner(config).docker_compose("attach", *services)
+   
 
 
 @click.command(help="Stop a running platform")


### PR DESCRIPTION
Edx-platform developers regularly utilize debuggers inside their codebase and the `tutor dev start` command does not allow attaching to containers on certain OSes such as MacOS. This command will allow users to attach a single running container using the `docker compose attach` command.

Caveats:

- Can only attach one service in one running terminal