### PR TITLE
feat: add data dir to lms and cms jobs

### DIFF
--- a/changelog.d/20251107_121314_mlabeeb03_mount_data_dir_to_jobs.md
+++ b/changelog.d/20251107_121314_mlabeeb03_mount_data_dir_to_jobs.md
@@ -1,0 +1,1 @@
+- [Improvement] Mount data directory to lms and cms jobs. (by @mlabeeb03)

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -26,6 +26,7 @@ services:
         - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
         - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
         - ../apps/openedx/config:/openedx/config:ro
+        - ../../data/lms-job:/openedx/data
         {%- for mount in iter_mounts(MOUNTS, "openedx", "lms-job") %}
         - {{ mount }}
         {%- endfor %}
@@ -40,6 +41,7 @@ services:
         - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
         - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
         - ../apps/openedx/config:/openedx/config:ro
+        - ../../data/cms-job:/openedx/data
         {%- for mount in iter_mounts(MOUNTS, "openedx", "cms-job") %}
         - {{ mount }}
         {%- endfor %}


### PR DESCRIPTION
closes #1263 

Docker compose file now mounts a separate data dir to lms and cms jobs. This is so that when do commands are run, their logs can persist. Analytics plugins such as Aspects would now be able to use these logs.

We use separate mounts because:
1. Multiple containers writing to the same destination is going to cause issues, and so we try to avoid that as much as we can.
2. In kubernetes, many providers do not support ReadWriteMany volumes, and we want to preserve some sort of consistency between Compose and Kubernetes.