### PR TITLE
fix: apply activation_key security patch only in release mode

### DIFF
--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -58,14 +58,14 @@ RUN git config --global user.email "tutor@overhang.io" \
 # Patches in Main node
 {%- else %}
 # Patches in non-Main mode (i.e., Release mode)
+
+# SECURITY FIX: remove activation_key exposure from account API
+RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/21cead238466ca398ba368518f1d3288431d68f4.patch | git am
 {%- endif %}
 
 {# Add new patches like this: #}
 {# RUN curl -fsSL https://github.com/openedx/edx-platform/commit/<GITSHA1>.patch | git am #}
 {# Include a comment on why the patch is neccessary. #}
-
-# SECURITY FIX: remove activation_key exposure from account API
-RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/21cead238466ca398ba368518f1d3288431d68f4.patch | git am
 
 {{ patch("openedx-dockerfile-post-git-checkout") }}
 


### PR DESCRIPTION
### Description

Follow-up to #1366. The security patch added in that PR fails when building against `master` edx-platform because the upstream commit is already present there, so `git am` fails with "patch already applied". This breaks builds on Tutor Main.

This PR moves the RUN command inside the non-Main (Release mode) branch of the existing `TUTOR_BRANCH_IS_MAIN` conditional, matching the pattern that the template already establishes for git patches.

### Testing

- Build openedx image in release mode (`EDX_PLATFORM_VERSION` pointing to `release/ulmo.x`): patch applies as before.
- Build openedx image in main mode (`EDX_PLATFORM_VERSION=master`): patch is skipped, build no longer fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)