### PR TITLE
fix: do not generate redis configmap when RUN_REDIS is False

### DIFF
--- a/changelog.d/20260506_154244_faraz.maqsood_redis_config_map_when_RUN_REDIS_is_false.md
+++ b/changelog.d/20260506_154244_faraz.maqsood_redis_config_map_when_RUN_REDIS_is_false.md
@@ -1,0 +1,1 @@
+- [BugFix] Redis configmap will not be generated & deployed with tutor k8s when RUN_REDIS is False. (by @Faraz32123)

--- a/tutor/templates/kustomization.yml
+++ b/tutor/templates/kustomization.yml
@@ -68,12 +68,14 @@ configMapGenerator:
   options:
     labels:
         app.kubernetes.io/name: openedx
+{% if RUN_REDIS %}
 - name: redis-config
   files:
   - apps/redis/redis.conf
   options:
     labels:
         app.kubernetes.io/name: redis
+{% endif %}
 {{ patch("kustomization-configmapgenerator") }}
 
 {%- if patch("k8s-override") or patch("kustomization-patches") %}


### PR DESCRIPTION
close #1279 