### PR TITLE
Ensure LMS_ROOT_URL is defined in i18n and assets settings modules

### DIFF
--- a/tutor/templates/build/openedx/settings/partials/assets.py
+++ b/tutor/templates/build/openedx/settings/partials/assets.py
@@ -14,5 +14,7 @@ XQUEUE_INTERFACE = {
 DATABASES = {
     "default": {},
 }
+LMS_BASE = "{{ LMS_HOST }}:8000"
+LMS_ROOT_URL = "http://{}".format(LMS_BASE)
 
 {{ patch("openedx-common-assets-settings") }}

--- a/tutor/templates/build/openedx/settings/partials/i18n.py
+++ b/tutor/templates/build/openedx/settings/partials/i18n.py
@@ -9,6 +9,8 @@ XQUEUE_INTERFACE = {
 DATABASES = {
     "default": {},
 }
+LMS_BASE = "{{ LMS_HOST }}:8000"
+LMS_ROOT_URL = "http://{}".format(LMS_BASE)
 
 derive_settings(__name__)
 


### PR DESCRIPTION
When running the management commands related to translations and static assets in `tutor/templates/build/openedx/Dockerfile`, `LMS_ROOT_URL` needs to have a valid value, otherwise the build will fail.

Tutor has relied on there being a valid value for `LMS_ROOT_URL` present in `lms/envs/common.py` and `cms/envs/common.py`, but upcoming changes to [edx-platform (#37045)](https://github.com/openedx/edx-platform/pull/37045) will create the need to ensure `LMS_ROOT_URL` has a valid value.

This PR stemmed from the discussion [here in edx-platform #37045](https://github.com/openedx/edx-platform/pull/37045#discussion_r2237782226).