### PR TITLE
fix: update dev jobs to use correct Django settings

### DIFF
--- a/changelog.d/20250324_115822_dawoud.sheraz_fix_dev_jobs_environment.md
+++ b/changelog.d/20250324_115822_dawoud.sheraz_fix_dev_jobs_environment.md
@@ -1,0 +1,1 @@
+- [Bugfix] Update lms and cms dev jobs to use correct django settings (by @dawoudsheraz)

--- a/tutor/templates/dev/docker-compose.jobs.yml
+++ b/tutor/templates/dev/docker-compose.jobs.yml
@@ -19,8 +19,13 @@ services:
 
   lms-job:
     <<: *openedx-job-service
+    environment:
+      DJANGO_SETTINGS_MODULE: lms.envs.tutor.development
+
 
   cms-job:
     <<: *openedx-job-service
+    environment:
+      DJANGO_SETTINGS_MODULE: cms.envs.tutor.development
 
   {{ patch("dev-docker-compose-jobs-services")|indent(2) }}


### PR DESCRIPTION
@ormsbee identified in  https://github.com/openedx/edx-platform/issues/36170#issuecomment-2744282360, as part of identifying core issue raised in https://github.com/overhangio/tutor/pull/1108#issuecomment-2744287105, that dev do jobs are not using dev settings and are using prod settings. Upon inspection, the bug is caused by the job yml not defining the DJANGO_SETTINGS_MODULE as part of environment. It is being done in local and k8s but missed in dev.