### PR TITLE
feat: Add a plausibility check for Meilisearch configuration

### DIFF
--- a/changelog.d/20250102_163724_fghaas_check_meilisearch.md
+++ b/changelog.d/20250102_163724_fghaas_check_meilisearch.md
@@ -1,0 +1,1 @@
+- [Improvement] Add a plausibility check that issues a warning if `RUN_MEILISEARCH` is `false` but `MEILISEARCH_URL` is unset. (by @fghaas)

--- a/tutor/config.py
+++ b/tutor/config.py
@@ -358,3 +358,23 @@ def _check_preview_lms_host(config: Config) -> None:
             f'Warning: PREVIEW_LMS_HOST="{preview_lms_host}" is not a subdomain of LMS_HOST="{lms_host}". '
             "This configuration is not typically recommended and may lead to unexpected behavior."
         )
+
+
+@hooks.Actions.CONFIG_LOADED.add()
+def _check_run_meilisearch(config: Config) -> None:
+    """
+    In case RUN_MEILISEARCH is set to false, check if
+    MEILISEARCH_URL has been set to a non-default value.
+    If not, print a warning to notify the user.
+    """
+
+    run_meilisearch = get_typed(config, "RUN_MEILISEARCH", bool, True)
+    if not run_meilisearch:
+        meilisearch_url = get_typed(config, "MEILISEARCH_URL", str, "")
+        meilisearch_url_default = get_defaults()["MEILISEARCH_URL"]
+        if meilisearch_url == meilisearch_url_default:
+            fmt.echo_alert(
+                "Warning: RUN_MEILISEARCH is false, but MEILISEARCH_URL is unset. "
+                "This configuration is not typically recommended and may lead to unexpected behavior. "
+                "Consider setting RUN_MEILISEARCH, or setting MEILISEARCH_URL to an existing, preconfigured Meilisearch instance."
+            )


### PR DESCRIPTION
Tutor is meant to be configured with either its own, or an externally preconfigured Meilisearch instance. Thus, the combination of configuring `RUN_MEILISEARCH: false` and leaving `MEILISEARCH_URL` at its default is almost certainly a configuration error.

Add an alert to notify the user of that configuration issue.

Related issue:
https://github.com/overhangio/tutor/issues/1185