### PR TITLE
feat: add new command `tutor dev hosts` to display status of MFEs

### DIFF
--- a/changelog.d/20250423_154820_muhammad.labeeb_show_exited_containers.md
+++ b/changelog.d/20250423_154820_muhammad.labeeb_show_exited_containers.md
@@ -1,0 +1,1 @@
+ - [Feature] Add new command `tutor dev hosts` that displays status of services. (by @mlabeeb03) 

--- a/tests/commands/test_dev.py
+++ b/tests/commands/test_dev.py
@@ -1,5 +1,7 @@
 import unittest
 
+from tutor.commands import dev
+
 from .base import TestCommandMixin
 
 
@@ -8,3 +10,35 @@ class DevTests(unittest.TestCase, TestCommandMixin):
         result = self.invoke(["dev", "--help"])
         self.assertEqual(0, result.exit_code)
         self.assertIsNone(result.exception)
+
+
+class HostsParsing(unittest.TestCase):
+    def test_host_port_single(self) -> None:
+        ps_output = """{"Publishers":[{"PublishedPort":8000}]}"""
+        host_port = dev.parse_ports(ps_output)
+        self.assertEqual(host_port, [8000])
+
+    def test_host_port_single_empty(self) -> None:
+        ps_output = """{"Publishers":[{"PublishedPort":0}]}"""
+        host_port = dev.parse_ports(ps_output)
+        self.assertEqual(host_port, [])
+
+    def test_host_port_multiple_services(self) -> None:
+        ps_output = """{"Publishers":[{"PublishedPort":0}]}
+        {"Publishers":[{"PublishedPort":8000}]}
+        {"Publishers":[{"PublishedPort":8001}]}"""
+
+        host_port = dev.parse_ports(ps_output)
+        self.assertEqual(host_port, [8000, 8001])
+
+    def test_host_port_multiple_publishers(self) -> None:
+        ps_output = """{"Publishers":[{"PublishedPort":0}, {"PublishedPort":3276}, {"PublishedPort":8000}]}"""
+
+        host_port = dev.parse_ports(ps_output)
+        self.assertEqual(host_port, [3276, 8000])
+
+    def test_host_port_multiple_services_publishers(self) -> None:
+        ps_output = """{"Publishers":[{"PublishedPort":0}, {"PublishedPort":3276}, {"PublishedPort":8000}]}
+        {"Publishers":[{"PublishedPort":0}, {"PublishedPort":8001}, {"PublishedPort":8002}]}"""
+        host_port = dev.parse_ports(ps_output)
+        self.assertEqual(host_port, [3276, 8000, 8001, 8002])

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 import typing as t
+from urllib.parse import urlparse
 
 import click
 
+from tutor import config as tutor_config
 from tutor import env as tutor_env
-from tutor import hooks
+from tutor import fmt, hooks, utils
 from tutor.commands import compose
 from tutor.types import Config, get_typed
 from tutor.utils import get_compose_stacks
@@ -43,6 +46,44 @@ class DevContext(compose.BaseComposeContext):
 @click.pass_context
 def dev(context: click.Context) -> None:
     context.obj = DevContext(context.obj.root)
+
+
+def parse_ports(docker_compose_ps_output: str) -> list[int]:
+    """
+    Extracts the ports from the docker ps output in json format.
+    """
+    exposed_ports = []
+    for line in docker_compose_ps_output.splitlines():
+        publishers = json.loads(line)["Publishers"]
+        for publisher in publishers:
+            port = publisher["PublishedPort"]
+            if port:
+                exposed_ports.append(port)
+    return exposed_ports
+
+
+@click.command(help="List the status of all services.")
+@click.pass_obj
+def hosts(context: compose.BaseComposeContext) -> None:
+    config = tutor_config.load(context.root)
+    docker_compose_ps_output = (
+        context.job_runner(config)
+        .docker_compose_output("ps", "--format", "json")
+        .decode()
+    )
+    exposed_ports = parse_ports(docker_compose_ps_output)
+    public_app_hosts: list[tuple[str, ...]] = [("URL", "STATUS")]
+    for host in hooks.Filters.APP_PUBLIC_HOSTS.iterate(context.NAME):
+        public_app_host = tutor_env.render_str(
+            config, "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://" + host
+        )
+        port = urlparse(public_app_host).port
+        status_marker = " ✅" if port in exposed_ports else ""
+        public_app_hosts.append((public_app_host, status_marker))
+    fmt.echo(utils.format_table(public_app_hosts))
+
+
+dev.add_command(hosts)
 
 
 @hooks.Actions.COMPOSE_PROJECT_STARTED.add()


### PR DESCRIPTION
closes #1204 
This PR fixes the issue mentioned in #1204 which is the lack of information for running MFEs.
Added new command `tutor dev hosts` that displays the status of all MFE hosts in the dev environment.