### PR TITLE
Ci/dependabot - Fix target scopes for dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,24 +2,28 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
 
   - package-ecosystem: "docker"
     directory: "/tutor/templates/build/openedx"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
 
   - package-ecosystem: "docker"
     directory: "/tutor/templates/build/permissions"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
 
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,16 @@ updates:
       day: "monday"
 
   - package-ecosystem: "docker"
-    directory: "/tutor/templates/build/openedx"
-    target-branch: "main"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-
-  - package-ecosystem: "docker"
     directory: "/tutor/templates/build/permissions"
     target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "alpine"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,13 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "main"
+    target-branch: "release"
     schedule:
       interval: "weekly"
       day: "monday"
     ignore:
       - dependency-name: "tutor-*" # requirements/plugins.txt is manually controlled
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,14 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "main"
+    target-branch: "release"
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directory: "/tutor/templates/build/permissions"


### PR DESCRIPTION
Dependabot was opening PRs for everything it could find, like Ubuntu 22.04 -> 26.04, Alpine 3.13 -> 3.24, and 5 Python PRs that all failed CI. This limits it to updates that are safe to take.

- pip → `release`, patches only
- github-actions → `release`, no majors
- docker → openedx entry removed, alpine patches only