### PR TITLE
fix: add venv instructions in docs for beginners

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,6 +27,19 @@ Requirements
 .. note::
     On Mac OS, by default, containers are allocated 2 GB of RAM, which is not enough. You should follow `these instructions from the official Docker documentation <https://docs.docker.com/docker-for-mac/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon. If the deployment fails because of insufficient memory during database migrations, check the :ref:`relevant section in the troubleshooting guide <migrations_killed>`.
 
+
+Virtual Environment (Recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To prevent conflicts with other Python packages and maintain a clean environment, it's recommended that Tutor should be installed within a Python virtual environment. This is especially important on fresh or shared systems where installing packages globally may require elevated privileges and can interfere with system-level Python dependencies:
+
+.. code-block:: bash
+
+   python3 -m venv env
+   source env/bin/activate
+
+For more details on virtual environments, refer to the official `Python documentation <https://docs.python.org/3/library/venv.html>`_.
+
 Download
 --------
 
@@ -43,18 +56,6 @@ Check the "tutor" package on Pypi: https://pypi.org/project/tutor. You will need
 
 .. _install_binary:
 
-
-Virtual Environment (Recommended)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To prevent conflicts with other Python packages and maintain a clean environment, it's recommended that Tutor should be installed within a Python virtual environment. This is especially important on fresh or shared systems where installing packages globally may require elevated privileges and can interfere with system-level Python dependencies:
-
-.. code-block:: bash
-
-   python3 -m venv env
-   source env/bin/activate
-
-For more details on virtual environments, refer to the official `Python documentation <https://docs.python.org/3/library/venv.html>`_.
 
 Binary release
 ~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,7 +45,7 @@ Check the "tutor" package on Pypi: https://pypi.org/project/tutor. You will need
 
 
 Virtual Environment (Recommended)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To prevent conflicts with other Python packages and maintain a clean environment, it's recommended that Tutor should be installed within a Python virtual environment. This is especially important on fresh or shared systems where installing packages globally may require elevated privileges and can interfere with system-level Python dependencies:
 
@@ -55,7 +55,6 @@ To prevent conflicts with other Python packages and maintain a clean environment
    source env/bin/activate
 
 For more details on virtual environments, refer to the official `Python documentation <https://docs.python.org/3/library/venv.html>`_.
-
 
 Binary release
 ~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -43,6 +43,20 @@ Check the "tutor" package on Pypi: https://pypi.org/project/tutor. You will need
 
 .. _install_binary:
 
+
+Virtual Environment (Recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To prevent conflicts with other Python packages and maintain a clean environment, it's recommended that Tutor should be installed within a Python virtual environment. This is especially important on fresh or shared systems where installing packages globally may require elevated privileges and can interfere with system-level Python dependencies:
+
+.. code-block:: bash
+
+   python3 -m venv env
+   source env/bin/activate
+
+For more details on virtual environments, refer to the official `Python documentation <https://docs.python.org/3/library/venv.html>`_.
+
+
 Binary release
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Description
This PR updates the installation documentation (install.rst) to recommend using a Python virtual environment when installing Tutor. The update is based on recurring issues observed in the community, such as permission errors on fresh systems, and challenges in managing dependencies. These concerns were raised in [Tutor Issue #1198](https://github.com/overhangio/tutor/issues/1198) and discussed in the [Open edX Forum](https://discuss.openedx.org/t/fresh-ubuntu-install/14974), where users reported problems due to system-level Python installations.

### Changes
Added a Virtual Environment (Recommended) section under the "Requirements"