### PR TITLE
fix: handle comma-separated MONGODB_HOST in LMS init dockerize wait

### DIFF
--- a/changelog.d/20260820_135205_carlos.marquez_fix_mongodb_host_comma_separated.md
+++ b/changelog.d/20260820_135205_carlos.marquez_fix_mongodb_host_comma_separated.md
@@ -1,0 +1,1 @@
+[Bugfix] Fix LMS init job failure when MONGODB_HOST contains comma-separated replica set members. (by @carlos-marquez-wgu)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -247,7 +247,7 @@ MongoDB
 
 - ``RUN_MONGODB`` (default: ``true``)
 - ``MONGODB_DATABASE`` (default: ``"openedx"``)
-- ``MONGODB_HOST`` (default: ``"mongodb"``)
+- ``MONGODB_HOST`` (default: ``"mongodb"``): accepts a comma-separated list of hosts for replica set configs.
 - ``MONGODB_PASSWORD`` (default: ``""``)
 - ``MONGODB_PORT`` (default: ``27017``)
 - ``MONGODB_USERNAME`` (default: ``""``)

--- a/tutor/templates/jobs/init/lms.sh
+++ b/tutor/templates/jobs/init/lms.sh
@@ -2,6 +2,9 @@ dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
 
 {%- if MONGODB_HOST.startswith("mongodb+srv://") %}
 echo "MongoDB is using SRV records, so we cannot wait for it to be ready"
+{%- elif ',' in MONGODB_HOST %}
+echo "Waiting for MongoDB (replica set, checking first member)"
+dockerize -wait tcp://{{ MONGODB_HOST.split(',')[0] }}:{{ MONGODB_PORT }} -timeout 20s
 {%- else %}
 dockerize -wait tcp://{{ MONGODB_HOST }}:{{ MONGODB_PORT }} -timeout 20s
 {%- endif %}

--- a/tutor/templates/jobs/init/lms.sh
+++ b/tutor/templates/jobs/init/lms.sh
@@ -3,8 +3,10 @@ dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
 {%- if MONGODB_HOST.startswith("mongodb+srv://") %}
 echo "MongoDB is using SRV records, so we cannot wait for it to be ready"
 {%- elif ',' in MONGODB_HOST %}
-echo "Waiting for MongoDB (replica set, checking first member)"
-dockerize -wait tcp://{{ MONGODB_HOST.split(',')[0] }}:{{ MONGODB_PORT }} -timeout 20s
+echo "Waiting for MongoDB (replica set, checking all members)"
+{%- for host in MONGODB_HOST.split(',') %}
+dockerize -wait tcp://{{ host.strip() }}:{{ MONGODB_PORT }} -timeout 20s
+{%- endfor %}
 {%- else %}
 dockerize -wait tcp://{{ MONGODB_HOST }}:{{ MONGODB_PORT }} -timeout 20s
 {%- endif %}


### PR DESCRIPTION
# Summary

When running the LMS init job with MONGODB_HOST set to a comma-separated string (ReplicaSet configuration), it fails at [lms.sh#6](https://github.com/overhangio/tutor/blob/v22.0.1/tutor/templates/jobs/init/lms.sh#L6).

Issue: https://github.com/overhangio/tutor/issues/1473

## Logs

```
2026/08/20 21:49:07 Waiting for tcp://mongodb,mongodb,mongodb:27017: dial tcp: lookup mongodb,mongodb,mongodb: no such host.
2026/08/20 21:49:08 Waiting for tcp://mongodb,mongodb,mongodb:27017: dial tcp: lookup mongodb,mongodb,mongodb: no such host.
2026/08/20 21:49:09 Waiting for tcp://mongodb,mongodb,mongodb:27017: dial tcp: lookup mongodb,mongodb,mongodb: no such host.
...
2026/08/20 21:49:09 Waiting for tcp://mongodb,mongodb,mongodb:27017: dial tcp: lookup mongodb,mongodb,mongodb: no such host.
2026/08/20 21:49:10 Failed to wait: timed out: tcp://mongodb,mongodb,mongodb:27017.
```

## Fix

When `MONGODB_HOST` contains a comma, `dockerize -wait` now targets only the first member.

## How-to test

While you can configure your own ReplicaSet, a quick local test is to repeat the same host, then run the LMS init job again like:

```
tutor config save --set MONGODB_HOST=mongodb,mongodb,mongodb
tutor dev do init -l lms
```