### PR TITLE
feat: get rid of `is_docker_rootless` template filter

### DIFF
--- a/changelog.d/20241121_110954_regis_remove_docker_rootless.md
+++ b/changelog.d/20241121_110954_regis_remove_docker_rootless.md
@@ -1,0 +1,1 @@
+- 💥[Improvement] Get rid of the `is_docker_rootless` template filter, which was used only by Elasticsearch. (by @regisb)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -242,25 +242,6 @@ class UtilsTests(unittest.TestCase):
         self.assertFalse(utils.is_http("home/user/"))
         self.assertFalse(utils.is_http("http-home/user/"))
 
-    @patch("subprocess.run")
-    def test_is_docker_rootless(self, mock_run: MagicMock) -> None:
-        # Mock rootless `docker info` output
-        utils.is_docker_rootless.cache_clear()
-        mock_run.return_value.stdout = "some prefix\n rootless foo bar".encode("utf-8")
-        self.assertTrue(utils.is_docker_rootless())
-
-        # Mock regular `docker info` output
-        utils.is_docker_rootless.cache_clear()
-        mock_run.return_value.stdout = "some prefix, regular docker".encode("utf-8")
-        self.assertFalse(utils.is_docker_rootless())
-
-    @patch("subprocess.run")
-    def test_is_docker_rootless_podman(self, mock_run: MagicMock) -> None:
-        """Test the `is_docker_rootless` when podman is used or any other error with `docker info`"""
-        utils.is_docker_rootless.cache_clear()
-        mock_run.side_effect = subprocess.CalledProcessError(1, "docker info")
-        self.assertFalse(utils.is_docker_rootless())
-
     def test_format_table(self) -> None:
         rows: List[Tuple[str, ...]] = [
             ("a", "xyz", "value 1"),

--- a/tutor/env.py
+++ b/tutor/env.py
@@ -66,7 +66,6 @@ def _prepare_environment() -> None:
             ("HOST_USER_ID", utils.get_user_id()),
             ("TUTOR_APP", __app__.replace("-", "_")),
             ("TUTOR_VERSION", __version__),
-            ("is_docker_rootless", utils.is_docker_rootless),
         ],
     )
 

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -194,20 +194,6 @@ def docker(*command: str) -> int:
     return execute("docker", *command)
 
 
-@lru_cache(maxsize=None)
-def is_docker_rootless() -> bool:
-    """
-    A helper function to determine if Docker is running in rootless mode.
-
-     - https://docs.docker.com/engine/security/rootless/
-    """
-    try:
-        results = subprocess.run(["docker", "info"], capture_output=True, check=True)
-        return "rootless" in results.stdout.decode()
-    except subprocess.CalledProcessError:
-        return False
-
-
 def docker_compose(*command: str) -> int:
     return execute("docker", "compose", *command)
 


### PR DESCRIPTION
This filter was used only by Elasticsearch, so we no longer need to include it in Tutor.