### PR TITLE
docs: note that plugin -main images must be built locally

### DIFF
--- a/docs/developing/main.rst
+++ b/docs/developing/main.rst
@@ -46,6 +46,19 @@ However, these images include the application master branch at the point in time
 
     tutor images build --no-cache all
 
+.. note::
+    On the ``main`` branch, image tags carry a ``-main`` suffix. Only the ``openedx`` and ``indigo`` images are published to Docker Hub with that suffix; the ``-main`` images for other plugins are not. As a result, ``tutor images pull all`` cannot fetch them and you must build these images yourself, for example::
+
+        tutor images build mfe
+
+    On Kubernetes, the images also need to be available from a registry that the cluster can reach. Set the ``DOCKER_REGISTRY`` configuration value (with a trailing slash) to a registry you can push to, then build and push the plugin images::
+
+        tutor config save --set DOCKER_REGISTRY=docker.io/myusername/
+        tutor images build mfe
+        tutor images push mfe
+
+    If you do not specifically need the master branches, running a :ref:`tagged release <install>` avoids this step entirely.
+
 Running Tutor Main alongside the latest release
 -----------------------------------------------
 


### PR DESCRIPTION
Document that plugin `-main` images (all except `openedx` and `indigo`) are not published to Docker Hub and must be built locally, with the extra registry-push step required on Kubernetes.

Closes overhangio/tutor-mfe#271