### PR TITLE
fix!: Raise exceptions when a plugin fails to load.

### DIFF
--- a/changelog.d/20260820_134659_kshitij_error_on_missing_plugin.md
+++ b/changelog.d/20260820_134659_kshitij_error_on_missing_plugin.md
@@ -1,0 +1,4 @@
+- [Feature] `tutor` now treats a missing plugin as an error and will now return 
+  a non-zero exit code if a plugin fails to load. This ensures that a missing 
+  or broken plugin stops deployment instead of potentially leading to a broken 
+  deployment (by @xitij2000)

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -1,6 +1,9 @@
 import unittest
+from unittest.mock import patch
 
+from tutor import hooks
 from tutor.__about__ import __version__
+from tutor.commands.cli import check_plugin_errors, cli, main
 
 from .base import TestCommandMixin
 
@@ -21,3 +24,43 @@ class CliTests(unittest.TestCase, TestCommandMixin):
         self.assertEqual(0, result.exit_code)
         self.assertIsNone(result.exception)
         self.assertRegex(result.output, rf"cli, version {__version__}\n")
+
+    def test_ignore_plugin_errors_flag_in_help(self) -> None:
+        """The --ignore-plugin-errors flag should appear in help output."""
+        result = self.invoke(["--help"])
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("ignore-plugin-errors", result.output)
+
+
+class PluginErrorExitCodeTests(unittest.TestCase):
+    """Tests for plugin error exit code behavior."""
+
+    def _add_plugin_error(self) -> None:
+        """Add a test plugin error."""
+        hooks.Filters.PLUGIN_ERRORS.add_item(("badplugin", "test error"))
+
+    def _clear_plugin_errors(self) -> None:
+        """Clear all plugin errors by clearing all callbacks."""
+        hooks.Filters.PLUGIN_ERRORS.clear()
+
+    def setUp(self) -> None:
+        self._clear_plugin_errors()
+        self.addCleanup(self._clear_plugin_errors)
+
+    def test_check_plugin_errors_exits_with_code_1(self) -> None:
+        """_check_plugin_errors should exit with code 1 when errors exist."""
+        self._add_plugin_error()
+        with self.assertRaises(SystemExit) as cm:
+            check_plugin_errors(False)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_check_plugin_errors_no_exit_when_ignored(self) -> None:
+        """_check_plugin_errors should not exit when --ignore-plugin-errors is set."""
+        self._add_plugin_error()
+        # Should not raise
+        check_plugin_errors(True)
+
+    def test_check_plugin_errors_no_exit_when_no_errors(self) -> None:
+        """_check_plugin_errors should not exit when there are no errors."""
+        # Should not raise
+        check_plugin_errors(False)

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -46,7 +46,9 @@ class PluginErrorExitCodeTests(PluginsTestCase):
             hooks.Filters.PLUGIN_ERRORS.add_item(("badplugin", "test error"))
 
     @contextmanager
-    def _prev_config(self, ignore_errors=False) -> Iterator[tuple[Context, Config]]:
+    def _prev_config(
+        self, ignore_errors: bool = False
+    ) -> Iterator[tuple[Context, Config]]:
         with temporary_root() as root:
             context = Context(root, ignore_errors)
             yield context, tutor_config.get_user(root)

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -1,6 +1,12 @@
 import unittest
+from contextlib import contextmanager
 
+from tests.helpers import PluginsTestCase, temporary_root
+from tutor import config as tutor_config
+from tutor import hooks
 from tutor.__about__ import __version__
+from tutor.commands.cli import check_plugin_errors
+from tutor.commands.context import Context
 
 from .base import TestCommandMixin
 
@@ -8,8 +14,8 @@ from .base import TestCommandMixin
 class CliTests(unittest.TestCase, TestCommandMixin):
     def test_help(self) -> None:
         result = self.invoke(["help"])
-        self.assertEqual(0, result.exit_code)
         self.assertIsNone(result.exception)
+        self.assertEqual(0, result.exit_code)
 
     def test_cli_help(self) -> None:
         result = self.invoke(["--help"])
@@ -21,3 +27,45 @@ class CliTests(unittest.TestCase, TestCommandMixin):
         self.assertEqual(0, result.exit_code)
         self.assertIsNone(result.exception)
         self.assertRegex(result.output, rf"cli, version {__version__}\n")
+
+    def test_ignore_plugin_errors_flag_in_help(self) -> None:
+        """The --ignore-plugin-errors flag should appear in help output."""
+        result = self.invoke(["--help"])
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("ignore-plugin-errors", result.output)
+
+
+class PluginErrorExitCodeTests(PluginsTestCase):
+    """Tests for plugin error exit code behavior."""
+
+    def _add_plugin_error(self) -> None:
+        """Add a test plugin error."""
+        with hooks.Contexts.PLUGINS.enter():
+            hooks.Filters.PLUGIN_ERRORS.add_item(("badplugin", "test error"))
+
+    @contextmanager
+    def _prev_config(self, ignore_errors=False):
+        with temporary_root() as root:
+            context = Context(root, ignore_errors)
+            yield context, tutor_config.get_user(root)
+
+    def test_check_plugin_errors_exits_with_code_1(self) -> None:
+        """_check_plugin_errors should exit with code 1 when errors exist."""
+        with self._prev_config() as (context, config):
+            self._add_plugin_error()
+            with self.assertRaises(SystemExit) as cm:
+                check_plugin_errors(context, config)
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_check_plugin_errors_no_exit_when_ignored(self) -> None:
+        """_check_plugin_errors should not exit when --ignore-plugin-errors is set."""
+        with self._prev_config(ignore_errors=True) as (context, config):
+            self._add_plugin_error()
+            # Should not raise
+            check_plugin_errors(context, config)
+
+    def test_check_plugin_errors_no_exit_when_no_errors(self) -> None:
+        """_check_plugin_errors should not exit when there are no errors."""
+        with self._prev_config() as (context, config):
+            # Should not raise
+            check_plugin_errors(context, config)

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -1,5 +1,6 @@
 import unittest
 from contextlib import contextmanager
+from typing import Iterator
 
 from tests.helpers import PluginsTestCase, temporary_root
 from tutor import config as tutor_config
@@ -7,6 +8,7 @@ from tutor import hooks
 from tutor.__about__ import __version__
 from tutor.commands.cli import check_plugin_errors
 from tutor.commands.context import Context
+from tutor.types import Config
 
 from .base import TestCommandMixin
 
@@ -44,7 +46,7 @@ class PluginErrorExitCodeTests(PluginsTestCase):
             hooks.Filters.PLUGIN_ERRORS.add_item(("badplugin", "test error"))
 
     @contextmanager
-    def _prev_config(self, ignore_errors=False):
+    def _prev_config(self, ignore_errors=False) -> Iterator[tuple[Context, Config]]:
         with temporary_root() as root:
             context = Context(root, ignore_errors)
             yield context, tutor_config.get_user(root)

--- a/tutor/commands/cli.py
+++ b/tutor/commands/cli.py
@@ -70,10 +70,13 @@ class TutorCli(click.Group):
             # That's ok, we just ignore it.
             return
         if not self.IS_ROOT_READY:
-            hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
-            self.IS_ROOT_READY = True
-            for cmd in hooks.Filters.CLI_COMMANDS.iterate():
-                self.add_command(cmd)
+            try:
+                hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
+                self.IS_ROOT_READY = True
+                for cmd in hooks.Filters.CLI_COMMANDS.iterate():
+                    self.add_command(cmd)
+            except Exception as exc:
+                raise click.ClickException(f"Error enabling plugins: {exc}") from exc
 
 
 @click.group(

--- a/tutor/commands/cli.py
+++ b/tutor/commands/cli.py
@@ -32,6 +32,23 @@ def main() -> None:
         sys.exit(1)
 
 
+def check_plugin_errors(ignore: bool) -> None:
+    """
+    Check for plugin loading errors and exit with code 1 if any were found,
+    unless --ignore-plugin-errors is set.
+    """
+    errors: list[tuple[str, str]] = list(hooks.Filters.PLUGIN_ERRORS.iterate())
+    if not errors:
+        return
+    for plugin, error in errors:
+        if ignore:
+            fmt.echo_alert(f"Failed to enable plugin '{plugin}': {error}")
+        else:
+            fmt.echo_error(f"Plugin '{plugin}' failed to load: {error}")
+    if errors and not ignore:
+        sys.exit(1)
+
+
 class TutorCli(click.Group):
     """
     Dynamically load subcommands at runtime.
@@ -70,13 +87,10 @@ class TutorCli(click.Group):
             # That's ok, we just ignore it.
             return
         if not self.IS_ROOT_READY:
-            try:
-                hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
-                self.IS_ROOT_READY = True
-                for cmd in hooks.Filters.CLI_COMMANDS.iterate():
-                    self.add_command(cmd)
-            except Exception as exc:
-                raise click.ClickException(f"Error enabling plugins: {exc}") from exc
+            hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
+            self.IS_ROOT_READY = True
+            for cmd in hooks.Filters.CLI_COMMANDS.iterate():
+                self.add_command(cmd)
 
 
 @click.group(
@@ -102,18 +116,36 @@ class TutorCli(click.Group):
     is_flag=True,
     help="Print this help",
 )
+@click.option(
+    "--ignore-plugin-errors",
+    "ignore_plugin_errors",
+    is_flag=True,
+    default=False,
+    help="Continue running even if plugin loading fails",
+)
 @click.pass_context
-def cli(context: click.Context, root: str, show_help: bool) -> None:
+def cli(
+    context: click.Context, root: str, show_help: bool, ignore_plugin_errors: bool
+) -> None:
     if utils.is_root():
         fmt.echo_alert(
             "You are running Tutor as root. This is strongly not recommended. If you are doing this in order to access"
             " the Docker daemon, you should instead add your user to the 'docker' group. (see https://docs.docker.com"
             "/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)"
         )
-    context.obj = Context(root)
+    context.obj = Context(root, ignore_plugin_errors)
     context.help_option_names = ["-h", "--help"]
     if context.invoked_subcommand is None or show_help:
         click.echo(context.get_help())
+
+
+@cli.result_callback()
+@click.pass_context
+def _after_subcommand(context: click.Context, result: t.Any, **kwargs: t.Any) -> None:
+    """
+    Runs after the invoked subcommand has finished.
+    """
+    check_plugin_errors(context.obj.ignore_plugin_errors)
 
 
 @click.command(help="Print this help", name="help")

--- a/tutor/commands/cli.py
+++ b/tutor/commands/cli.py
@@ -6,7 +6,7 @@ import typing as t
 import appdirs
 import click
 
-from tutor import exceptions, fmt, hooks, utils
+from tutor import config, exceptions, fmt, hooks, utils
 from tutor.__about__ import __app__, __version__
 from tutor.commands.config import config_command
 from tutor.commands.context import Context
@@ -16,6 +16,7 @@ from tutor.commands.k8s import k8s
 from tutor.commands.local import local
 from tutor.commands.mounts import mounts_command
 from tutor.commands.plugins import plugins_command
+from tutor.types import Config
 
 
 def main() -> None:
@@ -30,6 +31,45 @@ def main() -> None:
     except exceptions.TutorError as e:
         fmt.echo_error(f"Error: {e.args[0]}")
         sys.exit(1)
+
+
+def check_plugin_errors(context: Context, prev_config: Config) -> None:
+    """
+    Check for plugin loading errors and exit with code 1 if any were found,
+    unless --ignore-plugin-errors is set or if the config file was changed.
+
+    In case the config file was changed, the errors might no longer be valid
+    with the new configuration, so warn the user instead.
+    """
+    errors: list[tuple[str, str]] = list(hooks.Filters.PLUGIN_ERRORS.iterate())
+    ignore = context.ignore_plugin_errors
+    if not errors:
+        return
+    has_config_changed = config.get_user(context.root) != prev_config
+    for plugin, error in errors:
+        if has_config_changed or ignore:
+            fmt.echo_alert(f"Failed to enable plugin '{plugin}': {error}")
+        else:
+            fmt.echo_error(f"Plugin '{plugin}' failed to load: {error}")
+    if has_config_changed:
+        fmt.echo_alert(
+            "The Config file was changed by running this command "
+            "so the above errors might no longer be valid. \n"
+            "Please run 'tutor config save' to check if the errors persist."
+        )
+    # Only exit with an error code if:
+    #   - errors are not being ignored
+    #   - the config file hasn't changed
+    #   - no exception has already been raised that would return its own error codek
+    if ignore or has_config_changed:
+        return
+    match sys.exc_info()[1]:
+        case None:
+            sys.exit(1)
+        case SystemExit(code=code) | click.exceptions.Exit(exit_code=code) if code == 0:
+            sys.exit(1)
+        case _:
+            return
 
 
 class TutorCli(click.Group):
@@ -70,13 +110,10 @@ class TutorCli(click.Group):
             # That's ok, we just ignore it.
             return
         if not self.IS_ROOT_READY:
-            try:
-                hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
-                self.IS_ROOT_READY = True
-                for cmd in hooks.Filters.CLI_COMMANDS.iterate():
-                    self.add_command(cmd)
-            except Exception as exc:
-                raise click.ClickException(f"Error enabling plugins: {exc}") from exc
+            hooks.Actions.PROJECT_ROOT_READY.do(ctx.params["root"])
+            self.IS_ROOT_READY = True
+            for cmd in hooks.Filters.CLI_COMMANDS.iterate():
+                self.add_command(cmd)
 
 
 @click.group(
@@ -102,16 +139,33 @@ class TutorCli(click.Group):
     is_flag=True,
     help="Print this help",
 )
+@click.option(
+    "--ignore-plugin-errors",
+    "ignore_plugin_errors",
+    is_flag=True,
+    default=False,
+    help="Continue running even if plugin loading fails",
+)
 @click.pass_context
-def cli(context: click.Context, root: str, show_help: bool) -> None:
+def cli(
+    context: click.Context, root: str, show_help: bool, ignore_plugin_errors: bool
+) -> None:
     if utils.is_root():
         fmt.echo_alert(
             "You are running Tutor as root. This is strongly not recommended. If you are doing this in order to access"
             " the Docker daemon, you should instead add your user to the 'docker' group. (see https://docs.docker.com"
             "/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)"
         )
-    context.obj = Context(root)
+    context.obj = Context(root, ignore_plugin_errors)
     context.help_option_names = ["-h", "--help"]
+    # If showing help, don't check plugin errors
+    is_showing_help = show_help or context.invoked_subcommand in (
+        None,
+        help_command.name,
+    )
+    if not is_showing_help:
+        init_config = config.get_user(root)
+        context.call_on_close(lambda: check_plugin_errors(context.obj, init_config))
     if context.invoked_subcommand is None or show_help:
         click.echo(context.get_help())
 

--- a/tutor/commands/context.py
+++ b/tutor/commands/context.py
@@ -12,8 +12,9 @@ class Context:
         $ tutor --root=... local run ...
     """
 
-    def __init__(self, root: str) -> None:
+    def __init__(self, root: str, ignore_plugin_errors: bool = False) -> None:
         self.root = root
+        self.ignore_plugin_errors = ignore_plugin_errors
 
 
 class BaseTaskContext(Context):

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -475,6 +475,15 @@ class Filters:
     #:   regular expression. For instance: ``("openedx", r".*xblock.*")``.
     MOUNTED_DIRECTORIES: Filter[list[tuple[str, str]], []] = Filter()
 
+    #: List of plugins that failed to load, along with the corresponding error
+    #: message. This filter is populated by :py:func:`tutor.plugins.load_all` when
+    #: a plugin raises an exception during loading. It is consumed by the CLI to
+    #: report errors after the subcommand has finished.
+    #:
+    #: :parameter list[tuple[str, str]] errors: list of ``(plugin_name, error_message)``
+    #:   tuples.
+    PLUGIN_ERRORS: Filter[list[tuple[str, str]], []] = Filter()
+
     #: List of plugin indexes that are loaded when we run ``tutor plugins update``. By
     #: default, the plugin indexes are stored in the user configuration. This filter makes
     #: it possible to extend and modify this list with plugins.

--- a/tutor/hooks/catalog.py
+++ b/tutor/hooks/catalog.py
@@ -476,8 +476,8 @@ class Filters:
     MOUNTED_DIRECTORIES: Filter[list[tuple[str, str]], []] = Filter()
 
     #: List of plugins that failed to load, along with the corresponding error
-    #: message. This filter is populated by :py:func:`tutor.plugins.load_all` when
-    #: a plugin raises an exception during loading. It is consumed by the CLI to
+    #: message. This filter is populated by `tutor.plugins.load_all` when a
+    #: plugin raises an exception during loading. It is consumed by the CLI to
     #: report errors after the subcommand has finished.
     #:
     #: :parameter list[tuple[str, str]] errors: list of ``(plugin_name, error_message)``

--- a/tutor/plugins/__init__.py
+++ b/tutor/plugins/__init__.py
@@ -62,6 +62,7 @@ def load_all(names: t.Iterable[str]) -> None:
             load(name)
         except Exception as e:
             fmt.echo_alert(f"Failed to enable plugin '{name}': {e}")
+            raise
     hooks.Actions.PLUGINS_LOADED.do()
 
 

--- a/tutor/plugins/__init__.py
+++ b/tutor/plugins/__init__.py
@@ -61,8 +61,7 @@ def load_all(names: t.Iterable[str]) -> None:
         try:
             load(name)
         except Exception as e:
-            fmt.echo_alert(f"Failed to enable plugin '{name}': {e}")
-            raise
+            hooks.Filters.PLUGIN_ERRORS.add_item((name, str(e)))
     hooks.Actions.PLUGINS_LOADED.do()
 
 

--- a/tutor/plugins/__init__.py
+++ b/tutor/plugins/__init__.py
@@ -61,8 +61,8 @@ def load_all(names: t.Iterable[str]) -> None:
         try:
             load(name)
         except Exception as e:
-            fmt.echo_alert(f"Failed to enable plugin '{name}': {e}")
-            raise
+            with hooks.Contexts.PLUGINS.enter():
+                hooks.Filters.PLUGIN_ERRORS.add_item((name, str(e)))
     hooks.Actions.PLUGINS_LOADED.do()
 
 


### PR DESCRIPTION
When a plugin is missing or throws an error while loading, Tutor continues as normal. At times this has made us recognise issues far later than we'd like. 

This change will raise an error causing the command to return an error and the break the CI flow rather than deploying a broken instance with missing plugins. 

We've considered few alternatives. 

1. Put this behind an option flag such as `--check`, however this flag would need to be added in a lot of places that cause plugins to load. 
2. Adding another command like `tutor doctor` this is a convention that many such tools follow that check the config and environment for errors and suggest fixes. This issue with this is that it will require updating existing usage of tutor to call tutor doctor first. 
3. Creating a plugin for this. We think this is a core feature hat should be part of tutor, but this could potentially be done in a plugin. 