### PR TITLE
docs: No need to unset SERVICE_VARIANT when testing

### DIFF
--- a/docs/tutorials/edx-platform.rst
+++ b/docs/tutorials/edx-platform.rst
@@ -152,7 +152,6 @@ Then, run unit tests with ``pytest`` commands::
 
     # Run tests on common apps
     unset DJANGO_SETTINGS_MODULE
-    unset SERVICE_VARIANT
     pytest common
     pytest openedx
     pytest xmodule


### PR DESCRIPTION
This removes a step which used to be required in order to smoothly
run all openedx-platform unit tests, but is now superfluous.

In the past, SERVICE_VARIANT was drawn from the container environment, so
trying to run LMS tests from the CMS container would fail, and vice-versa.
However, as of https://github.com/openedx/openedx-platform/pull/37746,
SERVICE_VARIANT is now automatically set to the appropriate value in the base
django settings modules at `openedx-platform/(lms,cms)/envs/common.py`.
Thus,  setting DJANGO_SETTINGS_MODULE is sufficient to get the correct
SERVICE_VARIANT django setting for testing.
________________

I've tested this locally.
