### PR TITLE
feat: add support for pruning unused ConfigMaps in k8s commands

### DIFF
--- a/changelog.d/20250729_164653_dmytro.kaliberda_cleanup_configmaps_using_prune.md
+++ b/changelog.d/20250729_164653_dmytro.kaliberda_cleanup_configmaps_using_prune.md
@@ -1,0 +1,1 @@
+ - [Feature] Add support for pruning unused Kubernetes ConfigMaps with `--prune-configmaps` via the Tutor CLI. (by @dkaliberda)

--- a/tutor/commands/k8s.py
+++ b/tutor/commands/k8s.py
@@ -277,8 +277,13 @@ Press enter when you are ready to continue"""
     ),
 )
 @click.argument("names", metavar="name", nargs=-1)
+@click.option(
+    "--prune-configmaps",
+    is_flag=True,
+    help="Prune ConfigMaps that are no longer in the manifests",
+)
 @click.pass_obj
-def start(context: K8sContext, names: List[str]) -> None:
+def start(context: K8sContext, names: List[str], prune_configmaps: bool) -> None:
     config = tutor_config.load(context.root)
     # Create namespace, if necessary
     # Note that this step should not be run for some users, in particular those
@@ -303,12 +308,14 @@ def start(context: K8sContext, names: List[str]) -> None:
                 context.root,
                 "--selector",
                 "app.kubernetes.io/component notin (job,namespace)",
+                prune_configmaps=prune_configmaps,
             )
         else:
             kubectl_apply(
                 context.root,
                 "--selector",
                 f"app.kubernetes.io/name={name}",
+                prune_configmaps=prune_configmaps,
             )
 
 
@@ -516,13 +523,33 @@ def upgrade(context: click.Context, from_release: Optional[str]) -> None:
     name="apply",
 )
 @click.argument("args", nargs=-1)
+@click.option(
+    "--prune-configmaps",
+    is_flag=True,
+    help="Prune ConfigMaps that are no longer in the manifests",
+)
 @click.pass_obj
-def apply_command(context: K8sContext, args: List[str]) -> None:
-    kubectl_apply(context.root, *args)
+def apply_command(context: K8sContext, args: List[str], prune_configmaps: bool) -> None:
+    kubectl_apply(context.root, *args, prune_configmaps=prune_configmaps)
 
 
-def kubectl_apply(root: str, *args: str) -> None:
-    utils.kubectl("apply", "--kustomize", tutor_env.pathjoin(root), *args)
+def kubectl_apply(root: str, *args: str, prune_configmaps: bool = False) -> None:
+    """
+    Apply Kubernetes resources using kubectl with optional ConfigMap pruning.
+
+    Args:
+        root: Root directory containing kustomization files
+        *args: Additional arguments to pass to kubectl apply
+        prune_configmaps: Enable pruning of ConfigMaps no longer in manifests
+    """
+    cmd_args = ["apply", "--kustomize", tutor_env.pathjoin(root)]
+
+    if prune_configmaps:
+        # Correct format is core/v1/ConfigMap
+        cmd_args.extend(["--prune", "--prune-allowlist", "core/v1/ConfigMap"])
+
+    cmd_args.extend(args)
+    utils.kubectl(*cmd_args)
 
 
 @click.command(help="Print status information for all k8s resources")


### PR DESCRIPTION
Introduces a `--prune-configmaps` option to the `start` and `apply` commands, allowing users to prune ConfigMaps no longer present in the manifests.

Updates the `kubectl_apply` function to handle this option by adding appropriate kubectl arguments for pruning. Enhances Kubernetes resource management by reducing clutter and maintaining consistency in ConfigMaps.

https://discuss.openedx.org/t/old-configmaps-from-previous-builds-remain-in-the-k8s-cluster/16630