### PR TITLE
fix: bump twine to 7.0.0 to accept Metadata-Version 2.5

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,6 @@ importlib-metadata==8.7.1
     #   keyring
     #   pyinstaller
     #   pyinstaller-hooks-contrib
-    #   twine
 importlib-resources==6.5.2
     # via -r requirements/base.txt
 iniconfig==2.1.0
@@ -207,7 +206,7 @@ tomli==2.4.1
     #   mypy
     #   pip-tools
     #   pytest
-twine==6.2.0
+twine==7.0.0
     # via -r requirements/dev.in
 types-docutils==0.22.3.20251115
     # via -r requirements/dev.in


### PR DESCRIPTION
hatchling 1.32.0, released on 2026-08-11, makes `python -m build --sdist` emit `Metadata-Version: 2.5`, and the pinned twine 6.2.0 rejects it, so `make test-pythonpackage` fails:

    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
    valid metadata version

The rejection comes from twine, not from packaging. twine/package.py monkeypatches `packaging.metadata._VALID_METADATA_VERSIONS` with a hard-coded list that stops at 2.4, which overrides the installed packaging, where 2.5 is already valid in 26.2. Upgrading packaging therefore changes nothing, while twine 7.0.0 accepts the identical artifact.

Since pyproject.toml declares `requires = ["hatchling"]` with no upper bound, the isolated build environment always resolves to the newest hatchling, so this hits every branch and is unrelated to any lockfile. Capping hatchling would only trade one lag for another -- the hard-coded list is twine's to maintain -- so bump the pin instead.

This blocks releases as well as CI: `twine upload` validates metadata before contacting the index, so `make push-pythonpackage` fails in the same way. It also unblocks the plugins whose CI installs `tutor[dev]` and inherits this pin.

twine 7.0.0 requires Python >= 3.10, matching the project's own floor, and its remaining tightened requirements are already satisfied by the lockfile (rich >= 14.3.3, packaging >= 26.1). It also drops the `importlib-metadata` dependency that twine 6 pulled in under `python_version < "3.10"`, hence the removed `# via` entry.

Closes #1459