### PR TITLE
build: pass --verbose to twine upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-pythonpackage: ## Build the "tutor" python package for upload to pypi
 	python -m build --sdist
 
 push-pythonpackage: ## Push python package to pypi
-	twine upload --skip-existing dist/tutor-$(shell make version).tar.gz
+	twine upload --verbose --skip-existing dist/tutor-$(shell make version).tar.gz
 
 test: test-lint test-unit test-types test-format test-pythonpackage ## Run all tests by decreasing order of priority
 


### PR DESCRIPTION
Surface PyPI's response body in the job log, so a rejected upload does not need a second tag to diagnose (the v22.0.0 400 gave no detail).