### PR TITLE
Docs: Replace outdated theme name with correct theme name on themes docs page

### DIFF
--- a/docs/tutorials/theming.rst
+++ b/docs/tutorials/theming.rst
@@ -35,9 +35,9 @@ Finally, you should enable your theme with the :ref:`settheme command <settheme>
 Developing a new theme
 ----------------------
 
-With Tutor, it's pretty easy to develop your own themes. Start by placing your files inside the ``env/build/openedx/themes`` directory. For instance, you could start from the ``edx.org`` theme present inside the ``edx-platform`` repository::
+With Tutor, it's pretty easy to develop your own themes. Start by placing your files inside the ``env/build/openedx/themes`` directory. For instance, you could start from the ``red-theme`` theme present inside the ``edx-platform`` repository::
 
-    cp -r /path/to/edx-platform/themes/edx.org "$(tutor config printroot)/env/build/openedx/themes/"
+    cp -r /path/to/edx-platform/themes/red-theme "$(tutor config printroot)/env/build/openedx/themes/"
 
 .. warning::
     You should not create a soft link here. If you do, it will trigger a ``Theme not found in any of the themes dirs`` error. This is because soft links are not properly resolved from inside docker containers.


### PR DESCRIPTION
The documentation for the `Themes` page contains an outdated theme name, `edx.org`. This PR updates it to the correct theme name, `red-theme`, which aligns with the theme present in the `edx-platform/theming` folder in the latest release.