### PR TITLE
fix: ignore Python 3.14 TypeVar references in docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,10 @@ nitpick_ignore = [
     # ParamSpec objects are not classes but may be referenced as such
     ("py:class", "tutor.core.hooks.actions.T"),
     ("py:class", "typing_extensions.ParamSpec"),
+    # Python 3.14: TypeVar references in autodoc are emitted as py:obj with
+    # the `typing.~T` short-name form, which has no resolvable target.
+    ("py:obj", "typing.~T"),
+    ("py:obj", "typing.~T2"),
 ]
 
 # Even outside nitpicky mode, some type-hint rendering can produce "ref.class"


### PR DESCRIPTION
## Summary

Fixes the `test 3.14 / build docs` job, which fails with:

```
WARNING: py:obj reference target not found: typing.~T
WARNING: py:obj reference target not found: typing.~T2
```

Failing run: https://github.com/overhangio/tutor/actions/runs/26876195790/job/79263978764

## Why

On Python 3.14, sphinx autodoc renders `TypeVar("T")` / `TypeVar("T2")` (from `tutor/core/hooks/{actions,filters}.py`) as `:py:obj:\`typing.~T\`` references — different domain:role than 3.13, which used `:py:class:`. The existing `nitpick_ignore` entries in `docs/conf.py` only match `("py:class", ...)`, so the new `py:obj` references slip through and fail the build under `-W`.

## Fix

Add two targeted `nitpick_ignore` entries for the `py:obj` shape:

\`\`\`python
("py:obj", "typing.~T"),
("py:obj", "typing.~T2"),
\`\`\`

The `typing.~T` literal (with the tilde) is the actual reftarget sphinx generates — the `~` is sphinx's display-only-last-component modifier and ends up in the warning text verbatim.

## Test plan

- [x] `test 3.14 / build docs` passes
- [x] `test 3.10 / build docs` still passes (entries are additive; no existing ignores changed)