### PR TITLE
fix: allow installing custom openedx-scorm-xblock using the `openedx-dockerfile-post-python-requirements` patch

### DIFF
--- a/changelog.d/20250203_192055_danyal.faheem_allow_installing_scorm_xblock_using_patch.md
+++ b/changelog.d/20250203_192055_danyal.faheem_allow_installing_scorm_xblock_using_patch.md
@@ -1,0 +1,1 @@
+- [Improvement] Allow installing custom openedx-scorm-xblock using the openedx-dockerfile-post-python-requirements patch. (by @Danyal-Faheem)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -111,10 +111,10 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     UWSGI_PROFILE_OVERRIDE="xml=no" \
     pip install --no-cache-dir --compile uwsgi==2.0.24
 
-{{ patch("openedx-dockerfile-post-python-requirements") }}
-
 # Install scorm xblock
 RUN pip install "openedx-scorm-xblock>=19.0.0,<20.0.0"
+
+{{ patch("openedx-dockerfile-post-python-requirements") }}
 
 {% for extra_requirements in OPENEDX_EXTRA_PIP_REQUIREMENTS %}
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \


### PR DESCRIPTION
The openedx-scorm-xblock was inconveniently being installed right after this patch was defined.

This meant that the only way to install a custom scorm-xblock was to use the OPENEDX_EXTRA_PIP_REQUIREMENTS setting which is not as convenient as the patch itself.