### PR TITLE
fix: bump build-time setuptools to 80.9.0 for the main branch

### DIFF
--- a/changelog.d/20260616_140000_abdul.muqadim_bump_setuptools_main.md
+++ b/changelog.d/20260616_140000_abdul.muqadim_bump_setuptools_main.md
@@ -1,0 +1,1 @@
+- [Bugfix] On the main branch, bump the pinned build-time `setuptools` to 80.9.0 (the release branch keeps 69.1.1). The older version cannot build packages that declare their license with the PEP 639 `project.license` field (e.g. `mysqlclient`) against the Open edX master branch, which broke `tutor images build openedx` on main. (by @Abdul-Muqadim-Arbisoft)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -20,7 +20,7 @@ ARG PIP_COMMAND="uv pip"
 # setuptools 81 removed pkg_resources. Inherited by all stages, and reused as
 # the single source of truth for the venv setuptools pin below.
 # https://github.com/overhangio/tutor/issues/1350
-RUN echo "setuptools==69.1.1" > /etc/openedx-build-constraints.txt
+RUN echo "setuptools==80.9.0" > /etc/openedx-build-constraints.txt
 ENV UV_BUILD_CONSTRAINT=/etc/openedx-build-constraints.txt
 ENV PIP_CONSTRAINT=/etc/openedx-build-constraints.txt
 


### PR DESCRIPTION
The setuptools build constraint added in #1411 pins 69.1.1, which is forward-ported from the release branch to main. On main we build against edx-platform's master branch, where mysqlclient==2.2.8 declares its license using the PEP 639 `project.license` format. setuptools only understands that format from 77.0.0 onwards, so building the openedx image with setuptools 69.1.1 fails:

    configuration error: `project.license` must be valid exactly by one

Bump the pinned version to 80.9.0 on main. It is new enough to build the master requirements (mysqlclient 2.2.8) and still ships pkg_resources, which setuptools 82.0.0 removes but which is still required at runtime by dependencies such as fs (pyfilesystem2) matching edx-platform's own `setuptools<82` constraint.

The release branch intentionally stays on 69.1.1: Ulmo's requirements build fine with it, and this avoids changing the setuptools version shipped by the current stable release.