### PR TITLE
chore: Update Redis

### DIFF
--- a/changelog.d/20250728_145408_codewithemad_update_redis.md
+++ b/changelog.d/20250728_145408_codewithemad_update_redis.md
@@ -1,0 +1,1 @@
+- [Improvement] Redis version upgraded to 7.4.5. (by @CodeWithEmad)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -87,7 +87,7 @@ This configuration parameter defines which MySQL Docker image to use.
 
 .. https://hub.docker.com/_/redis/tags
 
-- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.2.4"``)
+- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.4.5"``)
 
 This configuration parameter defines which Redis Docker image to use.
 

--- a/tutor/templates/apps/redis/redis.conf
+++ b/tutor/templates/apps/redis/redis.conf
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/redis/redis/6.0/redis.conf
+# https://raw.githubusercontent.com/redis/redis/7.4.5/redis.conf
 port 6379
 
 tcp-backlog 511

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -24,7 +24,7 @@ DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.7"
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/redis/tags
-DOCKER_IMAGE_REDIS: "docker.io/redis:7.2.4"
+DOCKER_IMAGE_REDIS: "docker.io/redis:7.4.5"
 # https://hub.docker.com/r/devture/exim-relay/tags
 DOCKER_IMAGE_SMTP: "docker.io/devture/exim-relay:4.96-r1-0"
 EDX_PLATFORM_REPOSITORY: "https://github.com/openedx/edx-platform.git"


### PR DESCRIPTION
This will update the version of Redis from 7.2.4 to 7.4.5.

P.S. There's a version 8.0.3, but since it's a major update, I preferred to go with the latest 7.x.x