### PR TITLE
Upgrade MySQL to v8.4.9

### DIFF
--- a/changelog.d/20260611_upgrade_mysql.md
+++ b/changelog.d/20260611_upgrade_mysql.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgrade MySQL to v8.4.9, the latest patch on the 8.4 LTS line. (by @ahmed-arb)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,7 +81,7 @@ This configuration parameter defines which MongoDB Docker image to use.
 
 .. https://hub.docker.com/_/mysql/tags?page=1&name=8.0
 
-- ``DOCKER_IMAGE_MYSQL`` (default: ``"docker.io/mysql:8.4.0"``)
+- ``DOCKER_IMAGE_MYSQL`` (default: ``"docker.io/mysql:8.4.9"``)
 
 This configuration parameter defines which MySQL Docker image to use.
 

--- a/tests/commands/test_images.py
+++ b/tests/commands/test_images.py
@@ -49,7 +49,7 @@ class ImagesTests(PluginsTestCase, TestCommandMixin):
         self.assertIsNone(result.exception)
         self.assertEqual(0, result.exit_code)
         # Note: we should update this tag whenever the mysql image is updated
-        image_pull.assert_called_once_with("docker.io/mysql:8.4.0")
+        image_pull.assert_called_once_with("docker.io/mysql:8.4.9")
 
     def test_images_printtag_image(self) -> None:
         result = self.invoke(["images", "printtag", "openedx"])

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -21,7 +21,7 @@ DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
 # https://hub.docker.com/_/mongo/tags
 DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.28"
 # https://hub.docker.com/_/mysql/tags
-DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.0"
+DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.9"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/redis/tags
 DOCKER_IMAGE_REDIS: "docker.io/redis:7.4.5"


### PR DESCRIPTION
Bumps the default MySQL image from `8.4.0` to `8.4.9`, the latest patch on the **8.4 LTS** line.

Open edX tests and ships against MySQL 8.4 LTS, so we stay on that line (rather than the non-LTS 9.x Innovation series) and move to the newest patch. No upgrade-command changes are needed for a patch bump — this PR is intentionally kept separate from the other dependency bumps in case 8.4-specific upgrade logic is needed later.

Part of #1400.

### Testing
- [x] `tutor images build openedx`
- [x] `tutor local launch` and confirm MySQL starts and migrations run