### PR TITLE
fix: exclude stray venv directory from sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 
 /build/
 /dist/
+/venv/
 
 # Unit test/ coverage reports
 .coverage

--- a/changelog.d/20251104_183216_ahmed.khalid_ulmo.md
+++ b/changelog.d/20251104_183216_ahmed.khalid_ulmo.md
@@ -1,0 +1,2 @@
+- [Bugfix] Fix packaging issue where a stray `venv/` directory was included in the source distribution (sdist)
+for previous releases. The build configuration now correctly excludes the `venv/` folder from package archives. (by @ahmed-arb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,10 @@ include = [
   "LICENSE.txt",
   ".hatch_build.py",
 ]
-exclude = ["tests*"]
+exclude = [
+  "tests*",
+  "venv*"
+]
 
 [tool.hatch.metadata]
 # Allow github dependencies in plugins.txt


### PR DESCRIPTION
A regression introduced in 19.0.3 caused the source distribution (sdist) published to PyPI to include a `venv/` directory that should not be part of the package. This update adds the necessary exclusions to the Hatch sdist configuration to ensure `venv/` is not bundled in future releases.

Related issue: https://github.com/overhangio/tutor/issues/1250