### PR TITLE
feat: added llms.txt file

### DIFF
--- a/changelog.d/20260807_added_llms_txt_file.md
+++ b/changelog.d/20260807_added_llms_txt_file.md
@@ -1,0 +1,1 @@
+- [Feature] Added llms.txt file (by @muhammadadeeltajamul)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List
 
 import docutils
@@ -93,6 +94,7 @@ extensions.append("sphinx_click")
 # -- Redirects for pages that were moved or removed
 # https://github.com/sphinx-contrib/sphinx-reredirects
 extensions.append("sphinx_reredirects")
+extensions.append("sphinx_llms_txt")
 redirects = {
     # Removed top-level pages
     "install": "gettingstarted/installation.html",
@@ -142,6 +144,7 @@ os.environ["HOME"] = "~"
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 # -- Options for HTML output -------------------------------------------------
+html_baseurl = "https://docs.tutor.edly.io/"
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "logo_only": True,
@@ -160,6 +163,7 @@ html_static_path = ["img"]
 html_logo = "https://overhang.io/static/img/tutor-logo.svg"
 html_favicon = "./img/favicon.png"
 html_show_sourcelink = False
+html_copy_source = False
 html_display_github = True
 html_show_sphinx = False
 html_github_user = "overhangio"
@@ -167,6 +171,14 @@ html_github_repo = "tutor"
 # Images do not link to themselves
 html_scaled_image_link = False
 html_show_copyright = False
+
+llms_txt_title = "Tutor"
+llms_txt_summary = (
+    Path(__file__).with_name("llms-summary.txt").read_text(encoding="utf-8").strip()
+)
+llms_txt_uri_template = "{base_url}{docname}.html"
+llms_txt_exclude = ["search", "genindex"]
+llms_txt_full_file = False
 
 # Custom variables
 here = os.path.abspath(os.path.dirname(__file__))

--- a/docs/llms-summary.txt
+++ b/docs/llms-summary.txt
@@ -1,0 +1,4 @@
+Tutor is the Open edX distribution and deployment system for installing,
+configuring, developing, and operating Open edX environments. This
+documentation covers installation, configuration, plugins, development
+workflows, and operations topics for local and Kubernetes deployments.

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,5 @@
 -r base.txt
+sphinx-llms-txt
 sphinx
 sphinx-rtd-theme
 sphinx-click

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -109,9 +109,12 @@ sphinx==7.4.7
     # via
     #   -r requirements/docs.in
     #   sphinx-click
+    #   sphinx-llms-txt
     #   sphinx-reredirects
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
+sphinx-llms-txt==0.7.1
+    # via -r requirements/docs.in
 sphinx-click==6.0.0
     # via -r requirements/docs.in
 sphinx-reredirects==0.1.6


### PR DESCRIPTION
## Summary
This PR adds `llms.txt` (LLM-friendly documentation indexing) for Tutor  during the docs build, while intentionally deferring llms-full.txt for a later iteration.

## What Changed
- Added sphinx-llms-txt to docs dependencies:
  - `docs.in`
  - `docs.txt`
- Enabled the Sphinx extension in `conf.py`
- Added llms.txt configuration in `conf.py`
- Moved llms summary text into a dedicated file `llms-summary.txt`

## Configuration Decisions
- Keep this first PR focused on `llms.txt` only.
- Use canonical docs links via `html_baseurl`.
- Exclude low-value generated pages from llms index.
- Keep summary content editable outside Python config by reading from a text file.

## Why `llms-full.txt` Is Not Included
- Current extension behavior and build artifacts can cause inconsistent `llms-full.txt` generation in incremental/local builds.
- This PR ships the low-risk, high-value index first, and defers llms-full until reliability and quality guarantees are in place.

## Validation
- Local docs build succeeds:
  - make -C docs html
  - make docs
- Generated output confirmed `llms.txt`

## CI Impact
No workflow logic changes required.

## Follow-Up (Optional)
Revisit llms-full generation once upstream behavior is stable and output quality is validated for Tutor docs.


Partially completes [Issue 1380](https://github.com/overhangio/tutor/issues/1380)