### PR TITLE
fix: use cms celery parameters for cms-worker

### DIFF
--- a/changelog.d/20241203_212810_danyal.faheem_fix_cms_worker_parameters.md
+++ b/changelog.d/20241203_212810_danyal.faheem_fix_cms_worker_parameters.md
@@ -1,0 +1,1 @@
+- [BugFix] Use the cms-worker parameters for the cms-worker instead of the lms-worker parameters. (by @Danyal-Faheem)

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -51,7 +51,7 @@ services:
     environment:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.tutor.production
-    command: {% for value in iter_lms_celery_parameters() %}
+    command: {% for value in iter_cms_celery_parameters() %}
       - "{{value}}"{% endfor %}
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
This fixes a bug introduced in #1134 where opening a course would throw a 500 error because the Course Outline could not be found. This is because the cms-worker was being run with the lms-worker parameters and would never pick up the Course Outline Generation tasks.