### PR TITLE
fix: `lms.startup` -> `django.setup`

### DIFF
--- a/tutor/templates/build/openedx/bin/site-configuration
+++ b/tutor/templates/build/openedx/bin/site-configuration
@@ -1,8 +1,8 @@
 #! /usr/bin/env python3
 import argparse
-import lms.startup
+import django
 
-lms.startup.run()
+django.setup()
 
 from django.conf import settings
 from django.contrib.sites.models import Site


### PR DESCRIPTION
lms/startup.py performs no logic other than setting up django, so it is being removed upstream:
https://github.com/openedx/edx-platform/pull/36302