### PR TITLE
fix: When pushing images to registry cache, use image-manifest=true

### DIFF
--- a/changelog.d/20241119_111602_fghaas_image_manifest.md
+++ b/changelog.d/20241119_111602_fghaas_image_manifest.md
@@ -1,0 +1,8 @@
+- [Improvement] When building images with
+  `tutor images build --cache-to-registry`, use an OCI-compliant cache
+  artifact format that should be universally compatible with all
+  registries. This enables the use of that option when working with
+  third-party registries such as [Harbor](https://goharbor.io/) or
+  [ECR](https://aws.amazon.com/ecr/). Requires
+  [BuildKit 0.12](https://github.com/moby/buildkit/releases/tag/v0.12.0)
+  or later. (by @angonz and @fghaas)

--- a/tutor/commands/images.py
+++ b/tutor/commands/images.py
@@ -227,7 +227,7 @@ def build(
                 image_build_args.append(f"--cache-from=type=registry,ref={tag}-cache")
             if cache_to_registry:
                 image_build_args.append(
-                    f"--cache-to=type=registry,mode=max,ref={tag}-cache"
+                    f"--cache-to=type=registry,mode=max,ref={tag}-cache,image-manifest=true"
                 )
 
             # Build contexts


### PR DESCRIPTION
Without this change, when building images with `--cache-to-registry`, BuildKit uses a proprietary cache artifact format, which breaks when using third-party registries such as [Harbor](https://goharbor.io/) or [ECR](https://aws.amazon.com/ecr/).
    
By adding the `image-manifest=true` option, BuildKit uses an OCI-compliant cache artifact format that should be compatible with all registries. This option requires BuildKit 0.12 or later (check with `docker buildx ls`).
    
See https://github.com/goharbor/harbor/issues/18941 and https://github.com/moby/buildkit/issues/2251 for background information.
    
Co-authored-by: @angonz