### PR TITLE
fix broken links

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,7 +25,7 @@ Requirements
     - Recommended configuration: 8 GB RAM, 4 CPU, 25 GB disk space
 
 .. note::
-    On Mac OS, by default, containers are allocated 2 GB of RAM, which is not enough. You should follow `these instructions from the official Docker documentation <https://docs.docker.com/docker-for-mac/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon. If the deployment fails because of insufficient memory during database migrations, check the :ref:`relevant section in the troubleshooting guide <migrations_killed>`.
+    On Mac OS, by default, containers are allocated 2 GB of RAM, which is not enough. You should follow `these instructions from the official Docker documentation <https://docs.docker.com/desktop/settings-and-maintenance/settings/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon. If the deployment fails because of insufficient memory during database migrations, check the :ref:`relevant section in the troubleshooting guide <migrations_killed>`.
 
 
 Virtual Environment (Recommended)

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -65,7 +65,7 @@ If the above command does not work, you should fix your Docker installation. Som
 
 Open edX requires at least 4 GB RAM, in particular, to run the SQL migrations. If the ``tutor local launch`` command dies after displaying "Running migrations", you most probably need to buy more memory or add swap to your machine.
 
-On macOS, by default, Docker allocates at most 2 GB of RAM to containers. ``launch`` tries to check the current allocation and outputs a warning if it can't find a value of at least 4 GB. Follow `these instructions from the official Docker documentation <https://docs.docker.com/docker-for-mac/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon.
+On macOS, by default, Docker allocates at most 2 GB of RAM to containers. ``launch`` tries to check the current allocation and outputs a warning if it can't find a value of at least 4 GB. Follow `these instructions from the official Docker documentation <https://docs.docker.com/desktop/settings-and-maintenance/settings/#advanced>`__ to allocate at least 4-5 GB to the Docker daemon.
 
 If migrations were killed halfway, there is a good chance that the MySQL database is in a state that is hard to recover from. The easiest way to recover is to delete all the MySQL data and restart the launch process. After more memory has been allocated to the Docker daemon, run::
 


### PR DESCRIPTION
broken links for mac RAM troubleshooting

https://docs.docker.com/docker-for-mac/#advanced

redirects to:

https://docs.docker.com/desktop/setup/sign-in/#advanced

which doesn't have the required information. I've updated the link to the new location