### PR TITLE
feat: only wait for tutor managed jobs while running k8s

### DIFF
--- a/changelog.d/20250514_161945_muhammad.labeeb_only_filter_tutor_jobs_in_k8s.md
+++ b/changelog.d/20250514_161945_muhammad.labeeb_only_filter_tutor_jobs_in_k8s.md
@@ -1,0 +1,1 @@
+-   [Improvement] Do not wait for non tutor jobs while running k8s. (by @mlabeeb03)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -7,9 +7,8 @@ import click
 
 from tutor import config as tutor_config
 from tutor import env as tutor_env
-from tutor import exceptions, fmt, hooks
+from tutor import exceptions, fmt, hooks, serialize, utils
 from tutor import interactive as interactive_config
-from tutor import serialize, utils
 from tutor.commands import jobs
 from tutor.commands.config import save as config_save_command
 from tutor.commands.context import BaseTaskContext
@@ -187,7 +186,7 @@ class K8sTaskRunner(BaseTaskRunner):
 
     def active_job_names(self) -> List[str]:
         """
-        Return a list of active job names
+        Return a list of active job names that are managed by tutor.
         Docs:
         https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#list-job-v1-batch
 
@@ -197,7 +196,10 @@ class K8sTaskRunner(BaseTaskRunner):
         api = K8sClients.instance().batch_api
         return [
             job.metadata.name
-            for job in api.list_namespaced_job(k8s_namespace(self.config)).items
+            for job in api.list_namespaced_job(
+                k8s_namespace(self.config),
+                label_selector="app.kubernetes.io/managed-by=tutor",
+            ).items
             if job.status.active
         ]
 


### PR DESCRIPTION
closes #1206
This PR is an improvement that fixes the issue mentioned in #1206 
Now we are only filtering jobs that are managed by tutor. This allows running tutor jobs even if other non tutor jobs are running the same namespace.