### PR TITLE
revert: fix: stop early SITE_ID override and document correct email configuration

### DIFF
--- a/changelog.d/20260120_142137_eemaanamir_remove_site_id.md
+++ b/changelog.d/20260120_142137_eemaanamir_remove_site_id.md
@@ -1,1 +1,0 @@
-- [Bugfix] Stop early SITE_ID override and document correct email configuration (by @eemaanamir)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -320,33 +320,6 @@ This configuration parameter sets the Contact Email.
 
 This configuration parameter sets the Platform Name.
 
-SITE_ID and email branding
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-We do **not** override ``SITE_ID`` during initial Tutor setup.
-
-Leaving ``SITE_ID`` unset allows Django to create sites correctly:
-
-- ``example.com`` → ``id = 1``
-- LMS site → ``id = 2``
-
-Overriding ``SITE_ID`` too early may result in the LMS site using ``id = 3`` and
-``example.com`` using ``id = 2``.
-
-When to set SITE_ID
-*******************
-
-For features that rely on site context (for example bulk emails or other
-personalized emails), explicitly set::
-
-    SITE_ID = 2
-
-Add this setting in the ``openedx-common-settings`` patch::
-
-    patches:
-      openedx-common-settings: |
-        SITE_ID = 2
-
 Custom Open edX docker image
 ----------------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -226,20 +226,3 @@ The handy :ref:`update-mysql-authentication-plugin <update_mysql_authentication_
 
     tutor local do update-mysql-authentication-plugin $(tutor config printvalue OPENEDX_MYSQL_USERNAME)
     tutor local do update-mysql-authentication-plugin $(tutor config printvalue MYSQL_ROOT_USERNAME)
-
-Emails sent without correct branding
-------------------------------------
-
-**Cause**
-
-When the platform cannot determine the site from the request, it falls back to
-``SITE_ID``. If ``SITE_ID`` points to ``example.com``, emails are sent without
-proper branding.
-
-**Fix**
-
-Ensure your LMS site uses ``id = 2`` and set::
-
-    SITE_ID = 2
-
-in the ``openedx-common-settings`` patch, then restart Tutor.

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -86,6 +86,9 @@ CACHES = {
     }
 }
 
+# The default Django contrib site is the one associated to the LMS domain name. 1 is
+# usually "example.com", so it's the next available integer.
+SITE_ID = 2
 
 # Contact addresses
 CONTACT_MAILING_ADDRESS = "{{ PLATFORM_NAME }} - {% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"


### PR DESCRIPTION
Reverts:
* https://github.com/overhangio/tutor/pull/1323
* https://github.com/overhangio/tutor/pull/1345

As I wrote in the [original issue](https://github.com/overhangio/tutor/issues/1182#issuecomment-3849922783), I don't think that removing the SITE_ID override fixes the email configuration bug. But it does introduce a breaking change, which is disrupting developers (by causing SiteNotFound error). I believe that this would also break production sites upon release of Tutor v21.1.0, which is counter to the Tutor philosophy of avoiding breaking changes between major versions.

I think we should revert this change for now, and then discuss a way forward to fix the email bug. I think there's a way to do it that doesn't cause a breaking change. But if we must do a breaking change, we should communicate it well keep it on `main` (not `release`) so that it doesn't break Ulmo sites.