### PR TITLE
Set charset utf8mb4 for all dbs

### DIFF
--- a/changelog.d/20250520_174054_andres_set_charset_for_all_dbs.md
+++ b/changelog.d/20250520_174054_andres_set_charset_for_all_dbs.md
@@ -1,0 +1,1 @@
+- [Improvement] Set charset utf8mb4 for all databases, not only ran by Tutor. (by @angonz)

--- a/tutor/templates/apps/openedx/config/partials/auth.yml
+++ b/tutor/templates/apps/openedx/config/partials/auth.yml
@@ -16,9 +16,7 @@ DATABASES:
     ATOMIC_REQUESTS: true
     OPTIONS:
       init_command: "SET sql_mode='STRICT_TRANS_TABLES'"
-      {%- if RUN_MYSQL %}
       charset: "utf8mb4"
-      {%- endif %}
 EMAIL_HOST_USER: "{{ SMTP_USERNAME }}"
 EMAIL_HOST_PASSWORD: "{{ SMTP_PASSWORD }}"
 {{ patch("openedx-auth") }}


### PR DESCRIPTION
#890 enclosed `charset: "utf8mb3"` in a `{%- if RUN_MYSQL %}` block. This was to fix an issue with the upgrade from Olive to Palm.
Later on, the charset was changed to **utf8mb4** by #1084. However, the setting was still enclosed in the condition to apply only when the DB is run by Tutor.
As a result, external databases are not open with **utf8mb4** charset.
