### PR TITLE
fix: move openedx-auth patch to bottom of file to allow patching EMAIL and DATABASES settings

### DIFF
--- a/changelog.d/20250127_183638_danyal.faheem_support_other_databases_through_plugin.md
+++ b/changelog.d/20250127_183638_danyal.faheem_support_other_databases_through_plugin.md
@@ -1,0 +1,1 @@
+- [Improvement] Move the openedx-auth patch to the bottom of the auth.yml file to allow patching DATABASES, EMAIL and XQUEUE options. (by @Danyal-Faheem)

--- a/tutor/templates/apps/openedx/config/partials/auth.yml
+++ b/tutor/templates/apps/openedx/config/partials/auth.yml
@@ -2,7 +2,6 @@ SECRET_KEY: "{{ OPENEDX_SECRET_KEY }}"
 AWS_ACCESS_KEY_ID: "{{ OPENEDX_AWS_ACCESS_KEY }}"
 AWS_SECRET_ACCESS_KEY: "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}"
 DOC_STORE_CONFIG: null
-{{ patch("openedx-auth") }}
 XQUEUE_INTERFACE:
   django_auth: null
   url: null
@@ -22,3 +21,4 @@ DATABASES:
       {%- endif %}
 EMAIL_HOST_USER: "{{ SMTP_USERNAME }}"
 EMAIL_HOST_PASSWORD: "{{ SMTP_PASSWORD }}"
+{{ patch("openedx-auth") }}


### PR DESCRIPTION
The `openedx-auth` patch is placed in an inconvenient position where adding DATABASES, XQUEUE or EMAIL settings to the patch does not actually apply these settings as they are below the patch so they are always overriden by the settings defined in Tutor.

We move the patch to the bottom of the file so that these settings can be overriden by the patch.