### PR TITLE
Upgrade MongoDB to v7.0.35

### DIFF
--- a/changelog.d/20260611_upgrade_mongodb.md
+++ b/changelog.d/20260611_upgrade_mongodb.md
@@ -1,0 +1,1 @@
+- [Security] Upgrade MongoDB to v7.0.35 to pull in upstream security patches, remaining on the 7.0 line that Open edX tests against. (by @ahmed-arb)

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -19,7 +19,7 @@ DOCKER_IMAGE_CADDY: "docker.io/caddy:2.7.4"
 # https://hub.docker.com/r/getmeili/meilisearch/tags
 DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
 # https://hub.docker.com/_/mongo/tags
-DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.28"
+DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.35"
 # https://hub.docker.com/_/mysql/tags
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"


### PR DESCRIPTION
Bumps the default MongoDB image from `7.0.28` to `7.0.35`, the latest patch on the **7.0** line, pulling in upstream security fixes.

We stay on 7.0 deliberately: Open edX Verawood's CI tests against `mongo-version: "7.0"` and pins `pymongo==4.4.0`, which predates MongoDB 8.0 server support. A future 7.0 → 8.0 major upgrade is tracked separately in #1400 because it requires `setFeatureCompatibilityVersion` stepping logic in `tutor/commands/upgrade/common.py` — kept this PR isolated so that logic can be added here if/when we go to 8.0.

Part of #1400.

### Testing
- [x] `tutor local launch` and confirm MongoDB starts cleanly (no featureCompatibilityVersion errors)