### PR TITLE
fix: update nightly migration action

### DIFF
--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -17,7 +17,9 @@ def _migrate_obsolete_nightly_root(root: str) -> None:
 
     REMOVE-ME-AFTER-v20: migrate this code to the sumac upgrade commands.
     """
-    if __version_suffix__ == "main":
+
+    # Run it for old nightly only
+    if __version_suffix__ == "":
         return
 
     # Migrate the project root

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -19,7 +19,7 @@ def _migrate_obsolete_nightly_root(root: str) -> None:
     """
 
     # Run it for old nightly only
-    if __version_suffix__ == "":
+    if __version_suffix__ != "main":
         return
 
     # Migrate the project root


### PR DESCRIPTION
After the announcement of tutor branch rename, [Braden mentioned](https://discuss.openedx.org/t/tutor-branches-rename/14455/2?u=syed_muhammad_dawoud) the environment migration for nightly did not work. Upon closer inspection, it seems the action was running on release and not main. When running on release, it was not checking the correct destination path and failing to rename. In case of release, the root would be `<path_to_project>/tutor'`. On main/nightly, it would ``<path_to_project>/tutor-nightly` which is what we want to rename to ``<path_to_project>/tutor-main`