### PR TITLE
fix: apply upstream security patch to remove activation_key exposure from account API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ instructions, because git commits are used to generate release notes:
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.0.4'></a>
+## v21.0.4 (2026-04-10)
+
+- [Security] Backport fix to remove `activation_key` exposure from `/api/user/v1/accounts/{username}`, preventing email verification bypass via OAuth2 password grant flow (source: upstream edx-platform commit 21cead238466ca398ba368518f1d3288431d68f4).
+
 <a id='changelog-21.0.3'></a>
 ## v21.0.3 (2026-04-09)
 

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -2,7 +2,7 @@ import os
 
 # Increment this version number to trigger a new release. See
 # docs/tutor.html#versioning for information on the versioning scheme.
-__version__ = "21.0.3"
+__version__ = "21.0.4"
 
 # The version suffix will be appended to the actual version, separated by a
 # dash. Use this suffix to differentiate between the actual released version and

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -64,6 +64,9 @@ RUN git config --global user.email "tutor@overhang.io" \
 {# RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}
 {# Include a comment on why the patch is neccessary. #}
 
+# SECURITY FIX: remove activation_key exposure from account API
+RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/21cead238466ca398ba368518f1d3288431d68f4.patch | git am
+
 {{ patch("openedx-dockerfile-post-git-checkout") }}
 
 ##### Empty layer with just the repo at the root.


### PR DESCRIPTION
### Description
This PR applies an upstream security fix from Open edX by backporting the following commit into the Tutor Open edX Docker image, which removes the activation_key field from the /api/user/v1/accounts/{username} response to prevent a vulnerability where attackers could bypass email verification by combining OAuth2 password grant access for inactive users with direct account activation:

https://github.com/openedx/openedx-platform/commit/21cead238466ca398ba368518f1d3288431d68f4

This issue is part of the security advisory discussed here:
https://discuss.openedx.org/t/security-upcoming-security-release-for-openedx-platform-2026-03-27/18655

This PR is proposed because the fix is not yet included in an official Open edX Ulmo release used by Tutor. Applying it at build time ensures that Tutor deployments are protected until the fix is available upstream in a stable release.