### PR TITLE
feat: avoid slow reindex of studio content during init

### DIFF
--- a/tutor/templates/jobs/init/cms.sh
+++ b/tutor/templates/jobs/init/cms.sh
@@ -17,10 +17,10 @@ fi
 # Copy-paste of units in Studio (highly requested new feature, but defaults to off in Quince)
 (./manage.py cms waffle_flag --list | grep contentstore.enable_copy_paste_units) || ./manage.py lms waffle_flag --create contentstore.enable_copy_paste_units --everyone
 
-# Re-index studio and courseware content
-# Note that this might be slow for large courses until this issue is resolved:
-# https://github.com/openedx/modular-learning/issues/235
-# But this is a necessary step to make sure the indexes are created and properly
-# configured.
-./manage.py cms reindex_studio --experimental
+# Create the index for studio and courseware content. Because we specify --init,
+# this will not populate the index (potentially slow) nor replace any existing
+# index (resulting in broken features until it is complete). If either of those
+# are necessary, it will print instructions on what command to run to do so.
+./manage.py cms reindex_studio --experimental --init
+# Create the courseware content index
 ./manage.py cms reindex_course --active


### PR DESCRIPTION
Now that https://github.com/openedx/edx-platform/pull/35981 has merged to Sumac, solving https://github.com/openedx/modular-learning/issues/235 , we can update the command that Tutor uses to populate the initial Studio search index.

What this means:
* Brand new instances will get a working index, and be able to start using the features right away. The `init` during instance setup will be nearly-instant.
* Upgraded instances with a small amount of content will see a notice during `init` that they need to run `reindex_studio` manually. The index will be created automatically during `init`, but it will be incomplete (existing content absent, but new content will show up in it). The `init` during instance setup will be nearly-instant, and the reindex command will take a few minutes when run manually.
* Upgraded instances with a huge amount of content will see a notice during `init` that they need to run `reindex_studio` manually. The index will be created automatically during `init`, but it will be incomplete (existing content absent, but new content will show up in it). The `init` during instance setup will be nearly-instant, and the reindex command could take up to several days when run manually. It can be interrupted and resumed as needed.

Compare this to the situation before this change:
* Brand new instances will get a working index, and be able to start using the features right away. The `init` during instance setup will be nearly-instant.
* Upgraded instances with a small amount of content will be able to start using the features right away. The `init` during instance setup will take a few minutes.
* Upgraded instances with a huge amount of content will hit a wall when the `init` process tries to run `reindex_studio`, and it takes several days and likely never completes before the task is terminated for one reason or another.

FYI @regisb @DanielVZ96 @ChrisChV @ormsbee 