### PR TITLE
fix: revert python version upgrade to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ instructions, because git commits are used to generate release notes:
 
 - [Bugfix] Add correct EVENT_BUS_REDIS_CONNECTION_URL settings for event-bus. (by @Faraz32123)
 
-- [Bugfix] The version of Python and Node.js were behind what edx-platform currently supports so update both. Python is now 3.12 and Node.js is now 24.
+- [Bugfix] Update Node.js to version 24. Python remains at 3.11 as upstream edx-platform does not fully support it yet.
 
 <a id='changelog-20.0.5'></a>
 ## v20.0.5 (2026-01-07)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -29,9 +29,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Install pyenv
 # https://www.python.org/downloads/
 # https://github.com/pyenv/pyenv/releases
-ARG PYTHON_VERSION=3.12.12
+ARG PYTHON_VERSION=3.11.8
 ENV PYENV_ROOT=/opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.6.20 --depth 1
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.3.36 --depth 1
 
 # Install Python
 RUN $PYENV_ROOT/bin/pyenv install $PYTHON_VERSION


### PR DESCRIPTION
This PR reverts the Python version upgrade from the previous commit while keeping the Node.js 24 update.

### Changes:
- Revert Python from 3.12 back to 3.11 and pyenv from 2.6.20 to 2.3.36
- Keep Node.js upgrade to version 24
- Update changelog to reflect that Python 3.12 is not yet fully supported by upstream edx-platform

### Reason:
The build failed with Python 3.12 because edx-platform does not fully support it yet. We'll revisit the Python upgrade once upstream compatibility is confirmed. You can see the complete error log [here](https://github.com/overhangio/tutor/pull/1329#discussion_r2695862152).