### PR TITLE
build: re-add auto-add for PRs with a different target

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,7 +1,10 @@
-name: Auto Add Issues to Project
+name: Auto Add Issues and Pull Requests to Project
 
 on:
   issues:
+    types:
+      - opened
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
This PR re-enables the auto-add-to-project for PRs but uses a different event (it was previously removed in https://github.com/overhangio/tutor/pull/1011). Instead of using pull_request, it relies on pull_request_target https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target. The pull_request_target allows running the GA on pull request base branch context and is recommended to use only if the underlying actions are NOT using / running any code from PR. The docs suggest using this if one needs to add labels or comments to PR.