### PR TITLE
Upgrade Caddy, Redis, Python and Node

### DIFF
--- a/changelog.d/20260611_upgrade_dependencies.md
+++ b/changelog.d/20260611_upgrade_dependencies.md
@@ -1,0 +1,2 @@
+- [Improvement] Upgrade Caddy to v2.11.4, Redis to v7.4.9, and Meilisearch to v1.36.0. The Meilisearch jump changes the on-disk index format; the standard `init` jobs rebuild the indexes, so re-run platform initialisation after upgrading. (by @ahmed-arb)
+- [Improvement] Upgrade Python to v3.12.13 and Node.js to v24.16.0 in the Open edX Docker image. (by @ahmed-arb)

--- a/changelog.d/20260611_upgrade_dependencies.md
+++ b/changelog.d/20260611_upgrade_dependencies.md
@@ -1,2 +1,2 @@
-- [Improvement] Upgrade Caddy to v2.11.4, Redis to v7.4.9, and Meilisearch to v1.36.0. The Meilisearch jump changes the on-disk index format; the standard `init` jobs rebuild the indexes, so re-run platform initialisation after upgrading. (by @ahmed-arb)
+- [Improvement] Upgrade Caddy to v2.11.4 and Redis to v7.4.9. (by @ahmed-arb)
 - [Improvement] Upgrade Python to v3.12.13 and Node.js to v24.16.0 in the Open edX Docker image. (by @ahmed-arb)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,7 +67,7 @@ This configuration parameter defines the name of the Docker image to run the dev
 
 .. https://hub.docker.com/r/devture/exim-relay/tags
 
-- ``DOCKER_IMAGE_CADDY`` (default: ``"docker.io/caddy:2.6.2"``)
+- ``DOCKER_IMAGE_CADDY`` (default: ``"docker.io/caddy:2.11.4"``)
 
 This configuration parameter defines which Caddy Docker image to use.
 
@@ -87,7 +87,7 @@ This configuration parameter defines which MySQL Docker image to use.
 
 .. https://hub.docker.com/_/redis/tags
 
-- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.4.5"``)
+- ``DOCKER_IMAGE_REDIS`` (default: ``"docker.io/redis:7.4.9"``)
 
 This configuration parameter defines which Redis Docker image to use.
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # https://github.com/pyenv/pyenv/releases
 ARG PYTHON_VERSION=3.12.13
 ENV PYENV_ROOT=/opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.6.18 --depth 1
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.7.2 --depth 1
 
 # Install Python
 RUN $PYENV_ROOT/bin/pyenv install $PYTHON_VERSION

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Install pyenv
 # https://www.python.org/downloads/
 # https://github.com/pyenv/pyenv/releases
-ARG PYTHON_VERSION=3.12.12
+ARG PYTHON_VERSION=3.12.13
 ENV PYENV_ROOT=/opt/pyenv
 RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.6.18 --depth 1
 
@@ -139,7 +139,7 @@ ENV PATH=/openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 # Install nodeenv with the version provided by edx-platform
 # https://github.com/openedx/edx-platform/blob/master/requirements/edx/assets.txt
 RUN $PIP_COMMAND install nodeenv==1.9.1
-RUN nodeenv /openedx/nodeenv --node=24.12.0 --prebuilt
+RUN nodeenv /openedx/nodeenv --node=24.16.0 --prebuilt
 
 # Install nodejs requirements
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -15,16 +15,16 @@ DOCKER_REGISTRY: "docker.io/"
 DOCKER_IMAGE_OPENEDX: "{{ DOCKER_REGISTRY }}overhangio/openedx:{{ TUTOR_VERSION }}"
 DOCKER_IMAGE_OPENEDX_DEV: "openedx-dev:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/caddy/tags
-DOCKER_IMAGE_CADDY: "docker.io/caddy:2.7.4"
+DOCKER_IMAGE_CADDY: "docker.io/caddy:2.11.4"
 # https://hub.docker.com/r/getmeili/meilisearch/tags
-DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
+DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.36.0"
 # https://hub.docker.com/_/mongo/tags
 DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.28"
 # https://hub.docker.com/_/mysql/tags
 DOCKER_IMAGE_MYSQL: "docker.io/mysql:8.4.0"
 DOCKER_IMAGE_PERMISSIONS: "{{ DOCKER_REGISTRY }}overhangio/openedx-permissions:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/redis/tags
-DOCKER_IMAGE_REDIS: "docker.io/redis:7.4.5"
+DOCKER_IMAGE_REDIS: "docker.io/redis:7.4.9"
 # https://hub.docker.com/r/devture/exim-relay/tags
 DOCKER_IMAGE_SMTP: "docker.io/devture/exim-relay:4.96-r1-0"
 EDX_PLATFORM_REPOSITORY: "https://github.com/openedx/edx-platform.git"

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -17,7 +17,7 @@ DOCKER_IMAGE_OPENEDX_DEV: "openedx-dev:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/caddy/tags
 DOCKER_IMAGE_CADDY: "docker.io/caddy:2.11.4"
 # https://hub.docker.com/r/getmeili/meilisearch/tags
-DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.36.0"
+DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
 # https://hub.docker.com/_/mongo/tags
 DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.28"
 # https://hub.docker.com/_/mysql/tags


### PR DESCRIPTION
Bundled patch/minor bumps for the dependencies that don't need any upgrade-command logic, each moving to the latest stable on its current line:

| Component | From | To | Notes |
|---|---|---|---|
| Caddy | 2.7.4 | 2.11.4 | latest stable Caddy 2.x |
| Redis | 7.4.5 | 7.4.9 | latest 7.4 patch (security fixes); stays on the OSS 7.x line |
| Python | 3.12.12 | 3.12.13 | latest 3.12 patch |
| Node.js | 24.12.0 | 24.16.0 | latest Node 24 Active LTS |

MySQL and MongoDB are handled in separate PRs (#1401, #1402), so their upgrade-command logic can evolve independently. Redis 8.x and MongoDB 8.0 remain deferred — see #1400.

Part of #1400.

### Testing
- [x] `tutor images build openedx` (Python + Node)
- [x] `tutor local launch`; verify Caddy proxying and Redis-backed cache/Celery.