### PR TITLE
build: separate bootstrap-dev and bootstrap-dev-plugins to fix Gitlab builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Print info about the current python installation
         run: make ci-info
       - name: Install requirements
-        run: make bootstrap-dev
+        run: make bootstrap-dev-plugins
 
       ##### Run tests, generate bundle
       # - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,11 @@ coverage-browse-report: coverage-html ## Open the HTML report in the browser
 bundle: ## Bundle the tutor package in a single "dist/tutor" executable
 	pyinstaller tutor.spec
 
-bootstrap-dev: ## Install dev requirements and all supported plugins
-	pip install .[full,dev]
+bootstrap-dev: ## Install dev requirements
+	pip install .[dev]
+
+bootstrap-dev-plugins: bootstrap-dev  ## Install dev requirements and all plugins
+	pip install .[full]
 
 pull-base-images: # Manually pull base images
 	docker image pull docker.io/ubuntu:22.04


### PR DESCRIPTION
Gitlab build uses bootstrap-dev to install dependencies during release pipeline. This fails for new/major releases as the plugin versions are not available on Pypi. This PR re-adds bootstrap-dev-plugins (removed in https://github.com/overhangio/tutor/commit/cd96a9f22f614fe05037141ee6fef16398d49568#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) to keep dev and plugin installation separate 