### PR TITLE
Fix/kubernetes v36 no authorization header attached error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ instructions, because git commits are used to generate release notes:
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.0.7'></a>
+## v21.0.7 (2026-05-25)
+
+- [BugFix] Redis configmap will not be generated & deployed with tutor k8s when RUN_REDIS is False. (by @Faraz32123)
+
+- [BugFix] Fix k8s-override patches not applying to jobs by rendering kustomization before renaming job. (by @Faraz32123)
+
+- [Improvement] Add tutorial for customizing and overriding translations, covering theme translation overrides (e.g. Indigo) and managing translations for forked repositories, custom plugins, and additional MFEs. (by @eemaanamir)
+
+- [BugFix] Temporarily pin kubernetes to v35 as kubernetes v36 in-cluster config no longer attaches Authorization header. (by @Faraz32123)
+
 <a id='changelog-21.0.6'></a>
 ## v21.0.6 (2026-05-08)
 

--- a/changelog.d/20260506_154244_faraz.maqsood_redis_config_map_when_RUN_REDIS_is_false.md
+++ b/changelog.d/20260506_154244_faraz.maqsood_redis_config_map_when_RUN_REDIS_is_false.md
@@ -1,1 +1,0 @@
-- [BugFix] Redis configmap will not be generated & deployed with tutor k8s when RUN_REDIS is False. (by @Faraz32123)

--- a/changelog.d/20260506_175622_faraz.maqsood_k8s_override_patch_doesnt_work_on_jobs.md
+++ b/changelog.d/20260506_175622_faraz.maqsood_k8s_override_patch_doesnt_work_on_jobs.md
@@ -1,1 +1,0 @@
-- [BugFix] Fix k8s-override patches not applying to jobs by rendering kustomization before renaming job. (by @Faraz32123)

--- a/changelog.d/20260519_000328_eemaan.amir_custom_translations.md
+++ b/changelog.d/20260519_000328_eemaan.amir_custom_translations.md
@@ -1,1 +1,0 @@
-- [Improvement] Add tutorial for customizing and overriding translations, covering theme translation overrides (e.g. Indigo) and managing translations for forked repositories, custom plugins, and additional MFEs. (by @eemaanamir)

--- a/changelog.d/20260525_231337_faraz.maqsood_kubernetes_v36_no_authorization_header_error.md
+++ b/changelog.d/20260525_231337_faraz.maqsood_kubernetes_v36_no_authorization_header_error.md
@@ -1,1 +1,0 @@
-- [BugFix] Temporarily pin kubernetes to v35 as kubernetes v36 in-cluster config no longer attaches Authorization header. (by @Faraz32123)

--- a/changelog.d/20260525_231337_faraz.maqsood_kubernetes_v36_no_authorization_header_error.md
+++ b/changelog.d/20260525_231337_faraz.maqsood_kubernetes_v36_no_authorization_header_error.md
@@ -1,0 +1,1 @@
+- [BugFix] Temporarily pin kubernetes to v35 as kubernetes v36 in-cluster config no longer attaches Authorization header. (by @Faraz32123)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,8 @@ appdirs
 # TODO: remove 8.3.0 when https://github.com/overhangio/tutor/issues/1276 is resolved completely
 click>=8.0,<8.3.0
 jinja2>=2.10
-kubernetes
+# TODO: remove cap when https://github.com/overhangio/tutor/issues/1390 is resolved
+kubernetes<36.0.0
 mypy
 packaging
 pycryptodome>=3.17.0

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -2,7 +2,7 @@ import os
 
 # Increment this version number to trigger a new release. See
 # docs/tutor.html#versioning for information on the versioning scheme.
-__version__ = "21.0.6"
+__version__ = "21.0.7"
 
 # The version suffix will be appended to the actual version, separated by a
 # dash. Use this suffix to differentiate between the actual released version and


### PR DESCRIPTION
- Temporarily pin kubernetes to v35 as kubernetes v36 in-cluster config no longer attaches Authorization header.
- related issue: https://github.com/kubernetes-client/python/issues/2591
- related tutor issue: https://github.com/overhangio/tutor/issues/1390