### PR TITLE
docs: add changelog entry for twine 7.0.0 bump

### DIFF
--- a/changelog.d/20260813_122253_abdul.muqadim_twine_metadata_version.md
+++ b/changelog.d/20260813_122253_abdul.muqadim_twine_metadata_version.md
@@ -1,0 +1,1 @@
+- [Bugfix] Bump twine to 7.0.0 so that the Python package can be checked and published again. Older twine versions rejected the `Metadata-Version: 2.5` field emitted by hatchling 1.32.0. (by @Abdul-Muqadim-Arbisoft)


### PR DESCRIPTION
Adds the changelog fragment that was missing from #1460, so the twine fix appears in the v22.0.1 release notes.