### PR TITLE
feat: add docker-compose.prod.override.yml support

### DIFF
--- a/changelog.d/20250416_123930_nlevesq_docker_compose_prod_override.md
+++ b/changelog.d/20250416_123930_nlevesq_docker_compose_prod_override.md
@@ -1,0 +1,15 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+
+- [Improvement] Add support for `docker-compose.prod.override.yml` when using
+  `tutor local` commands
+

--- a/docs/local.rst
+++ b/docs/local.rst
@@ -218,6 +218,8 @@ You might want to customise the docker-compose services listed in ``$(tutor conf
 
     vim $(tutor config printroot)/env/local/docker-compose.override.yml
 
-The values in this file will override the values from ``docker-compose.yml`` and ``docker-compose.prod.yml``, as explained in the `docker-compose documentation <https://docs.docker.com/compose/extends/#adding-and-overriding-configuration>`__.
+The values in this file will override the values from ``docker-compose.yml`` as explained in the `docker-compose documentation <https://docs.docker.com/compose/extends/#adding-and-overriding-configuration>`__.
+
+Services defined in ``docker-compose.prod.yml`` can be overriden in a ``docker-compose.prod.override.yml`` file in that same folder.
 
 Similarly, the job service configuration can be overridden by creating a ``docker-compose.jobs.override.yml`` file in that same folder.

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -19,6 +19,7 @@ class LocalTaskRunner(compose.ComposeTaskRunner):
             tutor_env.pathjoin(self.root, "local", "docker-compose.yml"),
             tutor_env.pathjoin(self.root, "local", "docker-compose.prod.yml"),
             tutor_env.pathjoin(self.root, "local", "docker-compose.override.yml"),
+            tutor_env.pathjoin(self.root, "local", "docker-compose.prod.override.yml"),
         ]
         self.docker_compose_job_files += [
             tutor_env.pathjoin(self.root, "local", "docker-compose.jobs.yml"),


### PR DESCRIPTION
This adds support for an optional `docker-compose.prod.override.yml` file used for `tutor local` commands. I'm proposing this because the current documentation suggests you can use `docker-compose.override.yml` to override services defined in `docker-compose.prod.yml`, but in practice this always errors.

Any `tutor dev` commands will try to use it and fail. Additionally even trying to run `tutor local start` (really anything that invokes `docker compose [start|up|restart]`) causes the equivalent of `tutor dev dc stop` to run, which will fail as services like `caddy` aren't defined for that project.

This example if put in `docker-compose.override.yml` will fail (under both `tutor dev` and `tutor local`), but if put in `docker-compose.prod.override.yml` both commands will work as expected:

```yaml
services:
  caddy:
    labels:
      - "key=value"
```