### PR TITLE
feat: add ability to not delete namespace while running tutor k8s delete command

### DIFF
--- a/changelog.d/20251217_184231_mlabeeb03_exclude_namespace_parameter.md
+++ b/changelog.d/20251217_184231_mlabeeb03_exclude_namespace_parameter.md
@@ -1,0 +1,1 @@
+- [Improvement] Add ability to not delete namespace while running `tutor k8s delete` command. (by @mlabeeb03)


### PR DESCRIPTION
closes #1018 

Add a new argument `--exclude-namespace` to `tutor k8s delete` command. This results in deleting all the resources that were already being deleted except the namespace. This is done by running the existing command in dry-run mode and filtering the required resources from the output of that commmand.