### PR TITLE
fix: derive Tutor Main plugin sources from the version suffix

### DIFF
--- a/.github/workflows/smoke-k8s.yml
+++ b/.github/workflows/smoke-k8s.yml
@@ -62,11 +62,11 @@ jobs:
       - name: Install tutor
         run: pip install -e .[dev]
 
-      # We install using the plugins file instead of tutor plugins install
+      # We install using the "full" extra instead of tutor plugins install
       # as we want the workflow in the main branch to install plugins on
-      # the main branch as well. plugins.txt automatically manages this.
+      # the main branch as well. .hatch_build.py automatically manages this.
       - name: Install tutor plugins
-        run: pip install -r requirements/plugins.txt
+        run: pip install -e .[full]
 
       - name: Enable tutor plugins
         run: tutor plugins enable ${{ github.event.inputs.plugins || 'indigo mfe' }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install -e .[dev]
 
       - name: Install tutor plugins
-        run: pip install -r requirements/plugins.txt
+        run: pip install -e .[full]
 
       - name: Enable tutor plugins
         run: tutor plugins enable ${{ github.event.inputs.plugins || 'indigo mfe' }}

--- a/.hatch_build.py
+++ b/.hatch_build.py
@@ -1,10 +1,15 @@
 # https://hatch.pypa.io/latest/how-to/config/dynamic-metadata/
 import os
+import re
 import typing as t
 
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 HERE = os.path.dirname(__file__)
+
+# Official plugins listed in requirements/plugins.txt are all hosted under this
+# GitHub organization, in a repository that has the same name as the package.
+PLUGINS_GITHUB_ORG = "https://github.com/overhangio"
 
 
 class MetaDataHook(MetadataHookInterface):
@@ -12,7 +17,7 @@ class MetaDataHook(MetadataHookInterface):
         metadata["dependencies"] = load_requirements("base.in")
         metadata["optional-dependencies"] = {
             "dev": load_requirements("dev.txt"),
-            "full": load_requirements("plugins.txt"),
+            "full": load_plugin_requirements(),
         }
 
 
@@ -26,3 +31,39 @@ def load_requirements(filename: str) -> list[str]:
             if line != "" and not line.startswith("#"):
                 requirements.append(line)
     return requirements
+
+
+def load_plugin_requirements() -> list[str]:
+    """
+    Load the official plugin requirements from requirements/plugins.txt.
+
+    That file always pins plugins to PyPI version ranges, on every branch. In
+    Tutor Main (i.e: when the version suffix is "main"), plugins are installed
+    from the main branch of their GitHub repository instead. This is the same
+    mechanism that sets OPENEDX_COMMON_VERSION to "master" in Tutor Main, and it
+    means that plugins.txt does not differ between the main and release
+    branches, so it never conflicts when one is merged into the other.
+    """
+    requirements = load_requirements("plugins.txt")
+    if load_version_suffix() != "main":
+        return requirements
+    main_requirements = []
+    for requirement in requirements:
+        match = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+        if not match:
+            raise ValueError(f"Invalid plugin requirement: '{requirement}'")
+        name = match.group(1)
+        main_requirements.append(f"{name}@git+{PLUGINS_GITHUB_ORG}/{name}@main")
+    return main_requirements
+
+
+def load_version_suffix() -> str:
+    """
+    Read __version_suffix__ from tutor/__about__.py without importing tutor,
+    which is not installed yet at build time.
+    """
+    with open(os.path.join(HERE, "tutor", "__about__.py"), encoding="utf-8") as f:
+        match = re.search(r'^__version_suffix__ = "([^"]*)"', f.read(), re.MULTILINE)
+    if not match:
+        raise ValueError("Could not find __version_suffix__ in tutor/__about__.py")
+    return match.group(1)

--- a/changelog.d/20260909_120000_abdul.muqadim_plugins_txt_main.md
+++ b/changelog.d/20260909_120000_abdul.muqadim_plugins_txt_main.md
@@ -1,0 +1,1 @@
+- [Improvement] In Tutor Main, official plugins are now installed from their GitHub main branches automatically by the build hook, based on the version suffix. `requirements/plugins.txt` is now identical between the main and release branches, which removes the recurring merge conflicts on release merges. (by @Abdul-Muqadim-Arbisoft)

--- a/docs/developing/main.rst
+++ b/docs/developing/main.rst
@@ -15,7 +15,7 @@ Running Tutor Main requires more than setting a few configuration variables: bec
 
 As usual, it is strongly recommended to run the command above in a `Python virtual environment <https://docs.python.org/3/tutorial/venv.html>`__.
 
-In addition to installing Tutor Main itself, this will install automatically the main versions of all official Tutor plugins (which are enumerated in `plugins.txt <https://github.com/overhangio/tutor/tree/main/requirements/plugins.txt>`_). Alternatively, if you wish to hack on an official plugin or install a custom plugin, you can clone that plugin's repository and install it. For instance::
+In addition to installing Tutor Main itself, this will install automatically the main versions of all official Tutor plugins (which are enumerated in `plugins.txt <https://github.com/overhangio/tutor/tree/main/requirements/plugins.txt>`_: in Tutor Main, they are installed from the main branch of their GitHub repositories rather than from PyPI). Alternatively, if you wish to hack on an official plugin or install a custom plugin, you can clone that plugin's repository and install it. For instance::
 
     git clone --branch=main https://github.com/myorganization/tutor-contrib-myplugin.git
     pip install -e ./tutor-contrib-myplugin

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,4 +1,8 @@
-# change version ranges when upgrading from verawood
+# Official plugins, pinned to PyPI version ranges. Change the ranges when
+# upgrading to a new Open edX release.
+# In Tutor Main these are automatically installed from the main branch of their
+# GitHub repositories instead (see .hatch_build.py), so this file must be kept
+# identical between the main and release branches.
 tutor-android>=22.0.0,<23.0.0
 tutor-cairn>=22.0.0,<23.0.0
 tutor-credentials>=22.0.0,<23.0.0


### PR DESCRIPTION
plugins.txt used to hold different content on the release and main branches: PyPI version ranges on release, GitHub main branch URLs on main. Every merge from release into main overwrote the main version, and it then had to be restored by hand (see #1343, #1450, #1475).

The file now always contains PyPI version ranges. When the version suffix is "main", the hatch metadata hook rewrites each requirement to install from the main branch of the plugin's GitHub repository instead. This is the same mechanism that sets OPENEDX_COMMON_VERSION to "master" in Tutor Main, and it keeps plugins.txt identical between branches so it no longer conflicts.

The smoke workflows install plugins via the "full" extra rather than the requirements file, so that the branch logic applies there too.

Closes #1310