### PR TITLE
fix: volume bind-mounts on selinux/fedora

### DIFF
--- a/changelog.d/20260526_124321_regis_fedora_selinux.md
+++ b/changelog.d/20260526_124321_regis_fedora_selinux.md
@@ -1,0 +1,1 @@
+- [Bugfix] Compatibility with Fedora/SELinux systems: volume bind-mounts must indicate that they are shared between different containers. Otherwise, SELinux fails to mount them. (by @regisb)

--- a/tutor/templates/dev/docker-compose.yml
+++ b/tutor/templates/dev/docker-compose.yml
@@ -5,7 +5,7 @@ x-openedx-service:
   tty: true
   volumes:
     # theme files
-    - ../build/openedx/themes:/openedx/themes
+    - ../build/openedx/themes:/openedx/themes:z
 
 services:
   permissions:

--- a/tutor/templates/local/docker-compose.jobs.yml
+++ b/tutor/templates/local/docker-compose.jobs.yml
@@ -23,12 +23,12 @@ services:
         SERVICE_VARIANT: lms
         DJANGO_SETTINGS_MODULE: lms.envs.tutor.production
       volumes:
-        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-        - ../apps/openedx/config:/openedx/config:ro
-        - ../../data/lms-job:/openedx/data
+        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+        - ../apps/openedx/config:/openedx/config:roz
+        - ../../data/lms-job:/openedx/data:z
         {%- for mount in iter_mounts(MOUNTS, "openedx", "lms-job") %}
-        - {{ mount }}
+        - {{ mount }}:z
         {%- endfor %}
       depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB), ("meilisearch", RUN_MEILISEARCH)]|list_if }}
 
@@ -38,12 +38,12 @@ services:
         SERVICE_VARIANT: cms
         DJANGO_SETTINGS_MODULE: cms.envs.tutor.production
       volumes:
-        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-        - ../apps/openedx/config:/openedx/config:ro
-        - ../../data/cms-job:/openedx/data
+        - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+        - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+        - ../apps/openedx/config:/openedx/config:roz
+        - ../../data/cms-job:/openedx/data:z
         {%- for mount in iter_mounts(MOUNTS, "openedx", "cms-job") %}
-        - {{ mount }}
+        - {{ mount }}:z
         {%- endfor %}
       depends_on: {{ [("mysql", RUN_MYSQL), ("mongodb", RUN_MONGODB), ("meilisearch", RUN_MEILISEARCH), ("redis", RUN_REDIS)]|list_if }}
 

--- a/tutor/templates/local/docker-compose.prod.yml
+++ b/tutor/templates/local/docker-compose.prod.yml
@@ -35,14 +35,14 @@ services:
       - "{{value}}"{% endfor %}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-      - ../apps/openedx/config:/openedx/config:ro
-      - ../../data/lms:/openedx/data
-      - ../../data/openedx-media:/openedx/media
-      - ../../data/openedx-media-private:/openedx/media-private
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+      - ../apps/openedx/config:/openedx/config:roz
+      - ../../data/lms:/openedx/data:z
+      - ../../data/openedx-media:/openedx/media:z
+      - ../../data/openedx-media-private:/openedx/media-private:z
       {%- for mount in iter_mounts(MOUNTS, "openedx", "lms-worker") %}
-      - {{ mount }}
+      - {{ mount }}:z
       {%- endfor %}
     depends_on:
       - lms
@@ -56,14 +56,14 @@ services:
       - "{{value}}"{% endfor %}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-      - ../apps/openedx/config:/openedx/config:ro
-      - ../../data/cms:/openedx/data
-      - ../../data/openedx-media:/openedx/media
-      - ../../data/openedx-media-private:/openedx/media-private
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+      - ../apps/openedx/config:/openedx/config:roz
+      - ../../data/cms:/openedx/data:z
+      - ../../data/openedx-media:/openedx/media:z
+      - ../../data/openedx-media-private:/openedx/media-private:z
       {%- for mount in iter_mounts(MOUNTS, "openedx", "cms-worker") %}
-      - {{ mount }}
+      - {{ mount }}:z
       {%- endfor %}
     depends_on:
       - cms

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -12,16 +12,16 @@ services:
       # Command script
       - ../apps/permissions/setowners.sh:/usr/local/bin/setowners.sh:ro
       # Bind-mounted volumes to set ownership
-      - ../../data/lms:/mounts/lms
-      - ../../data/cms:/mounts/cms
-      - ../../data/lms-job:/mounts/lms-job
-      - ../../data/cms-job:/mounts/cms-job
-      - ../../data/openedx-media:/mounts/openedx
-      - ../../data/openedx-media-private:/mounts/openedx-private
-      {% if RUN_MONGODB %}- ../../data/mongodb:/mounts/mongodb{% endif %}
-      {% if RUN_MYSQL %}- ../../data/mysql:/mounts/mysql{% endif %}
-      {% if RUN_MEILISEARCH %}- ../../data/meilisearch:/mounts/meilisearch{% endif %}
-      {% if RUN_REDIS %}- ../../data/redis:/mounts/redis{% endif %}
+      - ../../data/lms:/mounts/lms:z
+      - ../../data/cms:/mounts/cms:z
+      - ../../data/lms-job:/mounts/lms-job:z
+      - ../../data/cms-job:/mounts/cms-job:z
+      - ../../data/openedx-media:/mounts/openedx:z
+      - ../../data/openedx-media-private:/mounts/openedx-private:z
+      {% if RUN_MONGODB %}- ../../data/mongodb:/mounts/mongodb:z{% endif %}
+      {% if RUN_MYSQL %}- ../../data/mysql:/mounts/mysql:z{% endif %}
+      {% if RUN_MEILISEARCH %}- ../../data/meilisearch:/mounts/meilisearch:z{% endif %}
+      {% if RUN_REDIS %}- ../../data/redis:/mounts/redis:z{% endif %}
       {{ patch("local-docker-compose-permissions-volumes")|indent(6) }}
 
   ############# External services
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
     user: "999:999"
     volumes:
-      - ../../data/mongodb:/data/db
+      - ../../data/mongodb:/data/db:z
     depends_on:
       - permissions
   {%- endif %}
@@ -51,7 +51,7 @@ services:
     restart: unless-stopped
     user: "999:999"
     volumes:
-      - ../../data/mysql:/var/lib/mysql
+      - ../../data/mysql:/var/lib/mysql:z
     environment:
       MYSQL_ROOT_PASSWORD: "{{ MYSQL_ROOT_PASSWORD }}"
   {%- endif %}
@@ -62,7 +62,7 @@ services:
     environment:
       MEILI_MASTER_KEY: "{{ MEILISEARCH_MASTER_KEY }}"
     volumes:
-      - ../../data/meilisearch:/meili_data
+      - ../../data/meilisearch:/meili_data:z
     restart: unless-stopped
     user: "1000:1000"
     depends_on:
@@ -75,8 +75,8 @@ services:
     working_dir: /openedx/redis/data
     user: "1000:1000"
     volumes:
-      - ../apps/redis/redis.conf:/openedx/redis/config/redis.conf:ro
-      - ../../data/redis:/openedx/redis/data
+      - ../apps/redis/redis.conf:/openedx/redis/config/redis.conf:roz
+      - ../../data/redis:/openedx/redis/data:z
     command: redis-server /openedx/redis/config/redis.conf
     restart: unless-stopped
     depends_on:
@@ -102,15 +102,15 @@ services:
       UWSGI_WORKERS: {{ OPENEDX_LMS_UWSGI_WORKERS }}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-      - ../apps/openedx/config:/openedx/config:ro
-      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:ro
-      - ../../data/lms:/openedx/data
-      - ../../data/openedx-media:/openedx/media
-      - ../../data/openedx-media-private:/openedx/media-private
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+      - ../apps/openedx/config:/openedx/config:roz
+      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:roz
+      - ../../data/lms:/openedx/data:z
+      - ../../data/openedx-media:/openedx/media:z
+      - ../../data/openedx-media-private:/openedx/media-private:z
       {%- for mount in iter_mounts(MOUNTS, "openedx", "lms") %}
-      - {{ mount }}
+      - {{ mount }}:z
       {%- endfor %}
     depends_on:
       - permissions
@@ -129,15 +129,15 @@ services:
       UWSGI_WORKERS: {{ OPENEDX_CMS_UWSGI_WORKERS }}
     restart: unless-stopped
     volumes:
-      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:ro
-      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:ro
-      - ../apps/openedx/config:/openedx/config:ro
-      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:ro
-      - ../../data/cms:/openedx/data
-      - ../../data/openedx-media:/openedx/media
-      - ../../data/openedx-media-private:/openedx/media-private
+      - ../apps/openedx/settings/lms:/openedx/edx-platform/lms/envs/tutor:roz
+      - ../apps/openedx/settings/cms:/openedx/edx-platform/cms/envs/tutor:roz
+      - ../apps/openedx/config:/openedx/config:roz
+      - ../apps/openedx/uwsgi.ini:/openedx/uwsgi.ini:roz
+      - ../../data/cms:/openedx/data:z
+      - ../../data/openedx-media:/openedx/media:z
+      - ../../data/openedx-media-private:/openedx/media-private:z
       {%- for mount in iter_mounts(MOUNTS, "openedx", "cms") %}
-      - {{ mount }}
+      - {{ mount }}:z
       {%- endfor %}
     depends_on:
       - permissions


### PR DESCRIPTION
I recently started running tutor on Fedora and realised that it was not working out of the box because of SELinux. That's because some bind-mounted volumes are shared between different containers. Without the "z" option, this sharing is disabled.

The "z" label is ignored in environments that do not use SELinux.

This feature is documented here:
https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label