### PR TITLE
chore: unpin kubernetes<36 constraint as the upstream authentication bug has been resolved

### DIFF
--- a/changelog.d/20260612_153210_danyalfaheem_unpin_kubernetes.md
+++ b/changelog.d/20260612_153210_danyalfaheem_unpin_kubernetes.md
@@ -1,0 +1,1 @@
+- [Improvement] Unpin kubernetes<36 constraint as the upstream authentication bug has been resolved. 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,8 +2,7 @@ appdirs
 # TODO: remove 8.3.0 when https://github.com/overhangio/tutor/issues/1276 is resolved completely
 click>=8.0,<8.3.0
 jinja2>=2.10
-# TODO: remove cap when https://github.com/overhangio/tutor/issues/1390 is resolved
-kubernetes<36.0.0
+kubernetes
 mypy
 packaging
 pycryptodome>=3.17.0


### PR DESCRIPTION
The bug reported in https://github.com/overhangio/tutor/issues/1390 was resolved by temporarily pinning the requirement to <36 in https://github.com/overhangio/tutor/pull/1391.

The upstream bug has been resolved in v36.0.2 and v36.0.1 as reported in the changelog: [https://github.com/kubernetes-client/python/blob/release-36.0/CHANGELOG.md\#v3602](https://github.com/kubernetes-client/python/blob/release-36.0/CHANGELOG.md/#v3602)

We now unpin that constraint to allow tutor to install the latest version of kubernetes-client.

**Note: In #1387, we accidentally pushed the unpin commit as well but it deleted the kubernetes requirement altogether from base.in. So, now we add back that requirement without the pin.**