### PR TITLE
fix: mysql user create if not exists error

### DIFF
--- a/tutor/templates/jobs/init/mysql.sh
+++ b/tutor/templates/jobs/init/mysql.sh
@@ -16,6 +16,15 @@ echo "MySQL is up and running"
 
 # edx-platform database
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE DATABASE IF NOT EXISTS {{ OPENEDX_MYSQL_DATABASE }};"
-mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{ OPENEDX_MYSQL_USERNAME }}';"
+# This command may fail if the specified user has created a custom view, such
+# as is done in the enterprise app.
+#
+# Yes, even 'if not exists' does not prevent this. :/
+# https://bugs.mysql.com/bug.php?id=107139
+#
+# When our minimum version of MySQL is 8.4, we should be able to drop this
+# || true workaround, as the SET_USER_ID privilege has been removed.
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{ OPENEDX_MYSQL_USERNAME }}';" || true
+# If the user truly doesn't exist, we'll get an error here.
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "ALTER USER '{{ OPENEDX_MYSQL_USERNAME }}'@'%' IDENTIFIED BY '{{ OPENEDX_MYSQL_PASSWORD }}';"
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT ALL ON {{ OPENEDX_MYSQL_DATABASE }}.* TO '{{ OPENEDX_MYSQL_USERNAME }}'@'%';"


### PR DESCRIPTION
## Description

This pull request fixes an issue where MySQL may choke on the 'create user if not exists' command in the case that a user has a view that they have created. This is a bug in MySQL that has existed for at least a few years: https://bugs.mysql.com/bug.php?id=107139

The bug is more likely to occur in some managed database environments where the provided 'admin user' does not have the "SET_USER_ID" privilege (in version 8.0) or the "ALLOW_NONEXISTENT_DEFINER" privilege (in version 8.4). This is the case, for instance, with DigitalOcean. It may also happen for reasons not yet fully understood even if this privilege is available.

## Supporting information

Internal ticket: https://tasks.opencraft.com/browse/BB-10998

Edx-Enterprise migration which creates a view: https://github.com/openedx/edx-enterprise/blob/master/enterprise/migrations/0236_create_vw_enterprise_customer_ecus_pecus.py

## Testing instructions

1. Run launch and verify nothing breaks in practice for normal migrations/initialization
2. Create an admin user with all privileges except for SET_USER_ID (if using MySQL 8.0) or ALLOW_NONEXISTENT_DEFINER (if using MySQL 8.4), and set its settings:
* MYSQL_ROOT_USERNAME
* MYSQL_ROOT_PASSWORD
* MYSQL_HOST
* MYSQL_PORT
... as needed.
* Try launching once more. Verify launch completes.