### PR TITLE
feat: disable obnoxious "imghdr" warning in edx-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-format: ## Run code formatting tests
 	black --check --diff $(BLACK_OPTS)
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --enable=unused-import,unused-argument --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
+	pylint --disable=all --enable=E --enable=unused-import,unused-argument,f-string-without-interpolation --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
 
 test-unit: ## Run unit tests
 	python -m unittest discover tests

--- a/changelog.d/20250108_094231_regis_sumac_warnings.md
+++ b/changelog.d/20250108_094231_regis_sumac_warnings.md
@@ -1,0 +1,1 @@
+- [Improvement] Silence "imghdr" warning in edx-platform. (by @regisb)

--- a/tests/commands/test_images.py
+++ b/tests/commands/test_images.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 from tests.helpers import PluginsTestCase, temporary_root
-from tutor import images, plugins, utils
+from tutor import images, plugins
 from tutor.__about__ import __version__
 from tutor.commands.images import ImageNotFoundError
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import subprocess
 import tempfile
 import unittest
 from io import StringIO

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -180,11 +180,9 @@ echo "INFO: Will import course data at: $course_root" && echo
 python ./manage.py cms import ../data "$course_root"
 
 # Re-index courses
-# TODO this is no longer compatible with meilisearch indexing. That is, until this PR is merged:
-# https://github.com/openedx/edx-platform/pull/35743
-# Anyway, it doesn't make much sense to reindex *all* courses after a single one has
-# been created. Thus we should # rely on course authors to press the "reindex" button in
-# the studio after the course has # been imported.
+# We are not doing this anymore, because it doesn't make much sense to reindex *all*
+# courses after a single one has been created. Thus we should # rely on course authors to
+# press the "reindex" button in the studio after the course has # been imported.
 #./manage.py cms reindex_course --all --setup
 """
     yield ("cms", template)

--- a/tutor/commands/jobs.py
+++ b/tutor/commands/jobs.py
@@ -375,8 +375,8 @@ def convert_mysql_utf8mb4_charset(
 
     if not config["RUN_MYSQL"]:
         fmt.echo_info(
-            f"You are not running MySQL (RUN_MYSQL=false). It is your "
-            f"responsibility to upgrade the charset and collation of your MySQL instance."
+            "You are not running MySQL (RUN_MYSQL=false). It is your "
+            "responsibility to upgrade the charset and collation of your MySQL instance."
         )
         return
 

--- a/tutor/commands/jobs_utils.py
+++ b/tutor/commands/jobs_utils.py
@@ -19,7 +19,6 @@ def get_mysql_change_charset_query(
     Utilized in the `tutor local do convert-mysql-utf8mb4-charset` command
     """
     return f"""
-            
             DROP PROCEDURE IF EXISTS UpdateColumns;
             DELIMITER $$
 
@@ -32,62 +31,62 @@ def get_mysql_change_charset_query(
                 DECLARE _column_name VARCHAR(255);
                 DECLARE _column_type VARCHAR(255);
                 DECLARE _collation_name VARCHAR(255);
-                
+
                 # We explicitly upgrade the utf8mb3_general_ci collations to utf8mb4_unicode_ci
                 # The other collations are upgraded from utf8mb3_* to utf8mb4_*
                 # For any other collation, we leave it as it is
                 DECLARE columns_cur CURSOR FOR
-                SELECT 
+                SELECT
                     TABLE_NAME,
                     COLUMN_NAME,
                     COLUMN_TYPE,
-                    CASE 
+                    CASE
                         WHEN COLLATION_NAME LIKE CONCAT('{charset_to_upgrade_from}', '_general_ci') THEN 'utf8mb4_unicode_ci'
                         WHEN COLLATION_NAME LIKE CONCAT('{charset_to_upgrade_from}', '_%') THEN CONCAT('{charset}', SUBSTRING_INDEX(COLLATION_NAME, '{charset_to_upgrade_from}', -1))
-                        ELSE COLLATION_NAME 
-                    END AS COLLATION_NAME 
-                FROM 
+                        ELSE COLLATION_NAME
+                    END AS COLLATION_NAME
+                FROM
                     INFORMATION_SCHEMA.COLUMNS
-                WHERE 
+                WHERE
                     TABLE_SCHEMA = '{database}'
                     AND COLLATION_NAME IS NOT NULL {query_to_append};
                 DECLARE CONTINUE HANDLER FOR NOT FOUND SET done_columns_loop = TRUE;
                 OPEN columns_cur;
                 columns_loop: LOOP
                     FETCH columns_cur INTO _table_name, _column_name, _column_type, _collation_name;
-                    
+
                     IF done_columns_loop THEN
                     LEAVE columns_loop;
                     END IF;
-                    
+
                     # First, upgrade the default charset and collation of the table
                     If _table_name <> _table_name_copy THEN
                     select _table_name;
                     SET FOREIGN_KEY_CHECKS = 0;
-                    SET @stmt = CONCAT('ALTER TABLE `', _table_name, '` CONVERT TO CHARACTER SET {charset} COLLATE {collation};'); 
+                    SET @stmt = CONCAT('ALTER TABLE `', _table_name, '` CONVERT TO CHARACTER SET {charset} COLLATE {collation};');
                     PREPARE query FROM @stmt;
                     EXECUTE query;
-                    DEALLOCATE PREPARE query; 
+                    DEALLOCATE PREPARE query;
                     SET FOREIGN_KEY_CHECKS = 1;
                     SET _table_name_copy = _table_name;
                     END IF;
-                    
+
                     # Then, upgrade the default charset and collation of each column
                     # This sequence of table -> column is necessary to preserve column defaults
                     SET FOREIGN_KEY_CHECKS = 0;
-                    SET @statement = CONCAT('ALTER TABLE `', _table_name, '` MODIFY `', _column_name, '` ', _column_type,' CHARACTER SET {charset} COLLATE ', _collation_name, ';'); 
+                    SET @statement = CONCAT('ALTER TABLE `', _table_name, '` MODIFY `', _column_name, '` ', _column_type,' CHARACTER SET {charset} COLLATE ', _collation_name, ';');
                     PREPARE query FROM @statement;
                     EXECUTE query;
-                    DEALLOCATE PREPARE query; 
+                    DEALLOCATE PREPARE query;
                     SET FOREIGN_KEY_CHECKS = 1;
-                        
+
                 END LOOP;
                 CLOSE columns_cur;
 
             END$$
 
             DELIMITER ;
-            
+
             DROP PROCEDURE IF EXISTS UpdateTables;
             DELIMITER $$
 
@@ -109,23 +108,23 @@ def get_mysql_change_charset_query(
                     IF done THEN
                     LEAVE tables_loop;
                     END IF;
-                    
+
                     select table_name_;
 
                     SET FOREIGN_KEY_CHECKS = 0;
-                    SET @stmt = CONCAT('ALTER TABLE `', table_name_, '` CONVERT TO CHARACTER SET {charset} COLLATE {collation};'); 
+                    SET @stmt = CONCAT('ALTER TABLE `', table_name_, '` CONVERT TO CHARACTER SET {charset} COLLATE {collation};');
                     PREPARE query FROM @stmt;
                     EXECUTE query;
-                    DEALLOCATE PREPARE query; 
-                    
+                    DEALLOCATE PREPARE query;
+
                     SET FOREIGN_KEY_CHECKS = 1;
-                        
+
                 END LOOP;
                 CLOSE cur;
-                
+
             END$$
             DELIMITER ;
-            
+
             use {database};
             ALTER DATABASE {database} CHARACTER SET {charset} COLLATE {collation};
             CALL UpdateColumns();

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -155,8 +155,6 @@ def _mount_edx_platform_python_requirements_compose(
     for image_name, regex in hooks.Filters.MOUNTED_DIRECTORIES.iterate():
         if re.match(regex, folder_name):
             # Bind-mount requirement
-            # TODO this is a breaking change because we associate runtime bind-mounts to
-            # "openedx" and no longer to "lms", "cms", etc.
             volumes.append((image_name, f"/mnt/{folder_name}"))
     return volumes
 

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -16,7 +16,7 @@ def _migrate_obsolete_nightly_root(root: str) -> None:
     Since Tutor switched from the "nightly" branch to the "main" branch, we
     automatically migrate data from the project root and the plugins root.
 
-    REMOVE-ME-AFTER-v20: migrate this code to the sumac upgrade commands.
+    REMOVE-AFTER-V20: migrate this code to the sumac upgrade commands.
     """
 
     # Run it for old nightly only

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -152,24 +152,13 @@ LOGGING["loggers"]["blockstore.apps.bundles.storage"] = {"handlers": ["console"]
 # These warnings are visible in simple commands and init tasks
 import warnings
 
-try:
-    from django.utils.deprecation import RemovedInDjango50Warning, RemovedInDjango51Warning
-    warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)
-    warnings.filterwarnings("ignore", category=RemovedInDjango51Warning)
-except ImportError:
-    # REMOVE-AFTER-V18:
-    # In Quince, edx-platform uses Django 5. But on master, edx-platform still uses Django 3.
-    # So, Tutor v17 needs to silence these warnings, whereas Tutor v17-nightly fails to import them.
-    # Once edx-platform master is upgraded to Django 5, the try-except wrapper can be removed.
-    pass
-
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="wiki.plugins.links.wiki_plugin")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="boto.plugin")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="botocore.vendored.requests.packages.urllib3._collections")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="pkg_resources")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="fs")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="fs.opener")
-SILENCED_SYSTEM_CHECKS = ["2_0.W001", "fields.W903"]
+# REMOVE-ME-AFTER-v20: check if we can remove these lines after upgrade.
+from django.utils.deprecation import RemovedInDjango50Warning, RemovedInDjango51Warning
+# RemovedInDjango5xWarning: 'xxx' is deprecated. Use 'yyy' in 'zzz' instead.
+warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)
+warnings.filterwarnings("ignore", category=RemovedInDjango51Warning)
+# DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="pgpy.constants")
 
 # Email
 EMAIL_USE_SSL = {{ SMTP_USE_SSL }}

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -152,7 +152,7 @@ LOGGING["loggers"]["blockstore.apps.bundles.storage"] = {"handlers": ["console"]
 # These warnings are visible in simple commands and init tasks
 import warnings
 
-# REMOVE-ME-AFTER-v20: check if we can remove these lines after upgrade.
+# REMOVE-AFTER-V20: check if we can remove these lines after upgrade.
 from django.utils.deprecation import RemovedInDjango50Warning, RemovedInDjango51Warning
 # RemovedInDjango5xWarning: 'xxx' is deprecated. Use 'yyy' in 'zzz' instead.
 warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -11,7 +11,6 @@ import string
 import struct
 import subprocess
 import sys
-from functools import lru_cache
 from typing import List, Tuple
 from urllib.error import URLError
 from urllib.request import urlopen


### PR DESCRIPTION
This warning was popping up with every manage.py command. E.g:

    $ ./manage.py lms shell -c "print(1)"
    2025-01-08 08:33:37,921 WARNING 33 [py.warnings] [user None] [ip None] warnings.py:110 - /openedx/venv/lib/python3.11/site-packages/pgpy/constants.py:5: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13                                                                                                                                       import imghdr

With this change, we explicitely ignore this warning. We also get rid
of warning removal which no longer makes sense in Sumac and Django 4.

We also fix pylint checking and remove a couple of irrelevant TODO items.