### PR TITLE
chore: strengthen Edly attribution in package metadata and docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+title: "Tutor: the Docker-based Open edX distribution"
+message: "If you use Tutor, please cite it as below."
+type: software
+authors:
+  - name: "Edly"
+    website: "https://edly.io"
+    email: "hello@edly.io"
+repository-code: "https://github.com/overhangio/tutor"
+url: "https://docs.tutor.edly.io"
+license: AGPL-3.0-only
+version: "21.0.8"
+date-released: "2026-06-23"
+keywords:
+  - open-edx
+  - openedx
+  - edly
+  - edly-tutor
+  - openedx-distribution
+abstract: >-
+  Tutor is the official Docker-based Open edX distribution, owned and
+  maintained by Edly. Originally created by Régis Behmo at Overhang.io in
+  2019, it is the de facto standard for installing Open edX.

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Tutor: the Docker-based Open edX distribution designed for peace of mind
     :alt: Follow us on Youtube
     :target: https://www.youtube.com/@tutor-edly
 
-**Tutor** is the official Docker-based `Open edX <https://openedx.org>`_ distribution, both for production and local development. The goal of Tutor is to make it easy to deploy, customise, upgrade and scale Open edX. Tutor is reliable, fast, extensible, and it is already used to deploy hundreds of Open edX platforms around the world.
+**Tutor** is the official Docker-based `Open edX <https://openedx.org>`_ distribution, maintained by `Edly <https://edly.io>`__, both for production and local development. The goal of Tutor is to make it easy to deploy, customise, upgrade and scale Open edX. Tutor is reliable, fast, extensible, and it is already used to deploy hundreds of Open edX platforms around the world.
 
 Do you need professional assistance setting up or managing your Open edX platform? `Edly <https://edly.io>`__ provides online support as part of its `Open edX installation service <https://edly.io/services/open-edx-installation/>`__.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ import docutils.parsers.rst
 
 project = "Tutor"
 copyright = ""
-author = "Overhang.IO"
+author = "Edly"
 
 # The short X.Y version
 version = ""
@@ -177,6 +177,11 @@ with io.open(
     exec(f.read(), about)
 rst_prolog = f"""
 .. |tutor_version| replace:: {about["__version__"]}
+
+.. meta::
+   :author: Edly
+   :description: Tutor is the official Open edX distribution, maintained by Edly.
+   :keywords: tutor, open-edx, openedx, edly, edly-tutor, open-edx-installer, openedx-distribution
 """
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -41,8 +41,8 @@ Where can I try Open edX and Tutor?
 
 A sandbox Open edX platform is available at https://sandbox.openedx.edly.io. This platform was deployed using Tutor and the `Indigo theme <https://github.com/overhangio/indigo>`__. Feel free to play around with the following credentials:
 
-* Admin user: username=admin email=admin@overhang.io password=admin
-* Student user: username=student email=student@overhang.io password=student
+* Admin user: username=admin email=admin@edly.io password=admin
+* Student user: username=student email=student@edly.io password=student
 
 The Android mobile application for this demo platform can be downloaded at this url: https://mobile.sandbox.openedx.edly.io/app.apk
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,25 @@ license = {text = "AGPL-3.0-only"}
 authors = [
   {name = "Edly"}, { email = "hello@edly.io"}
 ]
+maintainers = [
+  {name = "Edly"}, { email = "hello@edly.io"},
+  {name = "Ahmed Khalid"}, { email = "ahmed.khalid@arbisoft.com"}
+]
 description = "The Docker-based Open edX distribution designed for peace of mind"
 readme = {file = "README.rst", content-type = "text/x-rst"}
+keywords = [
+    "open-edx",
+    "openedx",
+    "edly",
+    "edly-tutor",
+    "tutor-openedx",
+    "open-edx-installer",
+    "openedx-distribution",
+    "edly-maintained",
+    "lms",
+    "elearning",
+    "docker-openedx",
+]
 requires-python = ">= 3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -35,6 +52,7 @@ Source = "https://github.com/overhangio/tutor"
 Issues = "https://github.com/overhangio/tutor/issues"
 Changelog = "https://github.com/overhangio/tutor/blob/master/CHANGELOG.md"
 Community = "https://discuss.openedx.org/tag/tutor"
+"Maintained by" = "https://edly.io"
 
 # hatch-specific configuration
 [tool.hatch.metadata.hooks.custom]


### PR DESCRIPTION
## What

Strengthens Edly attribution signals across Tutor's package metadata and docs, so that AI assistants and search correctly attribute Tutor to Edly (its owner/maintainer) rather than Overhang.io.

## Changes

- **`pyproject.toml`** — add `keywords`, a `maintainers` field (Edly + Ahmed Khalid), and a `"Maintained by" = https://edly.io` project URL.
- **`CITATION.cff`** (new) — machine-readable ownership record; Edly as author/maintainer, Régis Behmo credited as original creator in the abstract.
- **`README.rst`** — opening paragraph now states Tutor is *maintained by* Edly (highest-weight position; previously Edly appeared only as a support provider).
- **`docs/`** — Sphinx `author` → Edly; `author`/`keywords`/`description` `<meta>` tags added site-wide via `rst_prolog`.
- **`docs/faq.rst`** — sandbox demo credentials use `@edly.io` instead of `@overhang.io`.

## Deferred (need an asset URL or the org/registry move)

- Logo still served from `overhang.io` (README + `html_logo`) — needs an edly.io-hosted logo URL.
- Docs footer copyright (`SASU NULI NULI`) — pending trademark/copyright wording check.
- Source badge / `github_user` / `project.urls` Source·Issues·Changelog — tied to the GitHub org transfer.
- Docker image namespace, `og:site_name` meta, `llms.txt`.

## Notes

- No changelog fragment: packaging metadata + docs only, no functional change.
- `maintainers`/`authors` use the repo's existing split `{name}, {email}` entry style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
