### PR TITLE
fix: Update MongoDB to v7.0.28

### DIFF
--- a/changelog.d/20260107_111147_faraz.maqsood_release.md
+++ b/changelog.d/20260107_111147_faraz.maqsood_release.md
@@ -1,0 +1,1 @@
+- [BugFix] Update MongoDB to v7.0.28, resolving a critical upstream security issue https://jira.mongodb.org/browse/SERVER-115508. (by @Faraz32123)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -75,7 +75,7 @@ This configuration parameter defines which Caddy Docker image to use.
 
 This configuration parameter defines which Meilisearch Docker image to use.
 
-- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:7.0.7"``)
+- ``DOCKER_IMAGE_MONGODB`` (default: ``"docker.io/mongo:7.0.28"``)
 
 This configuration parameter defines which MongoDB Docker image to use.
 

--- a/tutor/commands/upgrade/compose.py
+++ b/tutor/commands/upgrade/compose.py
@@ -227,7 +227,7 @@ def upgrade_from_quince(context: click.Context, config: Config) -> None:
     click.echo(fmt.title("Upgrading from Quince"))
     upgrade_mongodb(context, config, "5.0.26", "5.0")
     upgrade_mongodb(context, config, "6.0.14", "6.0")
-    upgrade_mongodb(context, config, "7.0.7", "7.0")
+    upgrade_mongodb(context, config, "7.0.28", "7.0")
 
 
 def upgrade_mongodb(

--- a/tutor/commands/upgrade/k8s.py
+++ b/tutor/commands/upgrade/k8s.py
@@ -315,7 +315,7 @@ def upgrade_from_quince(config: Config) -> None:
     click.echo(fmt.title("Upgrading from Quince"))
     upgrade_mongodb(config, "5.0.26", "5.0")
     upgrade_mongodb(config, "6.0.14", "6.0")
-    upgrade_mongodb(config, "7.0.7", "7.0")
+    upgrade_mongodb(config, "7.0.28", "7.0")
 
 
 def upgrade_mongodb(

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -19,7 +19,7 @@ DOCKER_IMAGE_CADDY: "docker.io/caddy:2.7.4"
 # https://hub.docker.com/r/getmeili/meilisearch/tags
 DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
 # https://hub.docker.com/_/mongo/tags
-DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.7"
+DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.28"
 # https://hub.docker.com/_/mysql/tags
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"


### PR DESCRIPTION
This upgrade resolves a critical upstream security issue [jira.mongodb.org/browse/SERVER-115508](https://jira.mongodb.org/browse/SERVER-115508).

MongoDB lets clients use network compression (zlib, snappy, zstd). A flaw in the server's zlib implementation allows an unauthenticated client to send a malformed compressed message that causes MongoDB to read and return uninitialized heap memory.

When compressed, MongoDB's wire protocol includes:
- a header
- a length field
- compressed data

The vulnerability arises when the length in the compressed data header does not match the length in the protocol header. MongoDB does not correctly validate this mismatch, which may lead to reading beyond the intended buffer and leaking uninitialized memory.
Upgrading to v7.0.28 includes the upstream fix and eliminates this risk.

- close #1324 