### PR TITLE
fix: support `plugins install ...` without pip, or pip outside path

### DIFF
--- a/changelog.d/20250527_092311_regis_plugin_install_without_pip.md
+++ b/changelog.d/20250527_092311_regis_plugin_install_without_pip.md
@@ -1,0 +1,1 @@
+- [Bugfix] Support plugin installation with unexpected `pip` path and/or uv. (by @regisb)


### PR DESCRIPTION
This change addresses two issues:

1. When running tutor as `.venv/bin/tutor ...`, we might not have the right `pip` in the PATH. To resolve this, we install plugins with `python -m pip install ...`.
2. When pip is not available, but `uv` is, we should be using the latter, not the former.

Close #1228.