### PR TITLE
v21.0.2

### DIFF
--- a/changelog.d/20260312_150520_upgrade_ulmo_2.md
+++ b/changelog.d/20260312_150520_upgrade_ulmo_2.md
@@ -1,0 +1,1 @@
+- [Feature] Upgrade to Open edX Ulmo.2 (by @ahmed-arb)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,7 +132,7 @@ Open edX customisation
 
 This defines the git repository from which you install Open edX platform code. If you run an Open edX fork with custom patches, set this to your own git repository. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
 
-- ``OPENEDX_COMMON_VERSION`` (default: ``"release/ulmo.1"``, or ``master`` in :ref:`Tutor Main <main>`)
+- ``OPENEDX_COMMON_VERSION`` (default: ``"release/ulmo.2"``, or ``master`` in :ref:`Tutor Main <main>`)
 
 This defines the default version that will be pulled from all Open edX git repositories.
 

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -2,7 +2,7 @@ import os
 
 # Increment this version number to trigger a new release. See
 # docs/tutor.html#versioning for information on the versioning scheme.
-__version__ = "21.0.1"
+__version__ = "21.0.2"
 
 # The version suffix will be appended to the actual version, separated by a
 # dash. Use this suffix to differentiate between the actual released version and

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -58,12 +58,6 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Patches in Main node
 {%- else %}
 # Patches in non-Main mode (i.e., Release mode)
-## Update edx-search to 4.4.0 to fix the Catalog MFE
-RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/1db37f309f710fa54e2372b1a3ca6dbb9b05640f.patch | git am
-## Bump Django 5.2.7->5.2.11 for security fix
-RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/5f95ef0ba14baf145652d93be33176c51f926c6e.patch | git am
-## Upgrade edx-ora2 to fix pkg_resources build error
-RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/e05ed0afb1a291635a91efc8c1620d06858f65c6.patch | git am
 {%- endif %}
 
 {# Add new patches like this: #}

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -61,7 +61,7 @@ OPENEDX_LMS_UWSGI_WORKERS: 2
 OPENEDX_MYSQL_DATABASE: "openedx"
 OPENEDX_MYSQL_USERNAME: "openedx"
 # the common version will be automatically set to "master" in the main branch
-OPENEDX_COMMON_VERSION: "release/ulmo.1"
+OPENEDX_COMMON_VERSION: "release/ulmo.2"
 OPENEDX_EXTRA_PIP_REQUIREMENTS: []
 MYSQL_HOST: "mysql"
 MYSQL_PORT: 3306


### PR DESCRIPTION
## Upgrade to Open edX Ulmo.2
This PR upgrades the Tutor installation from Open edX Ulmo.1 (v21.0.1) to Ulmo.2 (v21.0.2).
### Changes:
- Bumped version to 21.0.2
- Updated OPENEDX_COMMON_VERSION to release/ulmo.2
- Removed Ulmo.1-specific patches from Dockerfile (now included in upstream Ulmo.2):
  - edx-search 4.4.0 update
  - Django 5.2.7→5.2.11 security fix
  - edx-ora2 pkg_resources build error fix
- Updated documentation to reflect new version

### Testing

- [x] Verify `tutor images build openedx` completes successfully
