### PR TITLE
build: update setup-python action to fix release issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         # https://github.com/actions/setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: 'pip'


### PR DESCRIPTION
Github release is failing https://github.com/overhangio/tutor/actions/runs/15110643974/job/42469163148 due to some cache issue on setup python action. It is happening because the action is dependent on a deprecated cache action. Updating it to v5 fixes it https://github.com/actions/setup-python/issues/1085