### PR TITLE
depr: remove webui plugin as it is deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ci-test-bundle: ## Run basic tests on bundle
 	yes "" | ./dist/tutor config save --interactive
 	./dist/tutor config save
 	./dist/tutor plugins list
-	./dist/tutor plugins enable android discovery forum license mfe minio notes webui xqueue
+	./dist/tutor plugins enable android discovery forum license mfe minio notes xqueue
 	./dist/tutor plugins list
 	./dist/tutor license --help
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Features
 * 100% `open source <https://github.com/overhangio/tutor>`__
 * Runs entirely on Docker
 * World-famous 1-click `installation and upgrades <https://docs.tutor.edly.io/install.html>`__
-* Comes with batteries included: `theming <https://github.com/overhangio/indigo>`__, `SCORM <https://github.com/overhangio/openedx-scorm-xblock>`__, `HTTPS <https://docs.tutor.edly.io/configuration.html#ssl-tls-certificates-for-https-access>`__, `web-based administration interface <https://github.com/overhangio/tutor-webui>`__, `mobile app <https://github.com/overhangio/tutor-android>`__, `custom translations <https://docs.tutor.edly.io/configuration.html#adding-custom-translations>`__...
+* Comes with batteries included: `theming <https://github.com/overhangio/indigo>`__, `SCORM <https://github.com/overhangio/openedx-scorm-xblock>`__, `HTTPS <https://docs.tutor.edly.io/configuration.html#ssl-tls-certificates-for-https-access>`__, `mobile app <https://github.com/overhangio/tutor-android>`__, `custom translations <https://docs.tutor.edly.io/configuration.html#adding-custom-translations>`__...
 * Extensible architecture with `plugins <https://docs.tutor.edly.io/plugins/index.html>`__
 * Works with `Kubernetes <https://docs.tutor.edly.io/k8s.html>`__
 * No technical skill required with the `zero-click Tutor AWS image <https://docs.tutor.edly.io/install.html#zero-click-aws-installation>`__

--- a/changelog.d/20250805_140709_abdul.muqadim_remove_webui_from_tutor_nightly.md
+++ b/changelog.d/20250805_140709_abdul.muqadim_remove_webui_from_tutor_nightly.md
@@ -1,0 +1,1 @@
+💥[Deprecation] Remove deprecated WebUI plugin in favor of Tutor Deck. (by @Abdul-Muqadim-Arbisoft)

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -10,5 +10,4 @@ tutor-jupyter@git+https://github.com/overhangio/tutor-jupyter@main
 tutor-mfe@git+https://github.com/overhangio/tutor-mfe@main
 tutor-minio@git+https://github.com/overhangio/tutor-minio@main
 tutor-notes@git+https://github.com/overhangio/tutor-notes@main
-tutor-webui@git+https://github.com/overhangio/tutor-webui@main
 tutor-xqueue@git+https://github.com/overhangio/tutor-xqueue@main

--- a/tutor/plugins/v0.py
+++ b/tutor/plugins/v0.py
@@ -287,7 +287,6 @@ class OfficialPlugin(BasePlugin):
         "mfe",
         "minio",
         "notes",
-        "webui",
         "xqueue",
     ]
 


### PR DESCRIPTION
- remove webui plugin  as it is deprecated.
- check tutor-webui deprecation issue for more info: https://github.com/overhangio/tutor-webui/issues/28