### PR TITLE
feat: update openedx version to teak.3 tag

### DIFF
--- a/changelog.d/20251203_125947_ahmed.khalid_release.md
+++ b/changelog.d/20251203_125947_ahmed.khalid_release.md
@@ -1,0 +1,1 @@
+- [Feature] Update OPENEDX_COMMON_VERSION to teak.3 tag (by @ahmed-arb)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,7 +132,7 @@ Open edX customisation
 
 This defines the git repository from which you install Open edX platform code. If you run an Open edX fork with custom patches, set this to your own git repository. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
 
-- ``OPENEDX_COMMON_VERSION`` (default: ``"release/teak.2"``, or ``master`` in :ref:`Tutor Main <main>`)
+- ``OPENEDX_COMMON_VERSION`` (default: ``"release/teak.3"``, or ``master`` in :ref:`Tutor Main <main>`)
 
 This defines the default version that will be pulled from all Open edX git repositories.
 

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -61,7 +61,7 @@ OPENEDX_LMS_UWSGI_WORKERS: 2
 OPENEDX_MYSQL_DATABASE: "openedx"
 OPENEDX_MYSQL_USERNAME: "openedx"
 # the common version will be automatically set to "master" in the main branch
-OPENEDX_COMMON_VERSION: "release/teak.2"
+OPENEDX_COMMON_VERSION: "release/teak.3"
 OPENEDX_EXTRA_PIP_REQUIREMENTS: []
 MYSQL_HOST: "mysql"
 MYSQL_PORT: 3306


### PR DESCRIPTION
Update Open edX Docker image tag to release/teak.3 now that teak.3 tag is out.
https://discuss.openedx.org/t/new-release-open-edx-teak-3-is-out/17717