### PR TITLE
fix: duplicate mounted volumes error

### DIFF
--- a/changelog.d/20260101_162439_faraz.maqsood_duplicate_mounts_error.md
+++ b/changelog.d/20260101_162439_faraz.maqsood_duplicate_mounts_error.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix duplicate volume mounts error caused by same repo/package name(e.g. openedx-scorm-xblock) matching multiple expressions(("openedx", r".*[xX][bB]lock.*"), ("openedx", r"openedx-.*")) in MOUNTED_DIRECTORIES. (by @Faraz32123)

--- a/tutor/plugins/openedx.py
+++ b/tutor/plugins/openedx.py
@@ -142,7 +142,7 @@ def _mount_python_requirements_build(
     for image_name, regex in hooks.Filters.MOUNTED_DIRECTORIES.iterate():
         if re.match(regex, name):
             volumes.append((image_name, f"mnt-{name}"))
-    return volumes
+    return list(set(volumes))
 
 
 @hooks.Filters.COMPOSE_MOUNTS.add()
@@ -156,7 +156,7 @@ def _mount_edx_platform_python_requirements_compose(
         if re.match(regex, folder_name):
             # Bind-mount requirement
             volumes.append((image_name, f"/mnt/{folder_name}"))
-    return volumes
+    return list(set(volumes))
 
 
 def iter_mounted_directories(mounts: list[str], image_name: str) -> t.Iterator[str]:


### PR DESCRIPTION
[MOUNTED_DIRECTORIES](https://github.com/overhangio/tutor/blob/c95b073a793b10e0fbeb0fcf9e6f03783a7d4ee3/tutor/plugins/openedx.py#L106C1-L116C2) has 2 expressions(`("openedx", r".*[xX][bB]lock.*")`, `("openedx", r"openedx-.*")`) which can overlap for some repositories(e.g. `openedx-scorm-xblock`) results in duplicate mounted volumes. After our changes, we get rid of the duplicates in `docker-compose.yml: services.cms.volumes` array.

**Before:**
<img width="1419" height="416" alt="Screenshot 2026-01-01 at 4 19 06 PM" src="https://github.com/user-attachments/assets/827af4e3-4f7f-4f39-ad2c-f700aedc73c2" />

**After:**
<img width="1419" height="502" alt="Screenshot 2026-01-01 at 4 19 52 PM" src="https://github.com/user-attachments/assets/d95de266-4025-4f04-9e90-0b5c211c80a1" />
