### PR TITLE
ci: enable manual workflow_dispatch on the dependency-check workflow

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -23,6 +23,7 @@
 name: Check Outdated Dependencies
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1" # Every Monday at 9 AM UTC
 


### PR DESCRIPTION
Adds a workflow_dispatch trigger so the workflow can be run on demand from the Actions tab. Landing this on the default branch lets future changes to this workflow be test-run from a feature branch before merging.