### PR TITLE
fix: Don't build uwsgi with xml support.

### DIFF
--- a/changelog.d/20241113_131448_feanil_fix_uwsgi_xml_issues_master.md
+++ b/changelog.d/20241113_131448_feanil_fix_uwsgi_xml_issues_master.md
@@ -1,13 +1,1 @@
-<!--
-Create a changelog entry for every new user-facing change. Please respect the following instructions:
-- Indicate breaking changes by prepending an explosion 💥 character.
-- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
-- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
-  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
-  the release notes for every release.
--->
-
-<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
-<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
-
-[Bugfix] Don't build uwsgi with XML support (by @feanil)
+- [Bugfix] Don't build uwsgi with XML support (by @feanil)

--- a/changelog.d/20241113_131448_feanil_fix_uwsgi_xml_issues_master.md
+++ b/changelog.d/20241113_131448_feanil_fix_uwsgi_xml_issues_master.md
@@ -1,0 +1,13 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+
+[Bugfix] Don't build uwsgi with XML support (by @feanil)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -94,8 +94,10 @@ RUN --mount=type=bind,from=edx-platform,source=/requirements/edx/base.txt,target
     pip install -r /openedx/edx-platform/requirements/edx/base.txt
 
 # Install extra requirements
+# We don't need xml configuration support in uwsgi so don't install it.
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install \
+    UWSGI_PROFILE_OVERRIDE="xml=no" \
+    pip install --no-cache-dir --compile \
     # Use redis as a django cache https://pypi.org/project/django-redis/
     django-redis==5.4.0 \
     # uwsgi server https://pypi.org/project/uWSGI/


### PR DESCRIPTION
When uwsgi runs with xml support, it throws the following error on startup with the latest version of edx-platform:

```
xmlsec.InternalError: (-1, 'lxml & xmlsec libxml2 library version mismatch')
```

See https://github.com/xmlsec/python-xmlsec/issues/320 for more details on this.

Essentially, the uWSGI wheel is built against a different version of libxml2 and it causes this version mismach error when trying to load xmlsec.  The xml support in uWSGI is only needed for runing with xml configuration files, which tutor does not do.  Following the guidance of the above issue, I updated the `openedx` Dockerfile to no longer compile with any xml support as a part of the build. The time to build uWSGI was only slightly more than building from cache so I'm not concerned about major slowdowns in the build time for un-cached builds.