### PR TITLE
fix: quote python-version in release.yml to avoid YAML float coercion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         # https://github.com/actions/setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: 'pip'
           cache-dependency-path: requirements/dev.txt
       - name: Install Hatch


### PR DESCRIPTION
## Problem

The `Release` workflow (`.github/workflows/release.yml`) fails on the `Set up Python` step on every runner (both `ubuntu-22.04` and `macos-14`):

```
Run actions/setup-python@v6
Installed versions
  Version 3.1 was not found in the local cache
  Error: The version '3.1' with architecture 'arm64' was not found for macOS 14.8.7.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

## Root cause

```yaml
- name: Set up Python
  uses: actions/setup-python@v6
  with:
    python-version: 3.10
```

`3.10` is unquoted here, so YAML parses it as the floating-point number `3.1` (trailing zero dropped), not the string `"3.10"`. `actions/setup-python` then looks for a Python `3.1` interpreter, which doesn't exist, and fails immediately — before any actual release steps run.

Every other workflow in this repo already quotes `python-version` correctly (`smoke.yml`, `smoke-k8s.yml`, `bump-version.yml`, `test.yml`'s matrix); `release.yml` was the only one that didn't.

This was hit while re-running the release pipeline for `v22.0.0` after fixing the PyPI upload issue in #1450.

## Fix

Quote the value: `python-version: "3.10"`.

## Verification

Confirmed by diffing against the other workflow files in this repo, all of which use the quoted form. This is a one-line, mechanical YAML fix with no behavioral ambiguity — the intent was always Python 3.10 (matches `requires-python = ">= 3.10"` in `pyproject.toml`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZTW35i5zdXT6m2noA1exc)_