### PR TITLE
chore: updated change log to declare breaking change

### DIFF
--- a/changelog.d/20260120_142137_eemaanamir_remove_site_id.md
+++ b/changelog.d/20260120_142137_eemaanamir_remove_site_id.md
@@ -1,1 +1,1 @@
-- [Bugfix] Stop early SITE_ID override and document correct email configuration (by @eemaanamir)
+- 💥[Bugfix] Stop early SITE_ID override and document correct email configuration (by @eemaanamir)


### PR DESCRIPTION
Issue: https://github.com/overhangio/tutor/issues/1182

Original PR: https://github.com/overhangio/tutor/pull/1323


This PR updates the changelog to mark this change as breaking. For existing instances, reverting `SITE_ID` back to its default value (`1`) can cause issues because no corresponding site exists. As a result, site maintainers will need to manually patch the site ID back to what they need, as described in the updated documentation.