### PR TITLE
fix: add meilisearch as a dependency on lms-job

### DIFF
--- a/changelog.d/20250102_143119_danyal.faheem_fix_meilisearch_init_job.md
+++ b/changelog.d/20250102_143119_danyal.faheem_fix_meilisearch_init_job.md
@@ -1,0 +1,1 @@
+- [Bugfix] Add meilisearch as a dependency on lms-job to avoid meilisearch init job crashing when the platform is stopped. (by @Danyal-Faheem)

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -29,7 +29,7 @@ services:
         {%- for mount in iter_mounts(MOUNTS, "openedx", "lms-job") %}
         - {{ mount }}
         {%- endfor %}
-      depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB)]|list_if }}
+      depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB), ("meilisearch", RUN_MEILISEARCH)]|list_if }}
 
     cms-job:
       image: {{ DOCKER_IMAGE_OPENEDX }}


### PR DESCRIPTION
Running the Meilisearch init job when the platform is stopped would crash as the meilisearch container wouldn't be running and the endpoint could not be hit.

We add a dependency in the lms-job on meilisearch as the meilisearch init job is run inside the lms container.