### PR TITLE
ci: make changelog fragment name unique per dependency

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -128,7 +128,9 @@ jobs:
           git config user.name "github-actions"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           FRAGMENT=$(scriv create --no-edit 2>&1 | awk '{print $NF}')
-          printf '%s\n' '- [Improvement] Upgrade ${{ matrix.display }} from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}. (by @github-actions[bot])' > "$FRAGMENT"
+          UNIQUE="${FRAGMENT%.md}_${{ matrix.name }}.md"
+          mv "$FRAGMENT" "$UNIQUE"
+          printf '%s\n' '- [Improvement] Upgrade ${{ matrix.display }} from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}. (by @github-actions[bot])' > "$UNIQUE"
 
       - name: Create Pull Request
         if: steps.check.outputs.outdated == 'true'


### PR DESCRIPTION
Concurrent matrix jobs generated the same changelog filename, causing merge conflicts (broke #1444/#1445). Now each dependency's fragment gets a unique name