### PR TITLE
chore: use py310 instead of py39 in smoke ci as it has reached eol

### DIFF
--- a/.github/workflows/smoke-k8s.yml
+++ b/.github/workflows/smoke-k8s.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # TODO: Update to 3.10 in main as 3.9 is EOL
-          python-version: "3.9"
+          python-version: "3.10"
 
       # kind is preferred over minikube for CI: no VM overhead (~300 MB for
       # control-plane vs ~2 GB), no tunnel daemon needed for LoadBalancer, and

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # TODO: Update to 3.10 in main as 3.9 is EOL
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install tutor
         run: pip install -e .[dev]

--- a/changelog.d/20260616_192205_danyalfaheem_py39depr_ci.md
+++ b/changelog.d/20260616_192205_danyalfaheem_py39depr_ci.md
@@ -1,0 +1,1 @@
+- [Improvement] Run smoke workflows on Python 3.10 instead of 3.9 as it has reached EOL. (by @Danyal-Faheem)


### PR DESCRIPTION
This is part of #1306 but was not done for new ci as they are merged into release. We make this change such that these ci are automatically updated when main is merged into release.