### PR TITLE
chore: CMS cookie secure settings

### DIFF
--- a/changelog.d/20260724_015046_donato.bracuto_cms_secure_cookies.md
+++ b/changelog.d/20260724_015046_donato.bracuto_cms_secure_cookies.md
@@ -1,0 +1,9 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+- [Chore] Move secure cookie configuration to the common production settings so it applies to both LMS and CMS. (by @jfavellar90)

--- a/changelog.d/20260724_015046_donato.bracuto_cms_secure_cookies.md
+++ b/changelog.d/20260724_015046_donato.bracuto_cms_secure_cookies.md
@@ -1,0 +1,1 @@
+- [Security] Move secure cookie configuration to the common production settings so it applies to both LMS and CMS. (by @jfavellar90)

--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -10,19 +10,6 @@ ALLOWED_HOSTS = [
 ]
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}")
 
-{% if ENABLE_HTTPS %}
-# Properly set the "secure" attribute on session/csrf cookies. This is required in
-# Chrome to support samesite=none cookies.
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
-SESSION_COOKIE_SAMESITE = "None"
-{% else %}
-# When we cannot provide secure session/csrf cookies, we must disable samesite=none
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
-SESSION_COOKIE_SAMESITE = "Lax"
-{% endif %}
-
 # CMS authentication
 IDA_LOGOUT_URI_LIST.append("{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}/logout/")
 

--- a/tutor/templates/apps/openedx/settings/partials/common_all.py
+++ b/tutor/templates/apps/openedx/settings/partials/common_all.py
@@ -162,7 +162,7 @@ try:
     warnings.filterwarnings("ignore", category=DeprecationWarning, module="pgpy.constants")
 except ImportError:
     pass # If the warnings don't exist we don't need to filter them.
-    
+
 # Email
 EMAIL_USE_SSL = {{ SMTP_USE_SSL }}
 # Forward all emails from edX's Automated Communication Engine (ACE) to django.
@@ -176,6 +176,19 @@ LANGUAGE_COOKIE_NAME = "openedx-language-preference"
 
 # Allow the platform to include itself in an iframe
 X_FRAME_OPTIONS = "SAMEORIGIN"
+
+{% if ENABLE_HTTPS %}
+# Properly set the "secure" attribute on session/csrf cookies. This is required in
+# Chrome to support samesite=none cookies.
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SAMESITE = "None"
+{% else %}
+# When we cannot provide secure session/csrf cookies, we must disable samesite=none
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SAMESITE = "Lax"
+{% endif %}
 
 {% set jwt_rsa_key | rsa_import_key %}{{ JWT_RSA_PRIVATE_KEY }}{% endset %}
 JWT_AUTH["JWT_ISSUER"] = "{{ JWT_COMMON_ISSUER }}"


### PR DESCRIPTION
This PR moves the cookie secure configuration from the LMS production files to the common configuration file. This change makes the CMS service getting the secure cookies configuration

It solves https://github.com/overhangio/tutor/issues/1409