### PR TITLE
fix: add openedx-private to permissions script for Libraries v2 uploads

### DIFF
--- a/changelog.d/20260316_165716_fix_libraries_v2_upload_permissions.md
+++ b/changelog.d/20260316_165716_fix_libraries_v2_upload_permissions.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix permission denied error when uploading files to Libraries v2 by adding `/mounts/openedx-private` to the permissions script. This resolves the issue where the `openedx-media-private` directory was mounted but ownership was not properly set for the app user. (by @ahmed-arb)

--- a/tutor/templates/apps/permissions/setowners.sh
+++ b/tutor/templates/apps/permissions/setowners.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-setowner $OPENEDX_USER_ID /mounts/lms /mounts/cms /mounts/openedx
+setowner $OPENEDX_USER_ID /mounts/lms /mounts/cms /mounts/openedx /mounts/openedx-private
 {% if RUN_MEILISEARCH %}setowner 1000 /mounts/meilisearch{% endif %}
 {% if RUN_MONGODB %}setowner 999 /mounts/mongodb{% endif %}
 {% if RUN_MYSQL %}setowner 999 /mounts/mysql{% endif %}


### PR DESCRIPTION
This fixes the PermissionError when uploading files to Libraries v2 by ensuring the openedx-media-private directory has correct ownership set. The directory was being mounted in docker-compose.yml but wasn't included in the setowners.sh script.

Resolves: https://github.com/overhangio/tutor/issues/1353