### PR TITLE
feat: install requirements correctly via pyproject.toml

### DIFF
--- a/changelog.d/20260805_121623_faraz.maqsood_install_requirements_from_projecttoml_using_uv_instead_of_requirement_files_as_per_upstream.md
+++ b/changelog.d/20260805_121623_faraz.maqsood_install_requirements_from_projecttoml_using_uv_instead_of_requirement_files_as_per_upstream.md
@@ -1,0 +1,1 @@
+- 💥[Feature] Install the openedx-platform requirements correctly from pyproject.toml file of openedx-platform as openedx-platform has migrated its Python dependency management from pip-compile to pyproject.toml + uv and planning to remove requirements/edx/{base,assets}.txt compat files as per issue #1434. (by @Faraz32123)

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -101,10 +101,10 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     setuptools==69.1.1 pip==24.0 wheel==0.43.0
 
 # Install base requirements and asset-building requirements
-RUN --mount=type=bind,from=edx-platform,source=/requirements/edx/base.txt,target=/openedx/edx-platform/requirements/edx/base.txt \
-    --mount=type=bind,from=edx-platform,source=/requirements/edx/assets.txt,target=/openedx/edx-platform/requirements/edx/assets.txt \
+RUN --mount=type=bind,from=edx-platform,source=/pyproject.toml,target=/openedx/edx-platform/pyproject.toml \
+    --mount=type=bind,from=edx-platform,source=/uv.lock,target=/openedx/edx-platform/uv.lock \
     --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    $PIP_COMMAND install -r /openedx/edx-platform/requirements/edx/base.txt -r /openedx/edx-platform/requirements/edx/assets.txt
+    cd /openedx/edx-platform && uv sync --frozen --no-default-groups --group bundled --group assets --no-install-project --active
 
 # Install extra requirements
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
@@ -280,7 +280,8 @@ USER app
 
 # Install dev python requirements
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    $PIP_COMMAND install -r requirements/edx/development.txt
+    uv export --frozen --no-hashes --no-default-groups --group development | \
+    $PIP_COMMAND install -r /dev/stdin
 # https://pypi.org/project/ipdb/
 # https://pypi.org/project/ipython (>=Python 3.10 started with 8.20)
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \


### PR DESCRIPTION
- Install the openedx-platform requirements correctly from pyproject.toml file of openedx-platform as openedx-platform has migrated its Python dependency management from pip-compile to pyproject.toml + uv and planning to remove requirements/edx/{base,assets}.txt compat files.
- close #1434 