### PR TITLE
fix: Fix the 'ln' command that fails silently

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -172,7 +172,8 @@ COPY --link --chown=$APP_USER_ID:$APP_USER_ID --from=nodejs-requirements /opened
 COPY --link --chown=$APP_USER_ID:$APP_USER_ID --from=nodejs-requirements /openedx/edx-platform/node_modules /openedx/node_modules
 
 # Symlink node_modules such that we can bind-mount the edx-platform repository
-RUN ln -s /openedx/node_modules /openedx/edx-platform/node_modules
+RUN rm -rf /openedx/edx-platform/node_modules && \
+    ln -s /openedx/node_modules /openedx/edx-platform/node_modules
 
 ENV PATH=/openedx/venv/bin:./node_modules/.bin:/openedx/nodeenv/bin:${PATH}
 ENV VIRTUAL_ENV=/openedx/venv/


### PR DESCRIPTION
- This command takes the form of: `ln -s source_directory target_directory`.

- If the `target_directory` already exists on the file system, the command will fail with a message that is similar to what is shown below.

	`ln: failed to create symbolic link 'target_directory': File exists`

- This message is not being logged (most likely due to how Docker's buildkit logs messages) and the build process fails when the '/scripts/copy-node-modules.sh' script is executed.

- This fix adds a 'rm' command to first remove the 'target_directory' before the 'ln' command is executed.