### PR TITLE
fix: apply upstream security patch to bump vendored pdf.js to 5.7.284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ instructions, because git commits are used to generate release notes:
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.0.9'></a>
+## v21.0.9 (2026-07-16)
+
+- [Security] Backport fix to bump vendored pdf.js from 1.0.907 to 5.7.284, addressing XSS vulnerability GHSA-mj74-gfq3-2v9f (source: upstream edx-platform commit 4d2e220d6f709b675018b8900ed1116f3d482ad9).
+
 <a id='changelog-21.0.8'></a>
 ## v21.0.8 (2026-06-23)
 

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -2,7 +2,7 @@ import os
 
 # Increment this version number to trigger a new release. See
 # docs/tutor.html#versioning for information on the versioning scheme.
-__version__ = "21.0.8"
+__version__ = "21.0.9"
 
 # The version suffix will be appended to the actual version, separated by a
 # dash. Use this suffix to differentiate between the actual released version and

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -59,6 +59,12 @@ RUN git config --global user.email "tutor@overhang.io" \
 {%- else %}
 # Patches in non-Main mode (i.e., Release mode)
 
+# SECURITY FIX: bump vendored pdf.js from 1.0.907 to 5.7.284
+# Addresses XSS vulnerability GHSA-mj74-gfq3-2v9f (CVE pending)
+# https://discuss.openedx.org/t/security-upcoming-security-release-for-openedx-platform/19128
+RUN git fetch origin 4d2e220d6f709b675018b8900ed1116f3d482ad9 \
+    && git cherry-pick 4d2e220d6f709b675018b8900ed1116f3d482ad9
+
 {%- endif %}
 
 {# Add new patches like this: #}


### PR DESCRIPTION
### Description

This PR applies an upstream security fix from Open edX by backporting the pdf.js library upgrade from v1.0.907 to v5.7.284 into the Tutor Open edX Docker image, addressing XSS vulnerability [GHSA-mj74-gfq3-2v9f](https://github.com/openedx/edx-platform/security/advisories/GHSA-mj74-gfq3-2v9f).

Source commit: https://github.com/openedx/edx-platform/commit/4d2e220d6f709b675018b8900ed1116f3d482ad9

This issue is part of the security advisory discussed here:
https://discuss.openedx.org/t/security-upcoming-security-release-for-openedx-platform/19128

### Why git fetch + cherry-pick instead of curl | git am

The standard approach (`curl -fsSL ...patch | git am`) does not work for this commit because the patch is ~13 MB (519 files changed, 197k insertions, 72k deletions) and GitHub returns HTTP 403 for `.patch` URLs of that size. Using `git fetch <sha> && git cherry-pick <sha>` achieves the same result reliably.

### Why this PR is needed

The fix was merged to `release/ulmo` on 2026-07-07, but `release/ulmo.3` (which is the `OPENEDX_COMMON_VERSION` used by all Tutor v21.0.x releases) does not include it. The `release/ulmo` branch is currently 8 commits ahead of the `release/ulmo.3` tag, and no `release/ulmo.4` tag has been cut yet.

This means all Tutor operators using default configuration are currently unpatched against this XSS vulnerability.

### Testing

Verified locally that `git fetch origin <sha> && git cherry-pick <sha>` applies cleanly on top of a shallow clone of `edx-platform` at `release/ulmo.3`.