### PR TITLE
chore: upgrade Meilisearch to v1.36.0

### DIFF
--- a/changelog.d/20260713_upgrade_meilisearch.md
+++ b/changelog.d/20260713_upgrade_meilisearch.md
@@ -6,3 +6,7 @@
       tutor local do init
       tutor local exec cms ./manage.py cms reindex_studio
       tutor local exec cms ./manage.py cms reindex_course --active
+
+- On a large site, the reindex takes a while and search stays incomplete until it finishes, so plan a maintenance window.
+
+- Rolling back is not just reverting the image tag. Because the format only moves forward, v1.8.4 cannot read a v1.36.0 database either, so you also need to restore your pre-upgrade data/meilisearch/data.ms backup.

--- a/changelog.d/20260713_upgrade_meilisearch.md
+++ b/changelog.d/20260713_upgrade_meilisearch.md
@@ -1,0 +1,8 @@
+- 💥[Improvement] Upgrade Meilisearch to v1.36.0. This changes the on-disk index format, so v1.36.0 refuses to start on a database created by v1.8.4: the container restart-loops with a "database version (1.8.4) is incompatible with your current engine version (1.36.0)" error. Meilisearch is only a derived index in Open edX and never a source of truth, so the existing index must be discarded and rebuilt after upgrading. Stop the platform, delete `data/meilisearch/data.ms`, then re-run initialisation and reindex: (by @HammadYousaf01)
+
+      tutor local stop
+      rm -rf "$(tutor config printroot)/data/meilisearch/data.ms"
+      tutor local start -d
+      tutor local do init
+      tutor local exec cms ./manage.py cms reindex_studio
+      tutor local exec cms ./manage.py cms reindex_course --active

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,7 +71,7 @@ This configuration parameter defines the name of the Docker image to run the dev
 
 This configuration parameter defines which Caddy Docker image to use.
 
-- ``DOCKER_IMAGE_MEILISEARCH`` (default: ``"docker.io/getmeili/meilisearch:v1.8.4"``)
+- ``DOCKER_IMAGE_MEILISEARCH`` (default: ``"docker.io/getmeili/meilisearch:v1.36.0"``)
 
 This configuration parameter defines which Meilisearch Docker image to use.
 

--- a/tutor/templates/config/defaults.yml
+++ b/tutor/templates/config/defaults.yml
@@ -17,7 +17,7 @@ DOCKER_IMAGE_OPENEDX_DEV: "openedx-dev:{{ TUTOR_VERSION }}"
 # https://hub.docker.com/_/caddy/tags
 DOCKER_IMAGE_CADDY: "docker.io/caddy:2.11.4"
 # https://hub.docker.com/r/getmeili/meilisearch/tags
-DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.8.4"
+DOCKER_IMAGE_MEILISEARCH: "docker.io/getmeili/meilisearch:v1.36.0"
 # https://hub.docker.com/_/mongo/tags
 DOCKER_IMAGE_MONGODB: "docker.io/mongo:7.0.35"
 # https://hub.docker.com/_/mysql/tags


### PR DESCRIPTION
# Upgrade Meilisearch to v1.36.0

This updates the default Meilisearch image from v1.8.4 to v1.36.0. Closes https://github.com/overhangio/tutor/issues/1400

Heads up: this is a breaking change for existing sites. Meilisearch changed its on-disk index format between these versions, so v1.36 will not boot on a database created by v1.8.4. If you only swap the image and restart, the container crash loops with an error like `database version (1.8.4) is incompatible with your current engine version (1.36.0),` and search goes down. Fresh installs are not affected.

If you are directly upgrading an existing deployment, run these steps after pulling this change:

```
tutor local stop
rm -rf "$(tutor config printroot)/data/meilisearch/data.ms"
tutor local start -d
tutor local do init
tutor local exec cms ./manage.py cms reindex_studio
tutor local exec cms ./manage.py cms reindex_course --active
```

A few things worth knowing:

- On a large site, the reindex takes a while and search stays incomplete until it finishes, so plan a maintenance window.
- Rolling back is not just reverting the image tag. Because the format only moves forward, v1.8.4 cannot read a v1.36 database either, so you also need to restore your pre-upgrade `data/meilisearch/data.ms` backup.

Tested with `tutor local` and `tutor dev` against the demo course. After the reset and reindex, the studio, courseware, and library indexes repopulate, and search returns results.
