### PR TITLE
v21.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ instructions, because git commits are used to generate release notes:
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.0.5'></a>
+## v21.0.5 (2026-05-05)
+
+- [Bugfix] Fixes wrong LMS_HOST when `tutor dev launch -I` is executed. After this change, it will set to `local.openedx.io` instead of `www.myopenedx.com` (by @muhammadadeeltajamul)
+
+- [Feature] Upgrade OPENEDX_COMMON_VERSION to release/ulmo.3 (by @ahmed-arb)
+
 <a id='changelog-21.0.4'></a>
 ## v21.0.4 (2026-04-10)
 

--- a/changelog.d/20260429_fixed_wrong_host_on_dev_launch.md
+++ b/changelog.d/20260429_fixed_wrong_host_on_dev_launch.md
@@ -1,1 +1,0 @@
-- [Bugfix] Fixes wrong LMS_HOST when `tutor dev launch -I` is executed. After this change, it will set to `local.openedx.io` instead of `www.myopenedx.com` (by @muhammadadeeltajamul)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,7 +132,7 @@ Open edX customisation
 
 This defines the git repository from which you install Open edX platform code. If you run an Open edX fork with custom patches, set this to your own git repository. You may also override this configuration parameter at build time, by providing a ``--build-arg`` option.
 
-- ``OPENEDX_COMMON_VERSION`` (default: ``"release/ulmo.2"``, or ``master`` in :ref:`Tutor Main <main>`)
+- ``OPENEDX_COMMON_VERSION`` (default: ``"release/ulmo.3"``, or ``master`` in :ref:`Tutor Main <main>`)
 
 This defines the default version that will be pulled from all Open edX git repositories.
 

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -2,7 +2,7 @@ import os
 
 # Increment this version number to trigger a new release. See
 # docs/tutor.html#versioning for information on the versioning scheme.
-__version__ = "21.0.4"
+__version__ = "21.0.5"
 
 # The version suffix will be appended to the actual version, separated by a
 # dash. Use this suffix to differentiate between the actual released version and

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -59,8 +59,6 @@ RUN git config --global user.email "tutor@overhang.io" \
 {%- else %}
 # Patches in non-Main mode (i.e., Release mode)
 
-# SECURITY FIX: remove activation_key exposure from account API
-RUN curl -fsSL https://github.com/openedx/openedx-platform/commit/21cead238466ca398ba368518f1d3288431d68f4.patch | git am
 {%- endif %}
 
 {# Add new patches like this: #}

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -61,7 +61,7 @@ OPENEDX_LMS_UWSGI_WORKERS: 2
 OPENEDX_MYSQL_DATABASE: "openedx"
 OPENEDX_MYSQL_USERNAME: "openedx"
 # the common version will be automatically set to "master" in the main branch
-OPENEDX_COMMON_VERSION: "release/ulmo.2"
+OPENEDX_COMMON_VERSION: "release/ulmo.3"
 OPENEDX_EXTRA_PIP_REQUIREMENTS: []
 MYSQL_HOST: "mysql"
 MYSQL_PORT: 3306


### PR DESCRIPTION
## Upgrade to Open edX Ulmo.3
This PR upgrades the Tutor installation from Open edX Ulmo.2 (v21.0.4) to Ulmo.3 (v21.0.5).

## Changes:

- Bumped version to 21.0.5
- Updated OPENEDX_COMMON_VERSION to release/ulmo.3
- Removed Ulmo.2-specific patches from Dockerfile (now included in upstream Ulmo.3)

Closes: https://github.com/overhangio/tutor/issues/1378