### PR TITLE
fix: Add correct redis url settings for event-bus

### DIFF
--- a/changelog.d/20260109_002919_faraz.maqsood_add_event_bus_defaults.md
+++ b/changelog.d/20260109_002919_faraz.maqsood_add_event_bus_defaults.md
@@ -1,0 +1,1 @@
+- [BugFix] Add correct EVENT_BUS_REDIS_CONNECTION_URL settings for event-bus. (by @Faraz32123)

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -246,5 +246,11 @@ OPENEDX_LEARNING = {
     }
 }
 
+# edx-event-bus-redis settings
+EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
+EVENT_BUS_REDIS_CONNECTION_URL = 'redis://@redis:6379/'
+EVENT_BUS_TOPIC_PREFIX = 'dev'
+EVENT_BUS_CONSUMER = 'edx_event_bus_redis.RedisEventConsumer'
+
 {{ patch("openedx-common-settings") }}
 ######## End of settings common to LMS and CMS


### PR DESCRIPTION
- `edx-event-bus-redis` is added in default requirements recently, but its setting named `EVENT_BUS_REDIS_CONNECTION_URL` was still using old devstack settings [redis://:password@edx.devstack.redis:6379/](https://github.com/openedx/edx-platform/blob/2b478146f862d9d024dbd1c020c588dd5362fae1/cms/envs/devstack.py#L307).
- In this PR, we have added event-bus related settings as defaults in both lms & cms.
- close #1278 