### PR TITLE
Update edx.rtd.io links to docs.openedx.org

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,7 +6,7 @@ FAQ
 What is Tutor?
 --------------
 
-Tutor is an open source distribution of the `Open edX platform <https://open.edx.org>`_. It uses the original code from the various Open edX repositories, such as `edx-platform <https://github.com/openedx/edx-platform/>`_, `cs_comments_service <https://github.com/openedx/cs_comments_service>`_, etc. and packages everything in a way that makes it very easy to install, administer and upgrade an Open edX installation. In particular, all services are run inside Docker containers.
+Tutor is an open source distribution of the `Open edX platform <https://open.edx.org>`_. It uses the original code from the various Open edX repositories, such as `edx-platform <https://github.com/openedx/edx-platform/>`_, `frontend-app-learning <https://github.com/openedx/frontend-app-learning>`_, etc. and packages everything in a way that makes it very easy to install, administer and upgrade an Open edX installation. In particular, all services are run inside Docker containers.
 
 Tutor makes it possible to deploy an Open edX instance locally, with `docker-compose <https://docs.docker.com/compose/overview/>`_ or on an existing `Kubernetes cluster <http://kubernetes.io/>`_. Want to learn more? Take a look at the :ref:`getting started concepts <intro>`.
 
@@ -25,7 +25,7 @@ The `devstack <https://github.com/openedx/devstack>`_ was a tool meant only for 
 Is Tutor officially supported by the Open edX project?
 ------------------------------------------------------
 
-As of the Open edX Maple release (December 9th 2021), Tutor is the only community-supported installation method for the Open edX platform: see the `official installation instructions <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-quince.master/installation/index.html>`__.
+As of the Open edX Maple release (December 9th 2021), Tutor is the only community-supported installation method for the Open edX platform: see the `official installation instructions <https://docs.tutor.edly.io/>`__.
 
 What features are missing from Tutor?
 -------------------------------------

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -93,7 +93,7 @@ In addition, all LMS and CMS logs are persisted to disk by default in the follow
     $(tutor config printroot)/data/lms/logs/all.log
     $(tutor config printroot)/data/cms/logs/all.log
 
-Finally, tracking logs that store `user events <https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html>`_ are persisted in the following files::
+Finally, tracking logs that store `user events <https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/index.html>`_ are persisted in the following files::
 
     $(tutor config printroot)/data/lms/logs/tracking.log
     $(tutor config printroot)/data/cms/logs/tracking.log

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,7 +22,7 @@ Yes :) This is what happens when you run ``tutor local launch``:
 2. Configuration files are generated from templates.
 3. Docker images are downloaded.
 4. Docker containers are provisioned.
-5. A full, production-ready Open edX platform (`Redwood <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-redwood.master/platform_releases/redwood.html>`__ release) is run with docker-compose.
+5. A full, production-ready Open edX platform (`Latest Release <https://docs.openedx.org/en/latest/community/release_notes/latest.html>`__) is run with docker-compose.
 
 The whole procedure should require less than 10 minutes, on a server with good bandwidth. Note that your host environment will not be affected in any way, since everything runs inside docker containers. Root access is not even necessary.
 

--- a/docs/tutorials/plugin.rst
+++ b/docs/tutorials/plugin.rst
@@ -49,7 +49,7 @@ We'll start by modifying some of our Open edX settings files. It's a frequent re
 
 If you have not already read :ref:`how_does_tutor_work` now would be a good time ☺️ Tutor uses templates to generate various files, such as settings, Dockerfiles, etc. These templates include ``{{ patch("patch-name") }}`` statements that allow plugins to insert arbitrary content in there. These patches are located at strategic locations. See :ref:`patches` for more information.
 
-Let's say that we would like to limit access to our brand new Open edX platform. It is not ready for prime-time yet, so we want to prevent users from registering new accounts. There is a feature flag for that in the LMS: `FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION']>`__. By default this flag is set to a true value, enabling anyone to create an account. In the following we'll set it to false.
+Let's say that we would like to limit access to our brand new Open edX platform. It is not ready for prime-time yet, so we want to prevent users from registering new accounts. There is a feature flag for that in the LMS: `FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION'] <https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html#featuretoggle-FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION']>`__. By default this flag is set to a true value, enabling anyone to create an account. In the following we'll set it to false.
 
 Add the following content to the ``myplugin.py`` file that you created earlier::
 


### PR DESCRIPTION
With the move to docs.openedx.org, update outdated reference links.

Ref: openedx/docs.openedx.org#988
