### PR TITLE
fix: pin plugins.txt to PyPI ranges instead of GitHub main refs

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,14 +1,14 @@
-# For Tutor Main, we install plugins from their main branches instead of from PyPI
-tutor-android@git+https://github.com/overhangio/tutor-android@main
-tutor-cairn@git+https://github.com/overhangio/tutor-cairn@main
-tutor-credentials@git+https://github.com/overhangio/tutor-credentials@main
-tutor-deck@git+https://github.com/overhangio/tutor-deck@main
-tutor-discovery@git+https://github.com/overhangio/tutor-discovery@main
-tutor-forum@git+https://github.com/overhangio/tutor-forum@main
-tutor-indigo@git+https://github.com/overhangio/tutor-indigo@main
-tutor-jupyter@git+https://github.com/overhangio/tutor-jupyter@main
-tutor-livedeps@git+https://github.com/overhangio/tutor-livedeps@main
-tutor-mfe@git+https://github.com/overhangio/tutor-mfe@main
-tutor-minio@git+https://github.com/overhangio/tutor-minio@main
-tutor-notes@git+https://github.com/overhangio/tutor-notes@main
-tutor-xqueue@git+https://github.com/overhangio/tutor-xqueue@main
+# change version ranges when upgrading from verawood
+tutor-android>=22.0.0,<23.0.0
+tutor-cairn>=22.0.0,<23.0.0
+tutor-credentials>=22.0.0,<23.0.0
+tutor-deck>=22.0.0,<23.0.0
+tutor-discovery>=22.0.0,<23.0.0
+tutor-forum>=22.0.0,<23.0.0
+tutor-indigo>=22.0.0,<23.0.0
+tutor-jupyter>=22.0.0,<23.0.0
+tutor-livedeps>=22.0.0,<23.0.0
+tutor-mfe>=22.0.0,<23.0.0
+tutor-minio>=22.0.0,<23.0.0
+tutor-notes>=22.0.0,<23.0.0
+tutor-xqueue>=22.0.0,<23.0.0


### PR DESCRIPTION
Revert plugins to install from PYPI


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZTW35i5zdXT6m2noA1exc)_