### PR TITLE
docs: add instructions for running migrations

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -366,6 +366,14 @@ Then, the ``openedx`` docker image must be rebuilt::
 
     tutor images build openedx
 
+Then, restart tutor for the changes to take effect::
+
+    tutor local start -d
+
+If your extra requirements have database migrations, those need to be run as well. If you are unsure of whether this is required, it is always good to run this command as it is idempotent::
+
+    tutor local do init
+
 .. _edx_platform_fork:
 
 Running a fork of ``edx-platform``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -368,7 +368,7 @@ Then, the ``openedx`` docker image must be rebuilt::
 
 Then, restart tutor for the changes to take effect::
 
-    tutor local start -d
+    tutor local reboot -d
 
 If your extra requirements have database migrations, those need to be run as well. If you are unsure of whether this is required, it is always good to run this command as it is idempotent::
 

--- a/docs/developing/openedx.rst
+++ b/docs/developing/openedx.rst
@@ -103,6 +103,10 @@ To rebuild assets, you can run the ``build-dev`` NPM script that comes with edx-
 
     tutor dev run lms npm run build-dev
 
+If you've added any new migrations to your codebase, you can run them as well::
+
+    tutor dev run lms ./manage.py lms migrate
+    tutor dev run cms ./manage.py cms migrate
 
 .. _specialized for developer usage:
 


### PR DESCRIPTION
One of the steps in improving our developer documentation as part of #1218. This was raised by Axim where they mentioned we have no mention of how to run migrations in our docs using tutor.