### PR TITLE
Trigger COMPOSE_PROJECT_STARTED on `run` command

### DIFF
--- a/changelog.d/20250417_162221_mlabeeb03_trigger_compose_started.md
+++ b/changelog.d/20250417_162221_mlabeeb03_trigger_compose_started.md
@@ -1,0 +1,1 @@
+- [Improvement] Stop `dev` platform on `local run` commands. Trigger `COMPOSE_PROJECT_STARTED` only once per tutor runtime. (by @mlabeeb03)

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -23,6 +23,8 @@ from tutor.types import Config
 
 
 class ComposeTaskRunner(BaseComposeTaskRunner):
+    HOOK_FIRED: bool = False
+
     def __init__(self, root: str, config: Config):
         super().__init__(root, config)
         self.project_name = ""
@@ -33,9 +35,12 @@ class ComposeTaskRunner(BaseComposeTaskRunner):
         """
         Run docker-compose with the right yml files.
         """
-        if "start" in command or "up" in command or "restart" in command:
-            # Note that we don't trigger the action on "run". That's because we
-            # don't want to trigger the action for every initialization script.
+        # Trigger the action just once per runtime
+        start_commands = ("start", "up", "restart", "run")
+        if not ComposeTaskRunner.HOOK_FIRED and any(
+            [cmd in command for cmd in start_commands]
+        ):
+            ComposeTaskRunner.HOOK_FIRED = True
             hooks.Actions.COMPOSE_PROJECT_STARTED.do(
                 self.root, self.config, self.project_name
             )

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -8,6 +8,7 @@ from tutor import env as tutor_env
 from tutor import hooks
 from tutor.commands import compose
 from tutor.types import Config, get_typed
+from tutor.utils import get_compose_stacks
 
 
 class DevTaskRunner(compose.ComposeTaskRunner):
@@ -51,7 +52,10 @@ def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
     started.
     """
     runner = DevTaskRunner(root, config)
-    if project_name != runner.project_name:
+    if (
+        runner.project_name in get_compose_stacks()
+        and project_name != runner.project_name
+    ):
         runner.docker_compose("stop")
 
 

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -6,6 +6,7 @@ from tutor import env as tutor_env
 from tutor import hooks
 from tutor.commands import compose
 from tutor.types import Config, get_typed
+from tutor.utils import get_compose_stacks
 
 
 class LocalTaskRunner(compose.ComposeTaskRunner):
@@ -48,7 +49,10 @@ def _stop_on_dev_start(root: str, config: Config, project_name: str) -> None:
     started.
     """
     runner = LocalTaskRunner(root, config)
-    if project_name != runner.project_name:
+    if (
+        runner.project_name in get_compose_stacks()
+        and project_name != runner.project_name
+    ):
         runner.docker_compose("stop")
 
 

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -51,7 +51,8 @@ class Actions:
     For more information about how actions work, check out the :py:class:`tutor.core.hooks.Action` API.
     """
 
-    #: Triggered whenever a "docker compose start", "up" or "restart" command is executed.
+    #: Triggered whenever a "docker compose start", "up", "restart" or "run" command is executed.
+    #: This hook is only triggered once per tutor runtime.
     #:
     #: :parameter str root: project root.
     #: :parameter dict config: project configuration.

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -11,10 +11,10 @@ import string
 import struct
 import subprocess
 import sys
+import uuid as uuid_module
 from typing import List, Tuple
 from urllib.error import URLError
 from urllib.request import urlopen
-import uuid as uuid_module
 
 import click
 from Crypto.Protocol.KDF import bcrypt, bcrypt_check
@@ -244,6 +244,18 @@ def check_output(*command: str) -> bytes:
         return subprocess.check_output(command)
     except Exception as e:
         raise exceptions.TutorError(f"Command failed: {literal_command}") from e
+
+
+def get_compose_stacks() -> list[str]:
+    """
+    Returns a list of names of all running docker compose projects
+    """
+    return [
+        entry["Name"]
+        for entry in json.loads(
+            check_output("docker", "compose", "ls", "--format", "json").decode("utf-8")
+        )
+    ]
 
 
 def warn_macos_docker_memory() -> None:


### PR DESCRIPTION
closes #1193

This PR fixes the issue mentioned in #1193.
We have: 

- Added run to the list of commands that will stop the previously running platform. i.e. stop `dev` on `local run` and vice versa.
- Make it so the `stop` is executed only once even if multiple `run` commands are executed in the same tutor runtime.
- Check for the status or previously running platform using `docker compose ls`. This saves us from calling the `stop` command even when the platform was already stopped.