### PR TITLE
Switch from commonLabels to labels, retaining backward compatibility

### DIFF
--- a/changelog.d/20260401_120050_ali.abbas02_commonlabels_depreciation.md
+++ b/changelog.d/20260401_120050_ali.abbas02_commonlabels_depreciation.md
@@ -1,0 +1,1 @@
+- [Improvement] Replace deprecated `commonLabels` with `labels` in `kustomization.yml` to fix kustomize deprecation warning. The `kustomization-commonlabels` patch is preserved for backwards compatibility. (by @<Syed-Ali-Abbas-568>)

--- a/docs/reference/patches.rst
+++ b/docs/reference/patches.rst
@@ -138,6 +138,16 @@ File: ``kustomization.yml``
 
 File: ``kustomization.yml``
 
+.. warning::
+   ``kustomization-commonlabels`` is deprecated and will be removed in the next major release. 
+   Please use ``kustomization-labels`` for adding custom labels.
+
+``kustomization-labels``
+==============================
+
+File: ``kustomization.yml``
+
+
 .. patch:: kustomization-configmapgenerator
 
 ``kustomization-configmapgenerator``

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -18,13 +18,24 @@ commonAnnotations:
   app.kubernetes.io/version: {{ TUTOR_VERSION }}
 
 # labels (and label selectors) added to all Resources
-# https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/commonlabels/
-commonLabels:
-  app.kubernetes.io/instance: openedx-{{ ID }}
-  app.kubernetes.io/part-of: openedx
-  app.kubernetes.io/managed-by: tutor
-  {{ patch("kustomization-commonlabels")|indent(2) }}
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/
+labels:
+- pairs:
+    app.kubernetes.io/instance: openedx-{{ ID }}
+    app.kubernetes.io/part-of: openedx
+    app.kubernetes.io/managed-by: tutor
+    {{ patch("kustomization-labels")|indent(4) }}
+  includeSelectors: true
+  includeTemplates: true
+{%- if patch("kustomization-commonlabels") %}
+# TODO: Depreciated Kustomiation-commonlabels, only being kept for backward compatibility
+- pairs:
+    {{ patch("kustomization-commonlabels")|indent(4) }}
+  includeSelectors: true
+  includeTemplates: true
+{%- endif %}
+
 
 configMapGenerator:
 - name: caddy-config

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -29,7 +29,7 @@ labels:
   includeSelectors: true
   includeTemplates: true
 {%- if patch("kustomization-commonlabels") %}
-# TODO: Depreciated Kustomiation-commonlabels, only being kept for backward compatibility
+# TODO: Deprecated Kustomiation-commonlabels, only being kept for backward compatibility
 - pairs:
     {{ patch("kustomization-commonlabels")|indent(4) }}
   includeSelectors: true


### PR DESCRIPTION
Fixes the deprecation warning when running kustomize commands:

```
Warning: 'commonLabels' is deprecated. Please use 'labels' instead.
```

Replaces `commonLabels` with the new `labels` field using `includeSelectors: true` and `includeTemplates: true` to preserve identical behaviour.

The old `kustomization-commonlabels` patch slot is kept alongside the new `kustomization-labels` slot for backwards compatibility with existing plugins.

Resolves [#1359](https://github.com/overhangio/tutor/issues/1359#issuecomment-4083328211)