### PR TITLE
Change version suffix to 'main' and load plugins from their main branches

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,14 +1,14 @@
-# # For Tutor Nightly, we install plugins from their nightly branches instead of from PyPI
-tutor-android@git+https://github.com/overhangio/tutor-android@nightly
-tutor-cairn@git+https://github.com/overhangio/tutor-cairn@nightly
-tutor-credentials@git+https://github.com/overhangio/tutor-credentials@nightly
-tutor-discovery@git+https://github.com/overhangio/tutor-discovery@nightly
-tutor-ecommerce@git+https://github.com/overhangio/tutor-ecommerce@nightly
-tutor-forum@git+https://github.com/overhangio/tutor-forum@nightly
-tutor-indigo@git+https://github.com/overhangio/tutor-indigo@nightly
-tutor-jupyter@git+https://github.com/overhangio/tutor-jupyter@nightly
-tutor-mfe@git+https://github.com/overhangio/tutor-mfe@nightly
-tutor-minio@git+https://github.com/overhangio/tutor-minio@nightly
-tutor-notes@git+https://github.com/overhangio/tutor-notes@nightly
-tutor-webui@git+https://github.com/overhangio/tutor-webui@nightly
-tutor-xqueue@git+https://github.com/overhangio/tutor-xqueue@nightly
+# # For Tutor Main, we install plugins from their main branches instead of from PyPI
+tutor-android@git+https://github.com/overhangio/tutor-android@main
+tutor-cairn@git+https://github.com/overhangio/tutor-cairn@main
+tutor-credentials@git+https://github.com/overhangio/tutor-credentials@main
+tutor-discovery@git+https://github.com/overhangio/tutor-discovery@main
+tutor-ecommerce@git+https://github.com/overhangio/tutor-ecommerce@main
+tutor-forum@git+https://github.com/overhangio/tutor-forum@main
+tutor-indigo@git+https://github.com/overhangio/tutor-indigo@main
+tutor-jupyter@git+https://github.com/overhangio/tutor-jupyter@main
+tutor-mfe@git+https://github.com/overhangio/tutor-mfe@main
+tutor-minio@git+https://github.com/overhangio/tutor-minio@main
+tutor-notes@git+https://github.com/overhangio/tutor-notes@main
+tutor-webui@git+https://github.com/overhangio/tutor-webui@main
+tutor-xqueue@git+https://github.com/overhangio/tutor-xqueue@main

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -10,7 +10,7 @@ __version__ = "18.1.4"
 # the main branch.
 # The suffix is cleanly separated from the __version__ in this module to avoid
 # conflicts when merging branches.
-__version_suffix__ = "nightly"
+__version_suffix__ = "main"
 
 # The app name will be used to define the name of the default tutor root and
 # plugin directory. To avoid conflicts between multiple locally-installed


### PR DESCRIPTION
This PR contains the https://github.com/overhangio/tutor/pull/1153, plus two Nightly-specific (aka Main-specific) commits:

* **Change version suffix from nightly to main.** As indicated in the linked PR's changelog entry, this is a breaking change, as it will rename the default TUTOR_ROOT and TUTOR_PLUGINS_ROOT.
* **Load plugins from main branches rather than nightly branches**. This is a safe changes as long as the plugins have already renamed their branches. If they haven't, then pop this commit off and merge it in later.