### PR TITLE
fix: don't append version suffix to an explicit TUTOR_APP

### DIFF
--- a/changelog.d/20260831_120000_abrandes_tutor_app_suffix.md
+++ b/changelog.d/20260831_120000_abrandes_tutor_app_suffix.md
@@ -1,0 +1,1 @@
+- [Bugfix] Do not append the version suffix to the app name when it was explicitly set with the `TUTOR_APP` environment variable. (by @arbrandes)

--- a/tutor/__about__.py
+++ b/tutor/__about__.py
@@ -12,17 +12,19 @@ __version__ = "22.0.1"
 # conflicts when merging branches.
 __version_suffix__ = "main"
 
-# The app name will be used to define the name of the default tutor root and
-# plugin directory. To avoid conflicts between multiple locally-installed
-# versions, if it is defined the version suffix will also be appended to the app
-# name.
-__app__ = os.environ.get("TUTOR_APP", "tutor")
-
 # Package version, as installed by pip, does not include the version suffix.
 # Otherwise, Tutor Main plugins will automatically install non-Main Tutor
 # version.
 __package_version__ = __version__
 
+# The app name will be used to define the name of the default tutor root and
+# plugin directory. To avoid conflicts between multiple locally-installed
+# versions, the version suffix is also appended to the default app name.
+__default_app__ = "tutor"
+
 if __version_suffix__:
     __version__ += "-" + __version_suffix__
-    __app__ += "-" + __version_suffix__
+    __default_app__ += "-" + __version_suffix__
+
+# An app name set explicitly with TUTOR_APP replaces the default.
+__app__ = os.environ.get("TUTOR_APP", __default_app__)


### PR DESCRIPTION
### Description

On branches with a version suffix, such as main, the suffix was appended to the app name even when that name came from the `TUTOR_APP` environment variable, turning a deliberate `TUTOR_APP=myapp` into `myapp-main`. The suffix is now applied only to the default app name, and `TUTOR_APP` is used as-is.

### LLM usage notice

Built with assistance from Claude.
