### PR TITLE
feat: better stop on start

### DIFF
--- a/changelog.d/20250513_150323_regis_stop_on_start.md
+++ b/changelog.d/20250513_150323_regis_stop_on_start.md
@@ -1,0 +1,1 @@
+- [Improvement] When running `local/dev start/run`, run `dev/local stop` less frequently. Also, make sure that we detect only running docker compose projects associated to Tutor. (by @regisb)

--- a/tutor/commands/compose.py
+++ b/tutor/commands/compose.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import typing as t
 
@@ -48,6 +49,18 @@ class ComposeTaskRunner(BaseComposeTaskRunner):
                 args += ["-f", docker_compose_path]
         args += ["--project-name", self.project_name, *command]
         return args
+
+    def is_running(self) -> bool:
+        """
+        Return True if some containers from this project are running.
+        """
+        running_projects = [
+            entry["Name"]
+            for entry in json.loads(
+                self.docker_compose_output("ls", "--format", "json").decode("utf-8")
+            )
+        ]
+        return self.project_name in running_projects
 
     def docker_compose(self, *command: str) -> int:
         """

--- a/tutor/commands/dev.py
+++ b/tutor/commands/dev.py
@@ -11,7 +11,6 @@ from tutor import env as tutor_env
 from tutor import fmt, hooks, utils
 from tutor.commands import compose
 from tutor.types import Config, get_typed
-from tutor.utils import get_compose_stacks
 
 
 class DevTaskRunner(compose.ComposeTaskRunner):
@@ -93,10 +92,7 @@ def _stop_on_local_start(root: str, config: Config, project_name: str) -> None:
     started.
     """
     runner = DevTaskRunner(root, config)
-    if (
-        runner.project_name in get_compose_stacks()
-        and project_name != runner.project_name
-    ):
+    if project_name != runner.project_name and runner.is_running():
         runner.docker_compose("stop")
 
 

--- a/tutor/commands/local.py
+++ b/tutor/commands/local.py
@@ -6,7 +6,6 @@ from tutor import env as tutor_env
 from tutor import hooks
 from tutor.commands import compose
 from tutor.types import Config, get_typed
-from tutor.utils import get_compose_stacks
 
 
 class LocalTaskRunner(compose.ComposeTaskRunner):
@@ -49,10 +48,7 @@ def _stop_on_dev_start(root: str, config: Config, project_name: str) -> None:
     started.
     """
     runner = LocalTaskRunner(root, config)
-    if (
-        runner.project_name in get_compose_stacks()
-        and project_name != runner.project_name
-    ):
+    if project_name != runner.project_name and runner.is_running():
         runner.docker_compose("stop")
 
 

--- a/tutor/utils.py
+++ b/tutor/utils.py
@@ -246,18 +246,6 @@ def check_output(*command: str) -> bytes:
         raise exceptions.TutorError(f"Command failed: {literal_command}") from e
 
 
-def get_compose_stacks() -> list[str]:
-    """
-    Returns a list of names of all running docker compose projects
-    """
-    return [
-        entry["Name"]
-        for entry in json.loads(
-            check_output("docker", "compose", "ls", "--format", "json").decode("utf-8")
-        )
-    ]
-
-
 def warn_macos_docker_memory() -> None:
     try:
         check_macos_docker_memory()


### PR DESCRIPTION
When we run `local/dev start` we expect that any running `dev/local` project will be stopped. Previously, we were running `docker compose ls` twice, and for all running Compose projects on the server. We changed this behaviour:

1. By swapping the project name check and the check for running compose projects, we run `docker compose ls` just once: for dev in local mode, and vice versa.
2. By checking only Compose projects in the context of local/dev. That way we ignore any other non-tutor project.