### PR TITLE
docs: Fix spacing for code syntax rendering

### DIFF
--- a/docs/tutor.rst
+++ b/docs/tutor.rst
@@ -72,7 +72,7 @@ Releasing a version includes two phases:
 
 1. Add changes and generate individual changelog entries:
 
-- run ``make changelog-entry``(or ``scriv create``) command - It will create changelog entries in a folder named changelog.d for the changes user has done for releasing a new version.
+- run ``make changelog-entry`` (or ``scriv create``) command - It will create changelog entries in a folder named changelog.d for the changes user has done for releasing a new version.
 - Commit and merge all the changes including the changelog entries. e.g this `commit <https://github.com/overhangio/tutor-discovery/commit/e30a78936d63439bde069aeff11960585bd81592>`__.
 
 2. Update version and compile changelogs:


### PR DESCRIPTION
Hi all, reading the docs I noticed an error in code formatting due to a missing space:

<img width="472" height="82" alt="image" src="https://github.com/user-attachments/assets/4d87f89b-d070-4bc3-a462-4e2942f52722" />

This fixes that! 😄 