### PR TITLE
Add auto-mounts for openedx-events and opaque-keys

### DIFF
--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -111,6 +111,8 @@ hooks.Filters.MOUNTED_DIRECTORIES.add_items(
         ("openedx", "edx-ora2"),
         ("openedx", "edx-search"),
         ("openedx", "openedx-learning"),
+        ("openedx", "openedx-events"),
+        ("openedx", "opaque-keys"),
         ("openedx", r"platform-plugin-.*"),
     ]
 )

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -110,8 +110,7 @@ hooks.Filters.MOUNTED_DIRECTORIES.add_items(
         ("openedx", "edx-enterprise"),
         ("openedx", "edx-ora2"),
         ("openedx", "edx-search"),
-        ("openedx", "openedx-learning"),
-        ("openedx", "openedx-events"),
+        ("openedx", r"openedx-.*"),
         ("openedx", "opaque-keys"),
         ("openedx", r"platform-plugin-.*"),
     ]


### PR DESCRIPTION
Sometimes I need to work on repos like `openedx-events` or `opaque-keys`, and it's inconvenient to do so without Tutor knowing to automatically include those in all of the edx-platform images. This just adds them to the list of repos that are auto-detected as being used in the `edx-platform` images like LMS and CMS images.

With this change, users can just use e.g. `tutor mounts add openedx-events` 