### PR TITLE
ci: add workflow to generate PRs for version bumps

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,81 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (e.g. 21.0.8)"
+        required: true
+        type: string
+      openedx_common_version:
+        description: "OPENEDX_COMMON_VERSION (e.g. release/ulmo.4) Leave blank to use current version"
+        required: false
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set version variables
+        run: |
+          echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install scriv
+        run: pip install scriv
+
+      - name: Bump version
+        run: |
+          sed -i 's/^__version__ = ".*"$/__version__ = "${{ github.event.inputs.version }}"/' tutor/__about__.py
+
+      - name: Resolve OPENEDX_COMMON_VERSION
+        id: resolve_version
+        run: |
+          INPUT="${{ github.event.inputs.openedx_common_version }}"
+          if [ -n "$INPUT" ]; then
+            echo "openedx_common_version=$INPUT" >> "$GITHUB_OUTPUT"
+          else
+            CURRENT=$(grep '^OPENEDX_COMMON_VERSION:' tutor/templates/config/defaults.yml | sed 's/OPENEDX_COMMON_VERSION: "\(.*\)"/\1/')
+            echo "openedx_common_version=$CURRENT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update OPENEDX_COMMON_VERSION in defaults.yml
+        run: |
+          sed -i 's|^OPENEDX_COMMON_VERSION: ".*"$|OPENEDX_COMMON_VERSION: "${{ steps.resolve_version.outputs.openedx_common_version }}"|' tutor/templates/config/defaults.yml
+
+      - name: Update OPENEDX_COMMON_VERSION in docs/configuration.rst
+        run: |
+          sed -i 's|``OPENEDX_COMMON_VERSION`` (default: ``"[^"]*"|``OPENEDX_COMMON_VERSION`` (default: ``"${{ steps.resolve_version.outputs.openedx_common_version }}"|' docs/configuration.rst
+
+      - name: Collect changelog entries
+        run: scriv collect
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b $RELEASE_TAG
+          git add -A
+          git commit -m "$RELEASE_TAG"
+          git push origin $RELEASE_TAG
+
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --title "$RELEASE_TAG" \
+            --body "Release preparation for $RELEASE_TAG" \
+            --base "${{ github.event.repository.default_branch }}" \
+            --head "$RELEASE_TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.14"
 
       - name: Install scriv
         run: pip install scriv

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,7 +28,16 @@ jobs:
       - name: Set version variables
         run: |
           echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v$VERSION" >> "$GITHUB_ENV"
+
+      - name: Prevent Release version bump
+        run: |
+          CURRENT_RELEASE=$(make version | cut -d. -f1)
+          INPUT_RELEASE=$(echo "$VERSION" | cut -d. -f1)
+          if [ "$INPUT_RELEASE" != "$CURRENT_RELEASE" ]; then
+            echo "Error: Release version bump detected. Use the manual release process as documented here (https://github.com/overhangio/tutor/blob/release/docs/tutor.rst#releasing-a-new-version-1) for Release version bums."
+            exit 1
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Set version variables
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          VERSION=$(echo "${{ github.event.inputs.version }}" | sed 's/^[vV]//')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=v$VERSION" >> "$GITHUB_ENV"
 
       - name: Prevent Release version bump

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set version variables
         run: |
@@ -28,7 +28,7 @@ jobs:
           echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
@@ -74,7 +74,7 @@ jobs:
         run: scriv collect
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,9 +1,12 @@
 name: Bump Version
-
+# This action should only be used for Major and Minor version bumps of tutor.
+# For Release version bumps, the process is manual as defined here: https://github.com/overhangio/tutor/blob/release/docs/tutor.rst#releasing-a-new-version-1
 on:
   workflow_dispatch:
     inputs:
       version:
+        # These versions should follow the tutor version format, aka RELEASE.MAJOR.MINOR(-BRANCH)
+        # More details for versioning are here: https://github.com/overhangio/tutor/blob/release/docs/tutor.rst#versioning
         description: "New version (e.g. 21.0.8)"
         required: true
         type: string

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -61,21 +61,12 @@ jobs:
       - name: Collect changelog entries
         run: scriv collect
 
-      - name: Commit and push changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b $RELEASE_TAG
-          git add -A
-          git commit -m "$RELEASE_TAG"
-          git push origin $RELEASE_TAG
-
       - name: Create Pull Request
-        run: |
-          gh pr create \
-            --title "$RELEASE_TAG" \
-            --body "Release preparation for $RELEASE_TAG" \
-            --base "${{ github.event.repository.default_branch }}" \
-            --head "$RELEASE_TAG"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ${{ env.RELEASE_TAG }}
+          branch: ${{ env.RELEASE_TAG }}
+          title: ${{ env.RELEASE_TAG }}
+          body: "Release preparation for ${{ env.RELEASE_TAG }}"
+          base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,27 +36,39 @@ jobs:
         run: pip install scriv
 
       - name: Bump version
-        run: |
-          sed -i 's/^__version__ = ".*"$/__version__ = "${{ github.event.inputs.version }}"/' tutor/__about__.py
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '__version__ = "[^"]*"'
+          replace: '__version__ = "${{ env.VERSION }}"'
+          include: "tutor/__about__.py"
+          regex: true
 
-      - name: Resolve OPENEDX_COMMON_VERSION
+      - name: Resolve current OPENEDX_COMMON_VERSION
         id: resolve_version
         run: |
           INPUT="${{ github.event.inputs.openedx_common_version }}"
           if [ -n "$INPUT" ]; then
             echo "openedx_common_version=$INPUT" >> "$GITHUB_OUTPUT"
           else
-            CURRENT=$(grep '^OPENEDX_COMMON_VERSION:' tutor/templates/config/defaults.yml | sed 's/OPENEDX_COMMON_VERSION: "\(.*\)"/\1/')
+            CURRENT=$(grep '^OPENEDX_COMMON_VERSION:' tutor/templates/config/defaults.yml | grep -oP '(?<=")[^"]+(?=")')
             echo "openedx_common_version=$CURRENT" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update OPENEDX_COMMON_VERSION in defaults.yml
-        run: |
-          sed -i 's|^OPENEDX_COMMON_VERSION: ".*"$|OPENEDX_COMMON_VERSION: "${{ steps.resolve_version.outputs.openedx_common_version }}"|' tutor/templates/config/defaults.yml
+      - name: Update OPENEDX_COMMON_VERSION in settings
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: 'OPENEDX_COMMON_VERSION: "[^"]*"'
+          replace: 'OPENEDX_COMMON_VERSION: "${{ steps.resolve_version.outputs.openedx_common_version }}"'
+          include: "tutor/templates/config/defaults.yml"
+          regex: true
 
-      - name: Update OPENEDX_COMMON_VERSION in docs/configuration.rst
-        run: |
-          sed -i 's|``OPENEDX_COMMON_VERSION`` (default: ``"[^"]*"|``OPENEDX_COMMON_VERSION`` (default: ``"${{ steps.resolve_version.outputs.openedx_common_version }}"|' docs/configuration.rst
+      - name: Update OPENEDX_COMMON_VERSION in docs
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '``OPENEDX_COMMON_VERSION`` \(default: ``"[^"]*"'
+          replace: '``OPENEDX_COMMON_VERSION`` (default: ``"${{ steps.resolve_version.outputs.openedx_common_version }}"'
+          include: "docs/configuration.rst"
+          regex: true
 
       - name: Collect changelog entries
         run: scriv collect
@@ -68,5 +80,5 @@ jobs:
           commit-message: ${{ env.RELEASE_TAG }}
           branch: ${{ env.RELEASE_TAG }}
           title: ${{ env.RELEASE_TAG }}
-          body: "Release preparation for ${{ env.RELEASE_TAG }}"
+          body: "Version bump to ${{ env.RELEASE_TAG }}"
           base: ${{ github.event.repository.default_branch }}

--- a/changelog.d/20260605_191327_danyalfaheem_add_versionbump_ci.md
+++ b/changelog.d/20260605_191327_danyalfaheem_add_versionbump_ci.md
@@ -1,0 +1,1 @@
+- [Improvement] Add a manually executable GitHub Action workflow to create version bump PRs for Major and Minor releases. (by @Danyal-Faheem)

--- a/docs/tutor.rst
+++ b/docs/tutor.rst
@@ -137,6 +137,14 @@ Releasing a new version
 
 When releasing a new version:
 
+For Major and Minor version bumps, run the Bump Version GitHub action. It should take care of the necessary steps.
+
+The action takes input for the new version number. For detailed guidelines on version numbering, refer to the (versioning guidelines :ref:`versioning`).
+
+In case of an openedx-platform version update, provide the updated version as input to the action as well.
+
+For Release version bumps, the process is a little manual on purpose to incorporate other changes: 
+
 - **Version Number**: Update the version number in `__about__.py`. For detailed guidelines on version numbering, refer to the (versioning guidelines :ref:`versioning`).
 - **Changelog Compilation**: Compile all changelog entries using ``make changelog``.
 - **Git Commit for Release**: Use the format ``git commit -a -m "vX.Y.Z"`` to indicate the new version in the git commit title.


### PR DESCRIPTION
A common theme is creating a new PR for a version bump which takes precious time out of a maintainers day Since the actual workflow is pretty predictable, we just added a small github action to bump version and create a new PR instead

This workflow is only run manually and requires inputs for the updated version, updated OPENEDX_COMMON_VERSION (optional)

The commit message, branch name, PR title are all named the new version as per previously used convention