### PR TITLE
feat: add max-log-requests argument in command tutor k8s logs

### DIFF
--- a/changelog.d/20250707_171130_muhammad.labeeb_add_max_log_request.md
+++ b/changelog.d/20250707_171130_muhammad.labeeb_add_max_log_request.md
@@ -1,0 +1,1 @@
+- [Feature] Add max-log-requests parameter for command `tutor k8s logs`. (by @mlabeeb03)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -439,23 +439,36 @@ def exec_command(context: K8sContext, service: str, args: List[str]) -> None:
 @click.option("-c", "--container", help="Print the logs of this specific container")
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
 @click.option("--tail", type=int, help="Number of lines to show from each container")
+@click.option(
+    "-m",
+    "--max-log-requests",
+    "max_log_requests",
+    type=int,
+    help="Maximum allowed concurrency while streaming logs",
+)
 @click.argument("service")
 @click.pass_obj
 def logs(
-    context: K8sContext, container: str, follow: bool, tail: bool, service: str
+    context: K8sContext,
+    container: str,
+    follow: bool,
+    tail: bool,
+    max_log_requests: int,
+    service: str,
 ) -> None:
     config = tutor_config.load(context.root)
 
     command = ["logs"]
     selectors = ["app.kubernetes.io/name=" + service] if service else []
     command += resource_selector(config, *selectors)
-
     if container:
         command += ["-c", container]
     if follow:
         command += ["--follow"]
     if tail is not None:
         command += ["--tail", str(tail)]
+    if max_log_requests is not None:
+        command += ["--max-log-requests", str(max_log_requests)]
 
     utils.kubectl(*command)
 


### PR DESCRIPTION
closes #1050 
This PR solves the issue mentioned in #1050 that states that we can not display logs if more than 5 pods are running.
The goal of this PR is to change maximum allowed concurrency while running the `tutor k8s logs` command. 